### PR TITLE
Complete api_modify: port append_comments + define_func / define_code / undefine

### DIFF
--- a/src/ida_multi_mcp/ida_mcp/api_modify.py
+++ b/src/ida_multi_mcp/ida_mcp/api_modify.py
@@ -584,6 +584,16 @@ def define_func(items: list[DefineOp] | DefineOp) -> list[DefineResult]:
                     "error": "Function already exists at this address",
                 })
                 continue
+            if existing and existing.start_ea != start_ea:
+                results.append({
+                    "addr": addr_str,
+                    "start": hex(start_ea),
+                    "error": (
+                        f"Address {hex(start_ea)} is inside function at "
+                        f"{hex(existing.start_ea)}; cannot start a new function here"
+                    ),
+                })
+                continue
 
             if ida_funcs.add_func(start_ea, end_ea):
                 func = idaapi.get_func(start_ea)

--- a/src/ida_multi_mcp/ida_mcp/api_modify.py
+++ b/src/ida_multi_mcp/ida_mcp/api_modify.py
@@ -565,6 +565,13 @@ def define_func(items: list[DefineOp] | DefineOp) -> list[DefineResult]:
 
         try:
             start_ea = parse_address(addr_str)
+            if not idaapi.is_loaded(start_ea):
+                results.append({
+                    "addr": addr_str,
+                    "start": hex(start_ea),
+                    "error": f"Address {hex(start_ea)} is not mapped in the IDB",
+                })
+                continue
             end_ea = parse_address(end_str) if end_str else idaapi.BADADDR
 
             if end_ea != idaapi.BADADDR and end_ea <= start_ea:
@@ -633,6 +640,13 @@ def define_code(items: list[DefineOp] | DefineOp) -> list[DefineResult]:
 
         try:
             ea = parse_address(addr_str)
+            if not idaapi.is_loaded(ea):
+                results.append({
+                    "addr": addr_str,
+                    "ea": hex(ea),
+                    "error": f"Address {hex(ea)} is not mapped in the IDB",
+                })
+                continue
             length = ida_ua.create_insn(ea)
             if length > 0:
                 results.append({"addr": addr_str, "ea": hex(ea), "length": length})
@@ -669,6 +683,13 @@ def undefine(items: list[UndefineOp] | UndefineOp) -> list[DefineResult]:
 
         try:
             start_ea = parse_address(addr_str)
+            if not idaapi.is_loaded(start_ea):
+                results.append({
+                    "addr": addr_str,
+                    "start": hex(start_ea),
+                    "error": f"Address {hex(start_ea)} is not mapped in the IDB",
+                })
+                continue
 
             if end_str:
                 end_ea = parse_address(end_str)

--- a/src/ida_multi_mcp/ida_mcp/api_modify.py
+++ b/src/ida_multi_mcp/ida_mcp/api_modify.py
@@ -1,11 +1,15 @@
+from typing import TypedDict
+
 import idaapi
 import idautils
 import idc
-import ida_hexrays
 import ida_bytes
-import ida_typeinf
-import ida_frame
 import ida_dirtree
+import ida_frame
+import ida_funcs
+import ida_hexrays
+import ida_typeinf
+import ida_ua
 
 from .rpc import tool
 from .sync import idasync, IDAError
@@ -14,13 +18,34 @@ from .utils import (
     decompile_checked,
     refresh_decompiler_ctext,
     CommentOp,
+    CommentAppendOp,
     AsmPatchOp,
+    DefineOp,
+    UndefineOp,
     FunctionRename,
     GlobalRename,
     LocalRename,
     StackRename,
     RenameBatch,
 )
+
+
+class AppendCommentResult(TypedDict, total=False):
+    addr: str
+    scope: str
+    appended: bool
+    skipped: bool
+    error: str
+
+
+class DefineResult(TypedDict, total=False):
+    addr: str
+    ea: str
+    start: str
+    end: str
+    size: int
+    length: int
+    error: str
 
 
 # ============================================================================
@@ -415,3 +440,240 @@ def rename(batch: RenameBatch) -> dict:
         result["stack"] = _rename_stack(_normalize_items(batch["stack"]))
 
     return result
+
+
+# ============================================================================
+# Append-style Comment (non-destructive)
+# ============================================================================
+
+
+def _append_comment_text(current: str, new_text: str, *, dedupe: bool) -> tuple[str, bool]:
+    """Merge new_text into current. Returns (merged_text, skipped_as_duplicate)."""
+    normalized_new = new_text.strip()
+    if dedupe and normalized_new:
+        existing_entries = [line.strip() for line in current.splitlines()]
+        if normalized_new in existing_entries:
+            return current, True
+    if not current:
+        return new_text, False
+    if not new_text:
+        return current, False
+    joiner = "" if current.endswith("\n") else "\n"
+    return f"{current}{joiner}{new_text}", False
+
+
+@tool
+@idasync
+def append_comments(
+    items: list[CommentAppendOp] | CommentAppendOp,
+) -> list[AppendCommentResult]:
+    """Append comments at addresses, deduping exact text by default. Unlike
+    set_comments (which overwrites), this preserves existing annotations — use
+    it for incremental commentary. scope='auto' (default) writes a function
+    comment when addr is a function start, otherwise a line comment; force
+    with scope='func' or 'line'. dedupe=True skips writes when the exact
+    stripped text already appears on its own line."""
+    if isinstance(items, dict):
+        items = [items]
+
+    if len(items) > _MAX_BATCH_SIZE:
+        raise IDAError(f"Batch too large: maximum {_MAX_BATCH_SIZE} items per request")
+
+    results: list[AppendCommentResult] = []
+    for item in items:
+        addr_str = item.get("addr", "")
+        comment = item.get("comment", "")
+        scope = str(item.get("scope", "auto") or "auto").lower()
+        dedupe = bool(item.get("dedupe", True))
+
+        try:
+            ea = parse_address(addr_str)
+            if scope not in {"auto", "func", "line"}:
+                results.append({"addr": addr_str, "error": f"Unsupported scope: {scope}"})
+                continue
+
+            fn = idaapi.get_func(ea)
+            use_func_comment = scope == "func" or (
+                scope == "auto" and fn is not None and fn.start_ea == ea
+            )
+
+            if use_func_comment:
+                if fn is None:
+                    results.append({"addr": addr_str, "error": f"No function found at {hex(ea)}"})
+                    continue
+                target_ea = fn.start_ea
+                current = idc.get_func_cmt(target_ea, False) or ""
+                new_comment, skipped = _append_comment_text(current, comment, dedupe=dedupe)
+                if skipped:
+                    results.append({"addr": addr_str, "scope": "func", "skipped": True})
+                    continue
+                if not idc.set_func_cmt(target_ea, new_comment, False):
+                    results.append({
+                        "addr": addr_str,
+                        "error": f"Failed to set function comment at {hex(target_ea)}",
+                    })
+                    continue
+                results.append({"addr": addr_str, "scope": "func", "appended": True})
+                continue
+
+            current = idaapi.get_cmt(ea, False) or ""
+            new_comment, skipped = _append_comment_text(current, comment, dedupe=dedupe)
+            if skipped:
+                results.append({"addr": addr_str, "scope": "line", "skipped": True})
+                continue
+            if not idaapi.set_cmt(ea, new_comment, False):
+                results.append({
+                    "addr": addr_str,
+                    "error": f"Failed to set disassembly comment at {hex(ea)}",
+                })
+                continue
+            results.append({"addr": addr_str, "scope": "line", "appended": True})
+        except Exception as e:
+            results.append({"addr": addr_str, "error": str(e)})
+
+    return results
+
+
+# ============================================================================
+# Code / Function Definition & Undefinition
+# ============================================================================
+
+
+@tool
+@idasync
+def define_func(items: list[DefineOp] | DefineOp) -> list[DefineResult]:
+    """Define a function at each given address. IDA infers bounds unless an
+    explicit end address is provided. Returns {addr, start, end} on success or
+    {addr, start, error} if the function already exists or add_func fails.
+    Use this when IDA auto-analysis missed a function entry point."""
+    if isinstance(items, dict):
+        items = [items]
+
+    if len(items) > _MAX_BATCH_SIZE:
+        raise IDAError(f"Batch too large: maximum {_MAX_BATCH_SIZE} items per request")
+
+    results: list[DefineResult] = []
+    for item in items:
+        addr_str = item.get("addr", "")
+        end_str = item.get("end", "")
+
+        try:
+            start_ea = parse_address(addr_str)
+            end_ea = parse_address(end_str) if end_str else idaapi.BADADDR
+
+            existing = idaapi.get_func(start_ea)
+            if existing and existing.start_ea == start_ea:
+                results.append({
+                    "addr": addr_str,
+                    "start": hex(start_ea),
+                    "error": "Function already exists at this address",
+                })
+                continue
+
+            if ida_funcs.add_func(start_ea, end_ea):
+                func = idaapi.get_func(start_ea)
+                results.append({
+                    "addr": addr_str,
+                    "start": hex(func.start_ea),
+                    "end": hex(func.end_ea),
+                })
+            else:
+                results.append({
+                    "addr": addr_str,
+                    "start": hex(start_ea),
+                    "error": "define_func failed",
+                })
+        except Exception as e:
+            results.append({"addr": addr_str, "error": str(e)})
+
+    return results
+
+
+@tool
+@idasync
+def define_code(items: list[DefineOp] | DefineOp) -> list[DefineResult]:
+    """Convert raw bytes to a code instruction at each given address. Returns
+    {addr, ea, length} on success (length is the instruction byte length) or
+    {addr, ea, error} if create_insn failed. Use this when IDA classified an
+    instruction as data or failed to decode."""
+    if isinstance(items, dict):
+        items = [items]
+
+    if len(items) > _MAX_BATCH_SIZE:
+        raise IDAError(f"Batch too large: maximum {_MAX_BATCH_SIZE} items per request")
+
+    results: list[DefineResult] = []
+    for item in items:
+        addr_str = item.get("addr", "")
+
+        try:
+            ea = parse_address(addr_str)
+            length = ida_ua.create_insn(ea)
+            if length > 0:
+                results.append({"addr": addr_str, "ea": hex(ea), "length": length})
+            else:
+                results.append({
+                    "addr": addr_str,
+                    "ea": hex(ea),
+                    "error": "Failed to create instruction",
+                })
+        except Exception as e:
+            results.append({"addr": addr_str, "error": str(e)})
+
+    return results
+
+
+@tool
+@idasync
+def undefine(items: list[UndefineOp] | UndefineOp) -> list[DefineResult]:
+    """Undefine item(s) at each address, converting them back to raw bytes.
+    Size is determined from `end` (exclusive) or `size`; defaults to 1 byte.
+    Uses ida_bytes.DELIT_EXPAND so adjacent items spanning into the range are
+    fully removed. Returns {addr, start, size} on success."""
+    if isinstance(items, dict):
+        items = [items]
+
+    if len(items) > _MAX_BATCH_SIZE:
+        raise IDAError(f"Batch too large: maximum {_MAX_BATCH_SIZE} items per request")
+
+    results: list[DefineResult] = []
+    for item in items:
+        addr_str = item.get("addr", "")
+        end_str = item.get("end", "")
+        size = item.get("size", 0)
+
+        try:
+            start_ea = parse_address(addr_str)
+
+            if end_str:
+                end_ea = parse_address(end_str)
+                nbytes = end_ea - start_ea
+            elif size:
+                nbytes = size
+            else:
+                nbytes = 1
+
+            if nbytes <= 0:
+                results.append({
+                    "addr": addr_str,
+                    "start": hex(start_ea),
+                    "error": f"Invalid range: {nbytes} bytes",
+                })
+                continue
+
+            if ida_bytes.del_items(start_ea, ida_bytes.DELIT_EXPAND, nbytes):
+                results.append({
+                    "addr": addr_str,
+                    "start": hex(start_ea),
+                    "size": nbytes,
+                })
+            else:
+                results.append({
+                    "addr": addr_str,
+                    "start": hex(start_ea),
+                    "error": "undefine failed",
+                })
+        except Exception as e:
+            results.append({"addr": addr_str, "error": str(e)})
+
+    return results

--- a/src/ida_multi_mcp/ida_mcp/api_modify.py
+++ b/src/ida_multi_mcp/ida_mcp/api_modify.py
@@ -567,6 +567,15 @@ def define_func(items: list[DefineOp] | DefineOp) -> list[DefineResult]:
             start_ea = parse_address(addr_str)
             end_ea = parse_address(end_str) if end_str else idaapi.BADADDR
 
+            if end_ea != idaapi.BADADDR and end_ea <= start_ea:
+                results.append({
+                    "addr": addr_str,
+                    "start": hex(start_ea),
+                    "end": hex(end_ea),
+                    "error": f"Invalid range: end ({hex(end_ea)}) must be greater than start ({hex(start_ea)})",
+                })
+                continue
+
             existing = idaapi.get_func(start_ea)
             if existing and existing.start_ea == start_ea:
                 results.append({

--- a/src/ida_multi_mcp/ida_mcp/api_modify.py
+++ b/src/ida_multi_mcp/ida_mcp/api_modify.py
@@ -539,6 +539,12 @@ def append_comments(
 # ============================================================================
 
 
+# Cap on the number of bytes a single undefine call may affect. Prevents a
+# stray `end` address or oversized `size` from wiping large regions of the
+# IDB. Mirrors this project's 1 MB memory read/write caps in spirit.
+_MAX_UNDEFINE_BYTES = 16 * 1024 * 1024
+
+
 @tool
 @idasync
 def define_func(items: list[DefineOp] | DefineOp) -> list[DefineResult]:
@@ -658,6 +664,18 @@ def undefine(items: list[UndefineOp] | UndefineOp) -> list[DefineResult]:
                     "addr": addr_str,
                     "start": hex(start_ea),
                     "error": f"Invalid range: {nbytes} bytes",
+                })
+                continue
+
+            if nbytes > _MAX_UNDEFINE_BYTES:
+                results.append({
+                    "addr": addr_str,
+                    "start": hex(start_ea),
+                    "error": (
+                        f"Range too large: {nbytes} bytes exceeds "
+                        f"_MAX_UNDEFINE_BYTES ({_MAX_UNDEFINE_BYTES}). "
+                        "Split into smaller undefine calls."
+                    ),
                 })
                 continue
 

--- a/src/ida_multi_mcp/ida_mcp/utils.py
+++ b/src/ida_multi_mcp/ida_mcp/utils.py
@@ -85,11 +85,37 @@ class CommentOp(TypedDict):
     comment: Annotated[str, "Comment text"]
 
 
+class CommentAppendOp(TypedDict):
+    """Comment append operation (adds text to existing comment)"""
+
+    addr: Annotated[str, "Address (hex or decimal)"]
+    comment: Annotated[str, "Comment text to append"]
+    scope: NotRequired[Annotated[str, "auto|func|line (default: auto)"]]
+    dedupe: NotRequired[
+        Annotated[bool, "Skip if exact text already exists (default: true)"]
+    ]
+
+
 class AsmPatchOp(TypedDict):
     """Assembly patch operation"""
 
     addr: Annotated[str, "Address (hex or decimal)"]
     asm: Annotated[str, "Assembly instruction(s), semicolon-separated"]
+
+
+class DefineOp(TypedDict, total=False):
+    """Define function/code operation"""
+
+    addr: Annotated[str, "Address to define (hex or decimal)"]
+    end: Annotated[str, "Optional end address for explicit bounds"]
+
+
+class UndefineOp(TypedDict, total=False):
+    """Undefine operation (convert items back to raw bytes)"""
+
+    addr: Annotated[str, "Address to undefine (hex or decimal)"]
+    end: Annotated[str, "Optional end address"]
+    size: Annotated[int, "Optional size in bytes"]
 
 
 class FunctionRename(TypedDict):


### PR DESCRIPTION
## Summary
Ports the four `api_modify` tools that were missing relative to upstream `ida-pro-mcp` v2.0.0, closing the HIGH-priority gap flagged in `docs/ida-pro-mcp/comparison.md`:

- **`append_comments`** — non-destructive comment append with `scope='auto|func|line'` and `dedupe` (default true). `set_comments` currently overwrites, so incremental annotation was impossible.
- **`define_func`** — wrap `ida_funcs.add_func` (end address optional).
- **`define_code`** — wrap `ida_ua.create_insn` to force code classification on bytes IDA classified as data.
- **`undefine`** — wrap `ida_bytes.del_items` with `DELIT_EXPAND`, accepting `end` address or explicit `size` (default 1 byte).

Three new TypedDicts (`CommentAppendOp`, `DefineOp`, `UndefineOp`) added to `utils.py`. All four tools apply the project's `_MAX_BATCH_SIZE = 500` cap, matching the existing `set_comments`/`patch_asm` pattern.

## Improvements beyond upstream
Five safety/clarity improvements layered on top of the straight port:

1. **`undefine` 16 MB byte-count cap** (`_MAX_UNDEFINE_BYTES`): a stray `end` address or oversized `size` could silently wipe megabytes of the IDB. Reject with a clear error that tells the caller to split into smaller calls. Mirrors this project's 1 MB memory read/write caps.
2. **`undefine` rejects zero/negative ranges**: an explicit error instead of `del_items` silently mis-executing.
3. **`define_func` rejects `end <= start`**: catches backwards/zero-length ranges up front with an explicit "end must be greater than start" error, instead of `add_func` returning False and producing the generic "define_func failed".
4. **`define_func` detects mid-function addresses**: if the caller passes an address inside an existing function but not at its start, report the containing function's start ("inside function at 0xNNNN; cannot start a new function here") instead of the generic failure.
5. **`define_func` / `define_code` / `undefine` reject unmapped addresses**: `idaapi.is_loaded()` pre-check so callers see "Address X is not mapped in the IDB" instead of a silent no-op or generic IDA API failure. `append_comments` is intentionally excluded — comments are stored in netnodes keyed by ea, so attaching a comment to an unmapped address is a supported (if odd) operation.

## Test plan
- [x] `python -m pytest tests/` → 143 passed, 3 skipped
- [x] `api_modify` already registered in `__init__.py`; no test stub changes needed
- [ ] Manual smoke test inside IDA (tool-level tests require a running IDA instance — not covered by this repo's test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)