### PR TITLE
Integrate idalib headless support with compat shims and IDA auto-detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = []
 dev = [
     "pytest>=7.0",
 ]
+idalib = [
+    "idapro>=0.0.7",
+]
 
 [project.scripts]
 ida-multi-mcp = "ida_multi_mcp.__main__:main"

--- a/src/ida_multi_mcp/__main__.py
+++ b/src/ida_multi_mcp/__main__.py
@@ -4,6 +4,7 @@ Provides flags for running the server, listing instances, and managing installat
 """
 
 import os
+import re
 import sys
 import argparse
 import json
@@ -16,6 +17,95 @@ from .server import serve
 from .registry import InstanceRegistry
 
 SERVER_NAME = "ida-multi-mcp"
+
+# ---------------------------------------------------------------------------
+# IDA installation auto-detection (used by --install)
+# ---------------------------------------------------------------------------
+
+_IDA_VERSION_RE = re.compile(r"(\d+\.\d+)")
+
+
+def _detect_ida_dir() -> str | None:
+    """Auto-detect the IDA Pro installation directory.
+
+    Resolution order:
+    1. ``IDADIR`` environment variable (if set and valid).
+    2. ``ida-config.json`` ``ida-install-dir`` field (if non-empty).
+    3. Filesystem scan of well-known locations (newest version wins).
+    """
+    # 1. Env var
+    env_dir = os.environ.get("IDADIR", "").strip()
+    if env_dir and os.path.isdir(env_dir):
+        return env_dir
+
+    # 2. ida-config.json (written by idapro package)
+    if sys.platform == "win32":
+        config_path = Path(os.environ.get("APPDATA", "")) / "Hex-Rays" / "IDA Pro" / "ida-config.json"
+    else:
+        config_path = Path.home() / ".idapro" / "ida-config.json"
+    try:
+        with open(config_path, "r") as f:
+            cfg = json.load(f)
+        cfg_dir = cfg.get("Paths", {}).get("ida-install-dir", "").strip()
+        if cfg_dir and os.path.isdir(cfg_dir):
+            return cfg_dir
+    except Exception:
+        pass
+
+    # 3. Filesystem scan
+    candidates: list[tuple[tuple[int, ...], str]] = []
+
+    scan_roots: list[Path] = []
+    if sys.platform == "win32":
+        for drive in ("C:\\", "D:\\"):
+            if os.path.isdir(drive):
+                scan_roots.append(Path(drive))
+        pf = os.environ.get("ProgramFiles", "C:\\Program Files")
+        if os.path.isdir(pf):
+            scan_roots.append(Path(pf))
+        pf86 = os.environ.get("ProgramFiles(x86)", "")
+        if pf86 and os.path.isdir(pf86):
+            scan_roots.append(Path(pf86))
+    elif sys.platform == "darwin":
+        scan_roots.extend([Path("/Applications"), Path.home() / "Applications"])
+    else:
+        scan_roots.extend([Path("/opt"), Path.home()])
+
+    seen: set[str] = set()
+    for root in scan_roots:
+        try:
+            for entry in root.iterdir():
+                if not entry.is_dir():
+                    continue
+                if "ida" not in entry.name.lower():
+                    continue
+                resolved = str(entry.resolve())
+                if resolved in seen:
+                    continue
+                seen.add(resolved)
+                has_marker = any(
+                    (entry / n).exists()
+                    for n in (
+                        "ida64.exe", "ida.exe",
+                        "ida64", "ida",
+                        "idalib.dll", "ida.dll",
+                        "libidalib.dylib", "libida.dylib",
+                        "libidalib.so", "libida.so",
+                    )
+                )
+                if not has_marker:
+                    continue
+                m = _IDA_VERSION_RE.search(entry.name)
+                ver = tuple(int(x) for x in m.group(1).split(".")) if m else (0, 0)
+                candidates.append((ver, resolved))
+        except PermissionError:
+            continue
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda t: t[0], reverse=True)
+    return candidates[0][1]
 
 
 def _replace_or_overwrite_file(src: str, dst: str, *, attempts: int = 6) -> bool:
@@ -805,6 +895,58 @@ def _get_ida_plugins_dir(custom_dir=None):
         return Path.home() / ".idapro" / "plugins"
 
 
+def _configure_idalib_path():
+    """Auto-detect IDA installation and write to ida-config.json.
+
+    The ``idapro`` package reads ``ida-config.json`` at import time to
+    locate IDA libraries. If the ``ida-install-dir`` field is already
+    populated or ``IDADIR`` is set, this is a no-op. Otherwise we scan
+    well-known paths, pick the newest version, and write it.
+    """
+    # Check if already configured
+    env_dir = os.environ.get("IDADIR", "").strip()
+    if env_dir and os.path.isdir(env_dir):
+        print(f"\n  [ok] IDADIR already set: {env_dir}")
+        return
+
+    # Check ida-config.json
+    if sys.platform == "win32":
+        config_path = Path(os.environ.get("APPDATA", "")) / "Hex-Rays" / "IDA Pro" / "ida-config.json"
+    else:
+        config_path = Path.home() / ".idapro" / "ida-config.json"
+
+    try:
+        with open(config_path, "r") as f:
+            cfg = json.load(f)
+        existing = cfg.get("Paths", {}).get("ida-install-dir", "").strip()
+        if existing and os.path.isdir(existing):
+            print(f"\n  [ok] ida-config.json already has ida-install-dir: {existing}")
+            return
+    except Exception:
+        cfg = {}
+
+    # Auto-detect
+    detected = _detect_ida_dir()
+    if not detected:
+        print("\n  [--] Could not auto-detect IDA installation directory.")
+        print("       Set IDADIR environment variable manually for headless (idalib) support.")
+        return
+
+    # Write to ida-config.json
+    cfg.setdefault("Paths", {})
+    cfg["Paths"]["ida-install-dir"] = detected
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(config_path, "w") as f:
+            json.dump(cfg, f, indent=4)
+        print(f"\n  [ok] Auto-detected IDA at: {detected}")
+        print(f"       Written to: {config_path}")
+    except Exception as e:
+        print(f"\n  [!!] Failed to write ida-config.json: {e}")
+        print(f"       Set IDADIR={detected} manually.")
+
+
 def cmd_install(args):
     """Install the IDA plugin and configure MCP clients."""
     print("Installing ida-multi-mcp...\n")
@@ -862,7 +1004,10 @@ def cmd_install(args):
 
     print("\n  [ok] IDA plugin installed!")
 
-    # 3. Auto-configure MCP clients
+    # 3. Auto-detect IDA installation and write to ida-config.json for idalib
+    _configure_idalib_path()
+
+    # 4. Auto-configure MCP clients
     print()
     install_mcp_servers()
 

--- a/src/ida_multi_mcp/__main__.py
+++ b/src/ida_multi_mcp/__main__.py
@@ -953,6 +953,11 @@ def main():
         "--registry", type=str, default=None,
         help="Path to registry JSON file (default: ~/.ida-mcp/instances.json)"
     )
+    parser.add_argument(
+        "--idalib-python", type=str, default=None,
+        help="Python executable with idapro installed (for headless idalib sessions). "
+             "Defaults to the same Python running this server."
+    )
 
     args = parser.parse_args()
 
@@ -967,7 +972,7 @@ def main():
         sys.exit(cmd_config(args))
     else:
         # Default: start MCP server
-        serve(registry_path=args.registry)
+        serve(registry_path=args.registry, idalib_python=args.idalib_python)
 
 
 if __name__ == "__main__":

--- a/src/ida_multi_mcp/ida_mcp/api_debug.py
+++ b/src/ida_multi_mcp/ida_mcp/api_debug.py
@@ -12,12 +12,12 @@ import os
 from typing import Annotated
 
 import ida_dbg
-import ida_entry
 import ida_idd
 import ida_idaapi
 import ida_name
 import idaapi
 
+from . import compat
 from .rpc import tool, unsafe, ext
 from .sync import idasync, IDAError
 from .utils import (
@@ -164,9 +164,9 @@ def list_breakpoints():
 def dbg_start():
     """Start debugger"""
     if len(list_breakpoints()) == 0:
-        for i in range(ida_entry.get_entry_qty()):
-            ordinal = ida_entry.get_entry_ordinal(i)
-            addr = ida_entry.get_entry(ordinal)
+        for i in range(compat.get_entry_qty()):
+            ordinal = compat.get_entry_ordinal(i)
+            addr = compat.get_entry(ordinal)
             if addr != ida_idaapi.BADADDR:
                 ida_dbg.add_bpt(addr, 0, idaapi.BPT_SOFT)
 

--- a/src/ida_multi_mcp/ida_mcp/api_resources.py
+++ b/src/ida_multi_mcp/ida_mcp/api_resources.py
@@ -14,6 +14,7 @@ import idaapi
 import idautils
 import idc
 
+from . import compat
 from .rpc import resource
 from .sync import idasync
 from .utils import (
@@ -100,11 +101,11 @@ def idb_segments_resource() -> list[Segment]:
 def idb_entrypoints_resource() -> list[dict]:
    """Get entry points (main, TLS callbacks, etc.)"""
    entrypoints = []
-   entry_count = ida_nalt.get_entry_qty()
+   entry_count = compat.get_entry_qty()
    for i in range(entry_count):
-      ordinal = ida_nalt.get_entry_ordinal(i)
-      ea = ida_nalt.get_entry(ordinal)
-      name = ida_nalt.get_entry_name(ordinal)
+      ordinal = compat.get_entry_ordinal(i)
+      ea = compat.get_entry(ordinal)
+      name = compat.get_entry_name(ordinal)
       entrypoints.append({"addr": hex(ea), "name": name, "ordinal": ordinal})
    return entrypoints
 
@@ -260,11 +261,11 @@ def import_name_resource(name: Annotated[str, "Import name"]) -> dict:
 @idasync
 def export_name_resource(name: Annotated[str, "Export name"]) -> dict:
    """Get specific export details by name"""
-   entry_count = ida_nalt.get_entry_qty()
+   entry_count = compat.get_entry_qty()
    for i in range(entry_count):
-      ordinal = ida_nalt.get_entry_ordinal(i)
-      ea = ida_nalt.get_entry(ordinal)
-      entry_name = ida_nalt.get_entry_name(ordinal)
+      ordinal = compat.get_entry_ordinal(i)
+      ea = compat.get_entry(ordinal)
+      entry_name = compat.get_entry_name(ordinal)
 
       if entry_name == name:
          return {

--- a/src/ida_multi_mcp/ida_mcp/api_survey.py
+++ b/src/ida_multi_mcp/ida_mcp/api_survey.py
@@ -13,13 +13,13 @@ import re
 from itertools import islice
 from typing import Annotated, TypedDict
 
-import ida_ida
 import ida_nalt
 import ida_segment
 import idaapi
 import idautils
 import idc
 
+from . import compat
 from .api_core import _get_strings_cache
 from .rpc import tool
 from .sync import idasync, tool_timeout
@@ -134,7 +134,7 @@ def _build_metadata() -> SurveyMetadata:
     module = ida_nalt.get_root_filename()
     base = hex(idaapi.get_imagebase())
     size = hex(get_image_size())
-    is_64 = ida_ida.inf_is_64bit()
+    is_64 = compat.inf_is_64bit()
 
     input_path = ida_nalt.get_input_file_path()
     try:
@@ -185,11 +185,11 @@ def _build_segments() -> list[SurveySegmentInfo]:
 
 def _build_entrypoints() -> list[SurveyEntrypoint]:
     entrypoints: list[SurveyEntrypoint] = []
-    entry_count = ida_nalt.get_entry_qty()
+    entry_count = compat.get_entry_qty()
     for i in range(entry_count):
-        ordinal = ida_nalt.get_entry_ordinal(i)
-        ea = ida_nalt.get_entry(ordinal)
-        name = ida_nalt.get_entry_name(ordinal)
+        ordinal = compat.get_entry_ordinal(i)
+        ea = compat.get_entry(ordinal)
+        name = compat.get_entry_name(ordinal)
         entrypoints.append({"addr": hex(ea), "name": name, "ordinal": ordinal})
     return entrypoints
 

--- a/src/ida_multi_mcp/ida_mcp/api_types.py
+++ b/src/ida_multi_mcp/ida_mcp/api_types.py
@@ -162,11 +162,8 @@ def read_struct(queries: list[StructRead] | StructRead) -> list[dict]:
                 member_addr = addr + offset
                 try:
                     if member.type.is_ptr():
-                        is_64bit = (
-                            ida_ida.inf_is_64bit()
-                            if ida_major >= 9
-                            else idaapi.get_inf_structure().is_64bit()
-                        )
+                        from . import compat
+                        is_64bit = compat.inf_is_64bit()
                         if is_64bit:
                             value = idaapi.get_qword(member_addr)
                             value_str = f"0x{value:016X}"

--- a/src/ida_multi_mcp/ida_mcp/compat.py
+++ b/src/ida_multi_mcp/ida_mcp/compat.py
@@ -1,0 +1,65 @@
+"""IDA SDK version compatibility shims.
+
+Provides unified wrappers for APIs that moved between IDA 8.3 and 9.3.
+Import from this module instead of from version-specific ``ida_*`` modules.
+
+Known migrations:
+- Entry point functions (get_entry_qty, get_entry_ordinal, get_entry,
+  get_entry_name): ida_nalt (8.x) → ida_entry (9.0+, exclusive in 9.3+).
+- inf_is_64bit: idaapi (8.x) → ida_ida (9.0+).
+"""
+
+from __future__ import annotations
+
+import idaapi
+
+# ---------------------------------------------------------------------------
+# Version detection
+# ---------------------------------------------------------------------------
+
+_kernel_version = idaapi.get_kernel_version()  # e.g. "9.3"
+_major, _minor = (int(x) for x in _kernel_version.split(".")[:2])
+
+
+# ---------------------------------------------------------------------------
+# Entry point API (ida_nalt in 8.x, ida_entry in 9.x)
+# ---------------------------------------------------------------------------
+
+try:
+    import ida_entry as _entry_mod
+    if not hasattr(_entry_mod, "get_entry_qty"):
+        raise ImportError
+except ImportError:
+    import ida_nalt as _entry_mod  # type: ignore[no-redef]
+
+
+def get_entry_qty() -> int:
+    return _entry_mod.get_entry_qty()
+
+
+def get_entry_ordinal(index: int) -> int:
+    return _entry_mod.get_entry_ordinal(index)
+
+
+def get_entry(ordinal: int) -> int:
+    return _entry_mod.get_entry(ordinal)
+
+
+def get_entry_name(ordinal: int) -> str:
+    return _entry_mod.get_entry_name(ordinal)
+
+
+# ---------------------------------------------------------------------------
+# inf_is_64bit (idaapi in 8.x, ida_ida in 9.x)
+# ---------------------------------------------------------------------------
+
+try:
+    import ida_ida
+    if hasattr(ida_ida, "inf_is_64bit"):
+        def inf_is_64bit() -> bool:
+            return ida_ida.inf_is_64bit()
+    else:
+        raise AttributeError
+except (ImportError, AttributeError):
+    def inf_is_64bit() -> bool:  # type: ignore[misc]
+        return idaapi.inf_is_64bit()

--- a/src/ida_multi_mcp/ida_tool_schemas.json
+++ b/src/ida_multi_mcp/ida_tool_schemas.json
@@ -18,10 +18,6 @@
             }
           ],
           "description": "Address(es) or name(s)"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -78,10 +74,6 @@
             }
           ],
           "description": "Convert numbers to various formats (hex, decimal, binary, ascii)"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -149,10 +141,6 @@
             }
           ],
           "description": "List functions with optional filtering and pagination"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -220,10 +208,6 @@
             }
           ],
           "description": "List global variables with optional filtering and pagination"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -250,10 +234,6 @@
         "count": {
           "type": "integer",
           "description": "Count (0=all)"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -282,10 +262,6 @@
         "offset": {
           "type": "integer",
           "description": "Skip first N matches (default: 0)"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -305,10 +281,6 @@
         "addr": {
           "type": "string",
           "description": "Function address to decompile"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -340,10 +312,6 @@
         "include_total": {
           "type": "boolean",
           "description": "Compute total instruction count (default: false)"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -377,10 +345,6 @@
         "limit": {
           "type": "integer",
           "description": "Max xrefs per address (default: 100, max: 1000)"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -442,10 +406,6 @@
               "additionalProperties": false
             }
           ]
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -482,10 +442,6 @@
         "limit": {
           "type": "integer",
           "description": "Max callees per function (default: 200, max: 500)"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -526,10 +482,6 @@
         "offset": {
           "type": "integer",
           "description": "Skip first N matches (default: 0)"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -570,10 +522,6 @@
         "offset": {
           "type": "integer",
           "description": "Skip first N blocks (default: 0)"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -628,10 +576,6 @@
         "offset": {
           "type": "integer",
           "description": "Skip first N matches (default: 0)"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -669,10 +613,6 @@
         "format": {
           "type": "string",
           "description": "Export format: json (default), c_header, or prototypes"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -718,10 +658,6 @@
         "max_edges_per_func": {
           "type": "integer",
           "description": "Max edges per function (default: 200, max: 5000)"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -783,10 +719,6 @@
               "additionalProperties": false
             }
           ]
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -849,10 +781,6 @@
             }
           ],
           "description": "Integer read requests (ty, addr). ty: i8/u64/i16le/i16be/etc"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -885,10 +813,6 @@
             }
           ],
           "description": "Addresses to read strings from"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -921,10 +845,6 @@
             }
           ],
           "description": "Global variable addresses or names to read values from"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -986,10 +906,6 @@
               "additionalProperties": false
             }
           ]
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -1062,10 +978,6 @@
             }
           ],
           "description": "Integer write requests (ty, addr, value). value is a string; supports 0x.. and negatives"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -1098,10 +1010,6 @@
             }
           ],
           "description": "C type declarations"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -1157,10 +1065,6 @@
               "additionalProperties": false
             }
           ]
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -1183,10 +1087,6 @@
         "filter": {
           "type": "string",
           "description": "Case-insensitive substring to search for in structure names"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -1274,10 +1174,6 @@
               "additionalProperties": false
             }
           ]
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -1310,10 +1206,6 @@
             }
           ],
           "description": "Addresses to infer types for"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -1375,10 +1267,6 @@
               "additionalProperties": false
             }
           ]
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -1434,10 +1322,6 @@
               "additionalProperties": false
             }
           ]
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -1671,10 +1555,6 @@
           },
           "required": [],
           "additionalProperties": false
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -1683,6 +1563,350 @@
     },
     "outputSchema": {
       "type": "object"
+    }
+  },
+  {
+    "name": "append_comments",
+    "description": "Append comments at addresses, deduping exact text by default. Unlike\n    set_comments (which overwrites), this preserves existing annotations \u2014 use\n    it for incremental commentary. scope='auto' (default) writes a function\n    comment when addr is a function start, otherwise a line comment; force\n    with scope='func' or 'line'. dedupe=True skips writes when the exact\n    stripped text already appears on its own line.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string",
+                    "description": "Address (hex or decimal)"
+                  },
+                  "comment": {
+                    "type": "string",
+                    "description": "Comment text to append"
+                  },
+                  "scope": {
+                    "type": "string",
+                    "description": "auto|func|line (default: auto)"
+                  },
+                  "dedupe": {
+                    "type": "boolean",
+                    "description": "Skip if exact text already exists (default: true)"
+                  }
+                },
+                "required": [
+                  "addr",
+                  "comment"
+                ],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "addr": {
+                  "type": "string",
+                  "description": "Address (hex or decimal)"
+                },
+                "comment": {
+                  "type": "string",
+                  "description": "Comment text to append"
+                },
+                "scope": {
+                  "type": "string",
+                  "description": "auto|func|line (default: auto)"
+                },
+                "dedupe": {
+                  "type": "boolean",
+                  "description": "Skip if exact text already exists (default: true)"
+                }
+              },
+              "required": [
+                "addr",
+                "comment"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": [
+        "items"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "addr": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "appended": {
+            "type": "boolean"
+          },
+          "skipped": {
+            "type": "boolean"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [],
+        "additionalProperties": false
+      }
+    }
+  },
+  {
+    "name": "define_func",
+    "description": "Define a function at each given address. IDA infers bounds unless an\n    explicit end address is provided. Returns {addr, start, end} on success or\n    {addr, start, error} if the function already exists or add_func fails.\n    Use this when IDA auto-analysis missed a function entry point.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string",
+                    "description": "Address to define (hex or decimal)"
+                  },
+                  "end": {
+                    "type": "string",
+                    "description": "Optional end address for explicit bounds"
+                  }
+                },
+                "required": [],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "addr": {
+                  "type": "string",
+                  "description": "Address to define (hex or decimal)"
+                },
+                "end": {
+                  "type": "string",
+                  "description": "Optional end address for explicit bounds"
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": [
+        "items"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "addr": {
+            "type": "string"
+          },
+          "ea": {
+            "type": "string"
+          },
+          "start": {
+            "type": "string"
+          },
+          "end": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "length": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [],
+        "additionalProperties": false
+      }
+    }
+  },
+  {
+    "name": "define_code",
+    "description": "Convert raw bytes to a code instruction at each given address. Returns\n    {addr, ea, length} on success (length is the instruction byte length) or\n    {addr, ea, error} if create_insn failed. Use this when IDA classified an\n    instruction as data or failed to decode.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string",
+                    "description": "Address to define (hex or decimal)"
+                  },
+                  "end": {
+                    "type": "string",
+                    "description": "Optional end address for explicit bounds"
+                  }
+                },
+                "required": [],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "addr": {
+                  "type": "string",
+                  "description": "Address to define (hex or decimal)"
+                },
+                "end": {
+                  "type": "string",
+                  "description": "Optional end address for explicit bounds"
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": [
+        "items"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "addr": {
+            "type": "string"
+          },
+          "ea": {
+            "type": "string"
+          },
+          "start": {
+            "type": "string"
+          },
+          "end": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "length": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [],
+        "additionalProperties": false
+      }
+    }
+  },
+  {
+    "name": "undefine",
+    "description": "Undefine item(s) at each address, converting them back to raw bytes.\n    Size is determined from `end` (exclusive) or `size`; defaults to 1 byte.\n    Uses ida_bytes.DELIT_EXPAND so adjacent items spanning into the range are\n    fully removed. Returns {addr, start, size} on success.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string",
+                    "description": "Address to undefine (hex or decimal)"
+                  },
+                  "end": {
+                    "type": "string",
+                    "description": "Optional end address"
+                  },
+                  "size": {
+                    "type": "integer",
+                    "description": "Optional size in bytes"
+                  }
+                },
+                "required": [],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "addr": {
+                  "type": "string",
+                  "description": "Address to undefine (hex or decimal)"
+                },
+                "end": {
+                  "type": "string",
+                  "description": "Optional end address"
+                },
+                "size": {
+                  "type": "integer",
+                  "description": "Optional size in bytes"
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": [
+        "items"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "addr": {
+            "type": "string"
+          },
+          "ea": {
+            "type": "string"
+          },
+          "start": {
+            "type": "string"
+          },
+          "end": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "length": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [],
+        "additionalProperties": false
+      }
     }
   },
   {
@@ -1704,10 +1928,6 @@
             }
           ],
           "description": "Address(es)"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -1789,10 +2009,6 @@
               "additionalProperties": false
             }
           ]
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -1848,10 +2064,6 @@
               "additionalProperties": false
             }
           ]
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -1868,10 +2080,6 @@
         "code": {
           "type": "string",
           "description": "Python code"
-        },
-        "instance_id": {
-          "type": "string",
-          "description": "Target IDA instance ID (defaults to active instance)"
         }
       },
       "required": [
@@ -1880,6 +2088,879 @@
     },
     "outputSchema": {
       "type": "object"
+    }
+  },
+  {
+    "name": "survey_binary",
+    "description": "Get a compact overview of the binary in one call. Returns file metadata,\n    segment layout, entry points, statistics, top 15 strings and functions ranked\n    by xref count (functions include classification: thunk/wrapper/leaf/dispatcher/\n    complex), imports by category, and call graph summary. Use this as your FIRST\n    tool call when starting analysis. Do not call list_funcs, imports, or find_regex\n    separately for triage \u2014 this returns all of that. Use detail_level='minimal'\n    for binaries with >10k functions.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "detail_level": {
+          "type": "string",
+          "description": "Detail level: 'standard' or 'minimal'"
+        }
+      },
+      "required": []
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "module": {
+              "type": "string"
+            },
+            "arch": {
+              "type": "string"
+            },
+            "base_address": {
+              "type": "string"
+            },
+            "image_size": {
+              "type": "string"
+            },
+            "md5": {
+              "type": "string"
+            },
+            "sha256": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "module",
+            "arch",
+            "base_address",
+            "image_size",
+            "md5",
+            "sha256"
+          ],
+          "additionalProperties": false
+        },
+        "statistics": {
+          "type": "object",
+          "properties": {
+            "total_functions": {
+              "type": "integer"
+            },
+            "named_functions": {
+              "type": "integer"
+            },
+            "library_functions": {
+              "type": "integer"
+            },
+            "unnamed_functions": {
+              "type": "integer"
+            },
+            "total_strings": {
+              "type": "integer"
+            },
+            "total_segments": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "total_functions",
+            "named_functions",
+            "library_functions",
+            "unnamed_functions",
+            "total_strings",
+            "total_segments"
+          ],
+          "additionalProperties": false
+        },
+        "segments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "start": {
+                "type": "string"
+              },
+              "end": {
+                "type": "string"
+              },
+              "size": {
+                "type": "string"
+              },
+              "permissions": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "start",
+              "end",
+              "size",
+              "permissions"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "entrypoints": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "addr": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "ordinal": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "addr",
+              "name",
+              "ordinal"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "interesting_strings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "addr": {
+                "type": "string"
+              },
+              "string": {
+                "type": "string"
+              },
+              "xref_count": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "addr",
+              "string",
+              "xref_count"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "interesting_functions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "addr": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "size": {
+                "type": "integer"
+              },
+              "xref_count": {
+                "type": "integer"
+              },
+              "callee_count": {
+                "type": "integer"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "addr",
+              "name",
+              "size",
+              "xref_count",
+              "callee_count",
+              "type"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "imports_by_category": {
+          "type": "object",
+          "properties": {
+            "crypto": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "module": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "addr",
+                  "name",
+                  "module"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "network": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "module": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "addr",
+                  "name",
+                  "module"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "file_io": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "module": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "addr",
+                  "name",
+                  "module"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "process": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "module": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "addr",
+                  "name",
+                  "module"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "registry": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "module": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "addr",
+                  "name",
+                  "module"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "other": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "module": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "addr",
+                  "name",
+                  "module"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "crypto",
+            "network",
+            "file_io",
+            "process",
+            "registry",
+            "other"
+          ],
+          "additionalProperties": false
+        },
+        "call_graph_summary": {
+          "type": "object",
+          "properties": {
+            "total_edges": {
+              "type": "integer"
+            },
+            "max_depth_estimate": {
+              "type": "null"
+            },
+            "root_functions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "leaf_functions_count": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "total_edges",
+            "max_depth_estimate",
+            "root_functions",
+            "leaf_functions_count"
+          ],
+          "additionalProperties": false
+        },
+        "_note": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "analyze_function",
+    "description": "Compact single-function analysis: pseudocode (capped at 100 lines), top\n    strings, top non-trivial constants, callers, callees, xrefs, comments, and\n    basic block summary. Use this for \"tell me everything about function X\" in\n    one call instead of chaining decompile + callees + xrefs_to separately.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "addr": {
+          "type": "string",
+          "description": "Function address or name"
+        },
+        "include_asm": {
+          "type": "boolean",
+          "description": "Include full disassembly (default: false, saves tokens)"
+        }
+      },
+      "required": [
+        "addr"
+      ]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "addr": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "prototype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "size": {
+          "type": "integer"
+        },
+        "decompiled": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "decompile_truncated": {
+          "type": "integer"
+        },
+        "assembly": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "constants": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          }
+        },
+        "callees": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "callers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "xrefs": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "comments": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "basic_blocks": {
+          "type": "object",
+          "properties": {
+            "count": {
+              "type": "integer"
+            },
+            "cyclomatic_complexity": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "count",
+            "cyclomatic_complexity"
+          ],
+          "additionalProperties": false
+        },
+        "error": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "analyze_component",
+    "description": "Analyze related functions as a group: per-function compact summaries,\n    internal call graph (edges only between supplied functions), shared globals,\n    interface vs internal classification, and strings used by multiple members.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "addrs": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Function addresses (comma-separated or list)"
+        }
+      },
+      "required": [
+        "addrs"
+      ]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "functions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "addr": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "prototype": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "size": {
+                "type": "integer"
+              },
+              "callees": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "strings": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "basic_blocks": {
+                "type": "integer"
+              },
+              "complexity": {
+                "type": "integer"
+              },
+              "error": {
+                "type": "string"
+              }
+            },
+            "required": [],
+            "additionalProperties": false
+          }
+        },
+        "internal_call_graph": {
+          "type": "object",
+          "properties": {
+            "nodes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "edges": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string"
+                  },
+                  "to": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "from",
+                  "to",
+                  "name"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "nodes",
+            "edges"
+          ],
+          "additionalProperties": false
+        },
+        "shared_globals": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "addr": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "accessed_by": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "addr",
+              "name",
+              "accessed_by"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "interface_functions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "internal_only": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "string_usage": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "diff_before_after",
+    "description": "Apply a rename/type/comment action and return the before/after decompilation\n    side by side. Actions: 'rename_func' ({name}), 'set_type' ({type}),\n    'set_comment' ({comment}). Useful to verify a rename or type change actually\n    improved readability. Returns {before, after, action_applied, changes_detected}.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "addr": {
+          "type": "string",
+          "description": "Function address"
+        },
+        "action": {
+          "type": "string",
+          "description": "Action: 'rename_func', 'set_type', 'set_comment'"
+        },
+        "action_args": {
+          "type": "object",
+          "description": "Arguments for the action"
+        }
+      },
+      "required": [
+        "addr",
+        "action",
+        "action_args"
+      ]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "before": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "after": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "action_applied": {
+          "type": "string"
+        },
+        "changes_detected": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "trace_data_flow",
+    "description": "Follow cross-references from or to an address, automatically traversing\n    multiple hops. 'forward' follows xrefs-from, 'backward' follows xrefs-to.\n    Returns nodes (with function name, instruction, code/data classification) and\n    edges. Do not use for call graph traversal \u2014 use callgraph for that.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "addr": {
+          "type": "string",
+          "description": "Starting address"
+        },
+        "direction": {
+          "type": "string",
+          "description": "'forward' (xrefs from) or 'backward' (xrefs to)"
+        },
+        "max_depth": {
+          "type": "integer",
+          "description": "Maximum traversal depth (default 5, max 20)"
+        }
+      },
+      "required": [
+        "addr"
+      ]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "start": {
+          "type": "string"
+        },
+        "direction": {
+          "type": "string"
+        },
+        "depth_reached": {
+          "type": "integer"
+        },
+        "nodes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "addr": {
+                "type": "string"
+              },
+              "func": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "instruction": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": {
+                "type": "string"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "depth": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "addr",
+              "func",
+              "instruction",
+              "type",
+              "name",
+              "depth"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "from": {
+                "type": "string"
+              },
+              "to": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "from",
+              "to",
+              "type"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "additionalProperties": false
     }
   }
 ]

--- a/src/ida_multi_mcp/idalib_manager.py
+++ b/src/ida_multi_mcp/idalib_manager.py
@@ -1,0 +1,260 @@
+"""idalib subprocess lifecycle manager.
+
+Spawns, monitors, and terminates headless idalib worker processes.
+Each worker opens one binary and listens on a unique localhost port.
+Does NOT depend on ``idapro`` — purely manages subprocesses.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import socket
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING
+
+from .health import is_process_alive, ping_instance
+
+if TYPE_CHECKING:
+    from .registry import InstanceRegistry
+
+# Default timeout (seconds) waiting for worker to become ready.
+_READY_TIMEOUT = 120
+# Poll interval while waiting for worker readiness.
+_READY_POLL_INTERVAL = 0.5
+
+
+def _find_free_port(host: str = "127.0.0.1") -> int:
+    """Bind an ephemeral port, release it, return the number.
+
+    There is a small TOCTOU race, but acceptable for localhost-only use.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, 0))
+        return s.getsockname()[1]
+
+
+class IdalibManager:
+    """Manages headless idalib worker subprocesses.
+
+    Each call to :meth:`spawn_session` starts a new Python subprocess
+    that opens one binary via ``idapro``, starts an HTTP MCP server on
+    a unique port, and registers itself in the shared
+    :class:`InstanceRegistry` so the router can forward tool calls.
+    """
+
+    def __init__(
+        self,
+        registry: InstanceRegistry,
+        python_executable: str | None = None,
+    ):
+        self.registry = registry
+        self.python_executable = python_executable or sys.executable
+        # instance_id -> subprocess.Popen
+        self._processes: dict[str, subprocess.Popen] = {}
+        # Register cleanup on interpreter shutdown
+        atexit.register(self.close_all_sessions)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def spawn_session(
+        self,
+        input_path: str,
+        *,
+        host: str = "127.0.0.1",
+        timeout: int = _READY_TIMEOUT,
+        unsafe: bool = False,
+    ) -> dict:
+        """Spawn a headless idalib worker for *input_path*.
+
+        Returns a dict with ``instance_id``, ``host``, ``port``, ``pid``,
+        ``binary`` on success, or ``error`` on failure.
+        """
+        resolved_path = os.path.realpath(input_path)
+        if not os.path.isfile(resolved_path):
+            return {"error": f"File not found: {input_path}"}
+
+        port = _find_free_port(host)
+
+        cmd = [
+            self.python_executable,
+            "-m", "ida_multi_mcp.idalib_worker",
+            "--host", host,
+            "--port", str(port),
+        ]
+        if unsafe:
+            cmd.append("--unsafe")
+        cmd.append(resolved_path)
+
+        creation_flags = 0
+        if sys.platform == "win32":
+            creation_flags = subprocess.CREATE_NO_WINDOW
+
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                creationflags=creation_flags,
+            )
+        except FileNotFoundError:
+            return {
+                "error": (
+                    f"Python executable not found: {self.python_executable}. "
+                    "Set --idalib-python to the correct Python with idapro installed."
+                )
+            }
+        except Exception as exc:
+            return {"error": f"Failed to spawn idalib worker: {exc}"}
+
+        # Wait for the worker to become ready.
+        if not self._wait_for_ready(host, port, proc, timeout):
+            # Worker didn't come up — collect stderr for diagnostics.
+            stderr_text = ""
+            try:
+                proc.terminate()
+                _, stderr_bytes = proc.communicate(timeout=5)
+                stderr_text = stderr_bytes.decode(errors="replace")[-500:]
+            except Exception:
+                proc.kill()
+            return {
+                "error": (
+                    f"idalib worker did not become ready within {timeout}s. "
+                    f"Last stderr: {stderr_text}"
+                )
+            }
+
+        # Register in the shared registry.
+        binary_name = os.path.basename(resolved_path)
+        instance_id = self.registry.register(
+            pid=proc.pid,
+            port=port,
+            idb_path=resolved_path,
+            host=host,
+            binary_name=binary_name,
+            binary_path=resolved_path,
+            type="idalib",
+        )
+
+        self._processes[instance_id] = proc
+        return {
+            "instance_id": instance_id,
+            "host": host,
+            "port": port,
+            "pid": proc.pid,
+            "binary": binary_name,
+        }
+
+    def close_session(self, instance_id: str) -> dict:
+        """Terminate the worker for *instance_id* and unregister it.
+
+        Returns ``{"ok": True}`` on success or ``{"error": ...}`` on failure.
+        """
+        proc = self._processes.get(instance_id)
+        if proc is None:
+            # Not managed by us (might be GUI or already closed).
+            info = self.registry.get_instance(instance_id)
+            if info is not None and info.get("type") == "idalib":
+                # Orphaned idalib entry — clean it up from registry.
+                self.registry.unregister(instance_id)
+                return {"ok": True, "note": "orphaned entry removed"}
+            return {"error": f"Instance '{instance_id}' is not a managed idalib session"}
+
+        # Terminate the subprocess.
+        try:
+            proc.terminate()
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()
+
+        del self._processes[instance_id]
+        self.registry.unregister(instance_id)
+        return {"ok": True}
+
+    def close_all_sessions(self) -> int:
+        """Terminate all managed idalib workers. Returns count closed."""
+        ids = list(self._processes.keys())
+        for iid in ids:
+            self.close_session(iid)
+        return len(ids)
+
+    def list_sessions(self) -> list[dict]:
+        """Return info about all managed idalib sessions."""
+        result = []
+        for iid, proc in list(self._processes.items()):
+            info = self.registry.get_instance(iid)
+            alive = is_process_alive(proc.pid)
+            if not alive:
+                # Clean up dead workers.
+                del self._processes[iid]
+                self.registry.unregister(iid)
+                continue
+            result.append({
+                "instance_id": iid,
+                "pid": proc.pid,
+                "host": info.get("host", "127.0.0.1") if info else "127.0.0.1",
+                "port": info.get("port", 0) if info else 0,
+                "binary_name": info.get("binary_name", "unknown") if info else "unknown",
+                "binary_path": info.get("binary_path", "") if info else "",
+                "type": "idalib",
+            })
+        return result
+
+    def get_status(self, instance_id: str) -> dict:
+        """Health / readiness check for a specific idalib session."""
+        proc = self._processes.get(instance_id)
+        if proc is None:
+            return {"error": f"Instance '{instance_id}' is not a managed idalib session"}
+
+        info = self.registry.get_instance(instance_id)
+        alive = is_process_alive(proc.pid)
+        if not alive:
+            del self._processes[instance_id]
+            self.registry.unregister(instance_id)
+            return {
+                "instance_id": instance_id,
+                "alive": False,
+                "reachable": False,
+                "error": "Worker process is dead",
+            }
+
+        host = info.get("host", "127.0.0.1") if info else "127.0.0.1"
+        port = info.get("port", 0) if info else 0
+        reachable = ping_instance(host, port, timeout=5.0)
+
+        return {
+            "instance_id": instance_id,
+            "pid": proc.pid,
+            "alive": True,
+            "reachable": reachable,
+            "binary_name": info.get("binary_name", "unknown") if info else "unknown",
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _wait_for_ready(
+        self,
+        host: str,
+        port: int,
+        proc: subprocess.Popen,
+        timeout: int,
+    ) -> bool:
+        """Poll until the worker responds to ping or until timeout/death."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            # Check if process died.
+            if proc.poll() is not None:
+                return False
+            if ping_instance(host, port, timeout=2.0):
+                return True
+            time.sleep(_READY_POLL_INTERVAL)
+        return False

--- a/src/ida_multi_mcp/idalib_manager.py
+++ b/src/ida_multi_mcp/idalib_manager.py
@@ -25,6 +25,48 @@ _READY_TIMEOUT = 120
 # Poll interval while waiting for worker readiness.
 _READY_POLL_INTERVAL = 0.5
 
+# idalib library file name per platform.
+_IDALIB_NAMES = {
+    "win32": "idalib.dll",
+    "darwin": "libidalib.dylib",
+    "linux": "libidalib.so",
+}
+
+
+def is_idalib_available() -> bool:
+    """Check whether the detected IDA installation includes idalib (Pro only).
+
+    Returns True if idalib.dll / libidalib.* exists in the IDA directory
+    resolved from IDADIR or ida-config.json.
+    """
+    ida_dir = _resolve_ida_dir()
+    if not ida_dir:
+        return False
+    lib_name = _IDALIB_NAMES.get(sys.platform, "libidalib.so")
+    return os.path.isfile(os.path.join(ida_dir, lib_name))
+
+
+def _resolve_ida_dir() -> str | None:
+    """Resolve IDA dir from IDADIR env or ida-config.json (no filesystem scan)."""
+    env_dir = os.environ.get("IDADIR", "").strip()
+    if env_dir and os.path.isdir(env_dir):
+        return env_dir
+    # ida-config.json
+    if sys.platform == "win32":
+        cfg_path = os.path.join(os.environ.get("APPDATA", ""), "Hex-Rays", "IDA Pro", "ida-config.json")
+    else:
+        cfg_path = os.path.join(os.path.expanduser("~"), ".idapro", "ida-config.json")
+    try:
+        import json
+        with open(cfg_path, "r") as f:
+            cfg = json.load(f)
+        d = cfg.get("Paths", {}).get("ida-install-dir", "").strip()
+        if d and os.path.isdir(d):
+            return d
+    except Exception:
+        pass
+    return None
+
 
 def _find_free_port(host: str = "127.0.0.1") -> int:
     """Bind an ephemeral port, release it, return the number.
@@ -74,6 +116,15 @@ class IdalibManager:
         Returns a dict with ``instance_id``, ``host``, ``port``, ``pid``,
         ``binary`` on success, or ``error`` on failure.
         """
+        if not is_idalib_available():
+            return {
+                "error": (
+                    "idalib is not available. Headless mode requires IDA Pro "
+                    "(IDA Home/Free do not include idalib). "
+                    "Ensure IDADIR points to an IDA Pro installation."
+                )
+            }
+
         resolved_path = os.path.realpath(input_path)
         if not os.path.isfile(resolved_path):
             return {"error": f"File not found: {input_path}"}

--- a/src/ida_multi_mcp/idalib_worker.py
+++ b/src/ida_multi_mcp/idalib_worker.py
@@ -1,0 +1,110 @@
+"""Headless idalib worker subprocess.
+
+This module is launched by :class:`IdalibManager` as a child process.
+It opens one binary via ``idapro``, registers all MCP tools from
+:mod:`ida_multi_mcp.ida_mcp`, then serves them over HTTP JSON-RPC on
+the given port.
+
+Usage::
+
+    python -m ida_multi_mcp.idalib_worker --host 127.0.0.1 --port 12345 /path/to/binary
+
+**This is the only module that requires the ``idapro`` package.**
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import signal
+import sys
+from pathlib import Path
+
+logger = logging.getLogger("idalib-worker")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Headless idalib MCP worker (one binary per process)"
+    )
+    parser.add_argument("--host", type=str, default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--unsafe", action="store_true",
+                        help="Enable unsafe / destructive tools")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    parser.add_argument("input_path", type=Path, help="Binary or IDB to open")
+
+    args = parser.parse_args()
+
+    # --- Configure logging ---------------------------------------------------
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="[idalib-worker %(process)d] %(levelname)s %(message)s",
+    )
+
+    # --- Validate input path before heavy imports ----------------------------
+    if not args.input_path.exists():
+        logger.error("File not found: %s", args.input_path)
+        sys.exit(1)
+
+    # --- Initialize idalib (must happen before any ida_* import) -------------
+    try:
+        import idapro  # noqa: F401 — side-effect: initialises headless IDA
+    except ImportError:
+        logger.error(
+            "The 'idapro' package is not installed in this Python (%s). "
+            "Install it or point --idalib-python at the correct interpreter.",
+            sys.executable,
+        )
+        sys.exit(1)
+
+    # Suppress console noise unless verbose
+    idapro.enable_console_messages(args.verbose)
+
+    # --- Open the database ---------------------------------------------------
+    import ida_auto
+
+    resolved = str(args.input_path.resolve())
+    logger.info("Opening database: %s", resolved)
+
+    # idapro.open_database opens (or creates) an IDB for the given binary.
+    try:
+        idapro.open_database(resolved, run_auto_analysis=True)
+    except Exception as exc:
+        logger.error("Failed to open database: %s", exc)
+        sys.exit(1)
+
+    logger.info("Waiting for auto-analysis to complete...")
+    ida_auto.auto_wait()
+    logger.info("Auto-analysis done.")
+
+    # --- Import tool package (triggers @tool registration) -------------------
+    from ida_multi_mcp.ida_mcp import MCP_SERVER, MCP_UNSAFE  # noqa: E402
+
+    # Gate unsafe tools unless --unsafe.
+    if not args.unsafe:
+        for name in list(MCP_UNSAFE):
+            MCP_SERVER.tools.methods.pop(name, None)
+        if MCP_UNSAFE:
+            logger.info("Unsafe tools disabled (start with --unsafe to enable)")
+
+    # --- Signal handling for clean shutdown -----------------------------------
+    def _shutdown(signum, frame):
+        logger.info("Received signal %s — shutting down...", signum)
+        try:
+            idapro.close_database()
+        except Exception:
+            pass
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, _shutdown)
+    signal.signal(signal.SIGTERM, _shutdown)
+
+    # --- Serve ---------------------------------------------------------------
+    logger.info("Serving on %s:%d", args.host, args.port)
+    MCP_SERVER.serve(host=args.host, port=args.port, background=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ida_multi_mcp/server.py
+++ b/src/ida_multi_mcp/server.py
@@ -603,9 +603,11 @@ class IdaMultiMcpServer:
             }
         }
 
-        # Register idalib management tool schemas
-        for schema in idalib_tools.IDALIB_TOOL_SCHEMAS:
-            self._tool_cache[schema["name"]] = schema.copy()
+        # Register idalib management tool schemas (only if IDA Pro with idalib is available)
+        from .idalib_manager import is_idalib_available
+        if is_idalib_available():
+            for schema in idalib_tools.IDALIB_TOOL_SCHEMAS:
+                self._tool_cache[schema["name"]] = schema.copy()
 
         _SINGLE_THREAD_WARNING = (
             " WARNING: IDA executes on a single main thread. "

--- a/src/ida_multi_mcp/server.py
+++ b/src/ida_multi_mcp/server.py
@@ -14,7 +14,8 @@ from .vendor.zeromcp import McpServer
 from .registry import InstanceRegistry
 from .router import InstanceRouter
 from .health import cleanup_stale_instances, rediscover_instances
-from .tools import management
+from .idalib_manager import IdalibManager
+from .tools import management, idalib as idalib_tools
 from .cache import get_cache, DEFAULT_MAX_OUTPUT_CHARS
 
 # Static IDA tool schemas (loaded once at import time)
@@ -43,15 +44,23 @@ class IdaMultiMcpServer:
     tool calls to the appropriate instance.
     """
 
-    def __init__(self, registry_path: str | None = None):
+    def __init__(
+        self,
+        registry_path: str | None = None,
+        idalib_python: str | None = None,
+    ):
         """Initialize the multi-instance MCP server.
 
         Args:
             registry_path: Path to registry JSON file (default: ~/.ida-mcp/instances.json)
+            idalib_python: Python executable with idapro installed (for headless sessions)
         """
         self.registry = InstanceRegistry(registry_path)
         self.router = InstanceRouter(self.registry)
         self.server = McpServer("ida-multi-mcp", version="1.0.0")
+
+        # idalib lifecycle manager
+        self.idalib_manager = IdalibManager(self.registry, python_executable=idalib_python)
 
         # Tool cache
         self._tool_cache: dict[str, dict] = {}
@@ -60,6 +69,7 @@ class IdaMultiMcpServer:
         # Set up management tools
         management.set_registry(self.registry)
         management.set_refresh_callback(self._refresh_tools)
+        idalib_tools.set_manager(self.idalib_manager)
 
         # Register handlers
         self._register_handlers()
@@ -215,6 +225,21 @@ class IdaMultiMcpServer:
                     "content": [{"type": "text", "text": json.dumps(result, indent=2)}],
                     "structuredContent": result,
                     "isError": "error" in result
+                }
+
+            # idalib management tools (local)
+            elif name in ("idalib_open", "idalib_close", "idalib_list", "idalib_status"):
+                handler = getattr(idalib_tools, name)
+                result = handler(arguments)
+                is_error = "error" in result
+                # After idalib_open succeeds, refresh tools so the new instance's
+                # tools become available immediately.
+                if name == "idalib_open" and not is_error:
+                    self._refresh_tools()
+                return {
+                    "content": [{"type": "text", "text": json.dumps(result, indent=2)}],
+                    "structuredContent": result,
+                    "isError": is_error,
                 }
 
             # IDA tools (proxied)
@@ -493,6 +518,7 @@ class IdaMultiMcpServer:
                             "type": "object",
                             "properties": {
                                 "id": {"type": "string"},
+                                "type": {"type": "string", "description": "gui or idalib"},
                                 "binary_name": {"type": "string"},
                                 "binary_path": {"type": "string"},
                                 "arch": {"type": "string"},
@@ -501,7 +527,7 @@ class IdaMultiMcpServer:
                                 "pid": {"type": "integer"},
                                 "registered_at": {"type": "string"}
                             },
-                            "required": ["id", "binary_name", "binary_path", "arch", "host", "port", "pid", "registered_at"]
+                            "required": ["id", "type", "binary_name", "binary_path", "arch", "host", "port", "pid", "registered_at"]
                         }
                     }
                 },
@@ -576,6 +602,10 @@ class IdaMultiMcpServer:
                 "required": ["output_dir", "instance_id"]
             }
         }
+
+        # Register idalib management tool schemas
+        for schema in idalib_tools.IDALIB_TOOL_SCHEMAS:
+            self._tool_cache[schema["name"]] = schema.copy()
 
         _SINGLE_THREAD_WARNING = (
             " WARNING: IDA executes on a single main thread. "
@@ -759,15 +789,16 @@ class IdaMultiMcpServer:
         print(f"[ida-multi-mcp] Server starting with {len(self._tool_cache)} tools",
               file=sys.stderr)
 
-        # Run server with stdio transport
+        # Run server with stdio transport (idalib cleanup via atexit in IdalibManager)
         self.server.stdio()
 
 
-def serve(registry_path: str | None = None):
+def serve(registry_path: str | None = None, idalib_python: str | None = None):
     """Start the ida-multi-mcp server.
 
     Args:
         registry_path: Optional custom registry path
+        idalib_python: Python executable with idapro installed (for headless)
     """
-    server = IdaMultiMcpServer(registry_path)
+    server = IdaMultiMcpServer(registry_path, idalib_python=idalib_python)
     server.run()

--- a/src/ida_multi_mcp/tools/idalib.py
+++ b/src/ida_multi_mcp/tools/idalib.py
@@ -1,0 +1,161 @@
+"""idalib management tools — exposed through the router MCP server.
+
+These four tools let MCP clients open/close/list/inspect headless idalib
+sessions.  Each session is a subprocess managed by :class:`IdalibManager`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..idalib_manager import IdalibManager
+
+_manager: IdalibManager | None = None
+
+
+def set_manager(manager: IdalibManager) -> None:
+    """Inject the :class:`IdalibManager` instance (called by server.py on startup)."""
+    global _manager
+    _manager = manager
+
+
+def _get_manager() -> IdalibManager:
+    if _manager is None:
+        raise RuntimeError("IdalibManager not initialized")
+    return _manager
+
+
+# ------------------------------------------------------------------
+# Tool functions (called from custom_tools_call in server.py)
+# ------------------------------------------------------------------
+
+
+def idalib_open(arguments: dict) -> dict:
+    """Open a binary in a new headless idalib session.
+
+    Required args:
+        input_path (str): Path to the binary or IDB file.
+    Optional args:
+        timeout (int): Seconds to wait for analysis (default 120).
+        unsafe (bool): Enable unsafe tools (default false).
+    """
+    mgr = _get_manager()
+    input_path = arguments.get("input_path", "")
+    if not input_path:
+        return {"error": "Missing required argument 'input_path'"}
+    timeout = int(arguments.get("timeout", 120))
+    unsafe = bool(arguments.get("unsafe", False))
+    return mgr.spawn_session(input_path, timeout=timeout, unsafe=unsafe)
+
+
+def idalib_close(arguments: dict) -> dict:
+    """Close a headless idalib session and terminate its worker process.
+
+    Required args:
+        instance_id (str): Instance ID of the idalib session.
+    """
+    mgr = _get_manager()
+    instance_id = arguments.get("instance_id", "")
+    if not instance_id:
+        return {"error": "Missing required argument 'instance_id'"}
+    return mgr.close_session(instance_id)
+
+
+def idalib_list(arguments: dict) -> dict:
+    """List all managed idalib sessions."""
+    mgr = _get_manager()
+    sessions = mgr.list_sessions()
+    return {"count": len(sessions), "sessions": sessions}
+
+
+def idalib_status(arguments: dict) -> dict:
+    """Health / readiness check for a specific idalib session.
+
+    Required args:
+        instance_id (str): Instance ID to check.
+    """
+    mgr = _get_manager()
+    instance_id = arguments.get("instance_id", "")
+    if not instance_id:
+        return {"error": "Missing required argument 'instance_id'"}
+    return mgr.get_status(instance_id)
+
+
+# ------------------------------------------------------------------
+# Tool schemas (registered in server._refresh_tools)
+# ------------------------------------------------------------------
+
+IDALIB_TOOL_SCHEMAS: list[dict] = [
+    {
+        "name": "idalib_open",
+        "description": (
+            "Open a binary in a new headless idalib session. "
+            "Spawns a background process that loads the binary via idalib, "
+            "waits for auto-analysis to complete, then registers as a regular "
+            "IDA instance. Use list_instances() to see it alongside GUI instances. "
+            "Requires idapro Python package on the configured Python."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "input_path": {
+                    "type": "string",
+                    "description": "Path to the binary or IDB file to open",
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": "Seconds to wait for analysis to complete (default 120)",
+                },
+                "unsafe": {
+                    "type": "boolean",
+                    "description": "Enable unsafe/destructive tools (default false)",
+                },
+            },
+            "required": ["input_path"],
+        },
+    },
+    {
+        "name": "idalib_close",
+        "description": (
+            "Close a headless idalib session and terminate its worker process. "
+            "The instance is removed from the registry."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "instance_id": {
+                    "type": "string",
+                    "description": "Instance ID of the idalib session to close",
+                },
+            },
+            "required": ["instance_id"],
+        },
+    },
+    {
+        "name": "idalib_list",
+        "description": "List all managed headless idalib sessions with pid, port, and binary info.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    {
+        "name": "idalib_status",
+        "description": (
+            "Health and readiness check for a specific idalib session. "
+            "Reports whether the worker process is alive and reachable via HTTP."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "instance_id": {
+                    "type": "string",
+                    "description": "Instance ID of the idalib session to check",
+                },
+            },
+            "required": ["instance_id"],
+        },
+    },
+]

--- a/src/ida_multi_mcp/tools/management.py
+++ b/src/ida_multi_mcp/tools/management.py
@@ -44,6 +44,7 @@ def list_instances() -> dict:
     for id, info in instances.items():
         result.append({
             "id": id,
+            "type": info.get("type", "gui"),
             "binary_name": info.get("binary_name", "unknown"),
             "binary_path": info.get("binary_path", "unknown"),
             "arch": info.get("arch", "unknown"),

--- a/tests/test_idalib_manager.py
+++ b/tests/test_idalib_manager.py
@@ -24,7 +24,24 @@ class TestFindFreePort:
         assert len(ports) >= 2
 
 
+@pytest.fixture(autouse=True)
+def _mock_idalib_available():
+    """Assume IDA Pro (idalib) is available in all manager tests."""
+    with patch("ida_multi_mcp.idalib_manager.is_idalib_available", return_value=True):
+        yield
+
+
 class TestIdalibManagerSpawn:
+    def test_spawn_rejected_without_ida_pro(self, tmp_path, tmp_registry):
+        """Without IDA Pro, spawn_session should return a clear error."""
+        binary = tmp_path / "test.bin"
+        binary.write_bytes(b"\x00" * 16)
+        with patch("ida_multi_mcp.idalib_manager.is_idalib_available", return_value=False):
+            mgr = IdalibManager(tmp_registry)
+            result = mgr.spawn_session(str(binary))
+            assert "error" in result
+            assert "IDA Pro" in result["error"]
+
     def test_spawn_file_not_found(self, tmp_path, tmp_registry):
         mgr = IdalibManager(tmp_registry)
         result = mgr.spawn_session(str(tmp_path / "nonexistent.exe"))

--- a/tests/test_idalib_manager.py
+++ b/tests/test_idalib_manager.py
@@ -1,0 +1,180 @@
+"""Tests for IdalibManager — subprocess lifecycle manager.
+
+All tests mock subprocesses; no idapro required.
+"""
+
+import subprocess
+import time
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+from ida_multi_mcp.idalib_manager import IdalibManager, _find_free_port
+
+
+class TestFindFreePort:
+    def test_returns_positive_int(self):
+        port = _find_free_port()
+        assert isinstance(port, int)
+        assert port > 0
+
+    def test_returns_different_ports(self):
+        ports = {_find_free_port() for _ in range(5)}
+        # At least 2 unique ports (unlikely all 5 collide)
+        assert len(ports) >= 2
+
+
+class TestIdalibManagerSpawn:
+    def test_spawn_file_not_found(self, tmp_path, tmp_registry):
+        mgr = IdalibManager(tmp_registry)
+        result = mgr.spawn_session(str(tmp_path / "nonexistent.exe"))
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_spawn_bad_python_executable(self, tmp_path, tmp_registry):
+        binary = tmp_path / "test.bin"
+        binary.write_bytes(b"\x00" * 16)
+        mgr = IdalibManager(tmp_registry, python_executable="/no/such/python")
+        result = mgr.spawn_session(str(binary))
+        assert "error" in result
+
+    @patch("ida_multi_mcp.idalib_manager.subprocess.Popen")
+    @patch("ida_multi_mcp.idalib_manager.ping_instance")
+    def test_spawn_success(self, mock_ping, mock_popen, tmp_path, tmp_registry):
+        binary = tmp_path / "test.bin"
+        binary.write_bytes(b"\x00" * 16)
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+        mock_proc.poll.return_value = None  # still running
+        mock_popen.return_value = mock_proc
+        mock_ping.return_value = True
+
+        mgr = IdalibManager(tmp_registry)
+        result = mgr.spawn_session(str(binary))
+
+        assert "error" not in result
+        assert "instance_id" in result
+        assert result["pid"] == 99999
+        assert result["binary"] == "test.bin"
+
+        # Verify registered in registry
+        info = tmp_registry.get_instance(result["instance_id"])
+        assert info is not None
+        assert info["type"] == "idalib"
+
+    @patch("ida_multi_mcp.idalib_manager.subprocess.Popen")
+    @patch("ida_multi_mcp.idalib_manager.ping_instance", return_value=False)
+    def test_spawn_timeout(self, mock_ping, mock_popen, tmp_path, tmp_registry):
+        binary = tmp_path / "test.bin"
+        binary.write_bytes(b"\x00" * 16)
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+        mock_proc.poll.return_value = None
+        mock_proc.communicate.return_value = (b"", b"analysis failed")
+        mock_popen.return_value = mock_proc
+
+        mgr = IdalibManager(tmp_registry)
+        result = mgr.spawn_session(str(binary), timeout=1)
+
+        assert "error" in result
+        assert "ready" in result["error"].lower()
+
+
+class TestIdalibManagerClose:
+    @patch("ida_multi_mcp.idalib_manager.subprocess.Popen")
+    @patch("ida_multi_mcp.idalib_manager.ping_instance", return_value=True)
+    def test_close_session(self, mock_ping, mock_popen, tmp_path, tmp_registry):
+        binary = tmp_path / "test.bin"
+        binary.write_bytes(b"\x00" * 16)
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
+        mgr = IdalibManager(tmp_registry)
+        spawn_result = mgr.spawn_session(str(binary))
+        iid = spawn_result["instance_id"]
+
+        close_result = mgr.close_session(iid)
+        assert close_result.get("ok") is True
+
+        # Verify unregistered
+        assert tmp_registry.get_instance(iid) is None
+
+    def test_close_nonexistent_session(self, tmp_registry):
+        mgr = IdalibManager(tmp_registry)
+        result = mgr.close_session("nonexistent")
+        assert "error" in result
+
+
+class TestIdalibManagerList:
+    @patch("ida_multi_mcp.idalib_manager.subprocess.Popen")
+    @patch("ida_multi_mcp.idalib_manager.ping_instance", return_value=True)
+    @patch("ida_multi_mcp.idalib_manager.is_process_alive", return_value=True)
+    def test_list_sessions(self, mock_alive, mock_ping, mock_popen, tmp_path, tmp_registry):
+        binary = tmp_path / "test.bin"
+        binary.write_bytes(b"\x00" * 16)
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
+        mgr = IdalibManager(tmp_registry)
+        mgr.spawn_session(str(binary))
+
+        sessions = mgr.list_sessions()
+        assert len(sessions) == 1
+        assert sessions[0]["type"] == "idalib"
+        assert sessions[0]["binary_name"] == "test.bin"
+
+
+class TestIdalibManagerStatus:
+    @patch("ida_multi_mcp.idalib_manager.subprocess.Popen")
+    @patch("ida_multi_mcp.idalib_manager.ping_instance", return_value=True)
+    @patch("ida_multi_mcp.idalib_manager.is_process_alive", return_value=True)
+    def test_status_healthy(self, mock_alive, mock_ping, mock_popen, tmp_path, tmp_registry):
+        binary = tmp_path / "test.bin"
+        binary.write_bytes(b"\x00" * 16)
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
+        mgr = IdalibManager(tmp_registry)
+        spawn_result = mgr.spawn_session(str(binary))
+        iid = spawn_result["instance_id"]
+
+        status = mgr.get_status(iid)
+        assert status["alive"] is True
+        assert status["reachable"] is True
+
+
+class TestListInstancesTypeField:
+    """Verify that list_instances includes the 'type' field."""
+
+    def test_gui_instance_defaults_to_gui(self, tmp_registry):
+        """Existing instances without explicit type should default to 'gui'."""
+        from ida_multi_mcp.tools.management import list_instances, set_registry
+        set_registry(tmp_registry)
+
+        tmp_registry.register(pid=1, port=100, idb_path="/a.i64",
+                              binary_name="a.exe", host="127.0.0.1")
+        result = list_instances()
+        assert result["count"] == 1
+        assert result["instances"][0]["type"] == "gui"
+
+    def test_idalib_instance_shows_idalib(self, tmp_registry):
+        from ida_multi_mcp.tools.management import list_instances, set_registry
+        set_registry(tmp_registry)
+
+        tmp_registry.register(pid=2, port=200, idb_path="/b.i64",
+                              binary_name="b.exe", host="127.0.0.1",
+                              type="idalib")
+        result = list_instances()
+        assert result["count"] == 1
+        assert result["instances"][0]["type"] == "idalib"

--- a/tests/test_utils_pure.py
+++ b/tests/test_utils_pure.py
@@ -33,7 +33,7 @@ _SUBMODULES = [
     "rpc", "http", "framework",
     "api_core", "api_analysis", "api_memory", "api_types",
     "api_modify", "api_stack", "api_debug", "api_python", "api_resources",
-    "api_survey", "api_composite",
+    "api_survey", "api_composite", "compat",
 ]
 
 # Create a real sync stub with IDAError


### PR DESCRIPTION
## Summary
Adds headless idalib session management to the router, plus IDA SDK version compatibility and IDA installation auto-detection.

### Headless idalib support (subprocess model)
- **`idalib_manager.py`** — spawns/monitors/terminates headless idalib worker subprocesses. No `idapro` dependency in the router itself.
- **`idalib_worker.py`** — the only file that imports `idapro`. Opens one binary per process, serves all MCP tools over HTTP.
- **`tools/idalib.py`** — 4 management tools: `idalib_open`, `idalib_close`, `idalib_list`, `idalib_status`.
- idalib instances appear in the shared registry as `type: "idalib"` alongside GUI instances.
- IDA Pro-only gate: `is_idalib_available()` checks for `idalib.dll`; IDA Home/Free users get a clear error.
- `pyproject.toml`: optional `[idalib]` dependency group.

### compat.py — IDA 8.3–9.3 compatibility
- Entry point functions (`get_entry_qty/ordinal/entry/name`): `ida_entry` (9.x) with `ida_nalt` (8.x) fallback.
- `inf_is_64bit`: `ida_ida` (9.x) with `idaapi` (8.x) fallback.
- Updated `api_survey.py`, `api_resources.py`, `api_debug.py`, `api_types.py` to use `compat.*`.

### IDA auto-detection during `--install`
- `_detect_ida_dir()` scans IDADIR env → `ida-config.json` → filesystem (drives, Program Files, /Applications, /opt).
- Picks newest version by regex, verifies with marker files (`ida.exe`, `ida64.exe`, `ida.dll`, etc.).
- Writes to `ida-config.json` so `idapro` package finds IDA at import time.

### Other
- `--idalib-python` CLI arg for custom Python executable.
- `list_instances` now includes `type` field (`gui` or `idalib`).
- Updated `ida_tool_schemas.json` from live IDA 9.3 (34 → 43 tools).

## Live test results (IDA 9.3, Client_dump_SCY.exe — 736k functions)

| Tool | PR | Result |
|---|---|---|
| `survey_binary` | #2 | PASS — metadata, 15 segments, top 15 strings/funcs, import categories |
| `analyze_function` | #3 | PASS — pseudocode 154 lines (100-line cap), xrefs, BB |
| `analyze_component` | #3 | PASS — internal call graph, interface classification |
| `trace_data_flow` | #3 | PASS — backward BFS, 50 call sites found |
| `diff_before_after` | #3 | PASS — set_comment before/after diff |
| `append_comments` | #4 | PASS — append + dedupe skip on duplicate |
| `define_func` | #4 | PASS — "already exists" error on existing function |
| `define_code` | #4 | PASS — 4-byte instruction created |
| `undefine` | #4 | PASS — 4 bytes reverted to raw |

## Test plan
- [x] `python -m pytest tests/` → 156 passed, 3 skipped
- [x] Live test: 9/9 new tools verified on IDA 9.3 with real binary
- [x] `compat.py` resolves IDA 9.3 `AttributeError` on `ida_nalt.get_entry_qty`
- [x] `--install` auto-detects IDA Home at `C:\Program Files\IDA Home (PC) 9.3`
- [x] `is_idalib_available()` correctly returns False for IDA Home
- [ ] IDA 8.x backward compat (not tested — compat.py has fallback logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)