### PR TITLE
Fix NameError in 4 new analysis tools (missing imports)

### DIFF
--- a/src/ida_multi_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_multi_mcp/ida_mcp/api_analysis.py
@@ -15,11 +15,14 @@ import ida_idaapi
 import ida_xref
 import ida_ua
 import ida_name
+import idc
 from .rpc import tool
 from .sync import idasync, tool_timeout
 from .utils import (
     parse_address,
     normalize_list_input,
+    normalize_dict_list,
+    paginate,
     get_function,
     get_prototype,
     get_stack_frame_variables_internal,
@@ -27,6 +30,7 @@ from .utils import (
     get_assembly_lines,
     get_all_xrefs,
     get_all_comments,
+    extract_function_strings,
     Function,
     Argument,
     DisassemblyFunction,


### PR DESCRIPTION
Adds missing imports to api_analysis.py: `paginate`, `normalize_dict_list`, `extract_function_strings` from utils, and `idc`. These were used by `xref_query`, `insn_query`, `func_profile`, and `classify_functions` but not in the import block, causing `NameError` at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)