### PR TITLE
Fix BSS reads for unloaded memory

### DIFF
--- a/docs/ida-pro-mcp/comparison.md
+++ b/docs/ida-pro-mcp/comparison.md
@@ -1,0 +1,125 @@
+# ida-pro-mcp (upstream) vs ida-multi-mcp — Comparison
+
+Last updated: 2026-04-16 (upstream commit `d80ed7f`)
+
+This document tracks what upstream features/fixes ida-multi-mcp has NOT yet adopted.
+
+## Current Coverage
+
+After PRs #2–#8, ida-multi-mcp has ported or implemented equivalents of most upstream tools. The remaining gaps are **bugfixes, optimizations, and minor features** rather than major missing tool categories.
+
+---
+
+## HIGH Priority — Correctness & Token Cost
+
+### 1. BSS/Virtual Memory Read Bug
+
+**Upstream fix**: commit `2fee279` — `read_bytes_bss_safe()` and `read_int_bss_safe()` helpers in `utils.py`.
+
+**Problem**: `ida_bytes.get_bytes()` returns `0xFF` for unloaded BSS/virtual memory regions. Upstream now returns `0x00` for these addresses, which is the correct semantic (BSS is zero-initialized).
+
+**Current state**: ida-multi-mcp uses raw `ida_bytes.get_bytes()` in `api_memory.py` and `api_types.py`, so reading BSS globals returns incorrect `0xFF` byte fills.
+
+**Impact**: Any memory read of uninitialized globals or BSS data is wrong. Affects `get_bytes`, `get_int`, `get_global_value`, `read_struct`.
+
+### 2. Token Optimization — Whitespace Compaction
+
+**Upstream fix**: PR #341 — `compact_whitespace()` function in `utils.py`.
+
+**What it does**: Collapses multiple spaces/tabs in decompiler and disassembly output while preserving string literals. Reduces response payload size.
+
+**Current state**: ida-multi-mcp sends raw Hex-Rays/disasm output with original whitespace, inflating token cost.
+
+**Impact**: `decompile` and `disasm` responses are larger than necessary. On a 736K-function binary, this can add up.
+
+### 3. Token Optimization — Compact JSON Serialization
+
+**Upstream fix**: PR #341 — `separators=(",", ":")` in zeromcp JSON serialization.
+
+**What it does**: Removes spaces after `:` and `,` in all JSON-RPC responses. ~15-20% reduction in wire bytes.
+
+**Current state**: ida-multi-mcp uses default `json.dumps()` with spaces (`", ": "`).
+
+**Impact**: Every tool response is larger than necessary. Combined with whitespace compaction, upstream achieves significant token savings.
+
+---
+
+## MEDIUM Priority — Usability & Performance
+
+### 4. parse_address Symbol Name Resolution
+
+**Upstream fix**: PR #349 — `parse_address()` now calls `idaapi.get_name_ea()` as fallback.
+
+**What it does**: Allows passing symbol names (e.g., `"main"`, `"CreateFileW"`) directly to any tool that takes an address parameter. If hex parsing fails, tries name lookup.
+
+**Current state**: ida-multi-mcp's `parse_address()` only accepts hex/decimal strings. Passing a function name like `"main"` fails with an error.
+
+**Impact**: Users must look up addresses before calling tools. Upstream allows natural name-based workflows.
+
+### 5. Lazy Cache Initialization
+
+**Upstream fix**: commit `c25459b` — removed `init_caches()` from plugin load path.
+
+**What it does**: Strings cache is built lazily on first access instead of at plugin startup. Reduces IDA startup time.
+
+**Current state**: ida-multi-mcp calls `init_caches()` eagerly on plugin load (`__init__.py` exports it, plugin calls it on Ctrl+M).
+
+**Impact**: Plugin startup is slower, especially on large binaries. Not a correctness issue.
+
+### 6. idalib Detection via `is_idaq()`
+
+**Upstream fix**: commit `b8be030` — uses `ida_kernwin.is_idaq()` instead of `sys.modules` check.
+
+**What it does**: Cleaner headless mode detection. `is_idaq()` returns `False` when running under idalib (no GUI).
+
+**Current state**: ida-multi-mcp uses `ida_major` version checks and separate `idalib_worker.py` architecture (subprocess model), so this is less relevant.
+
+**Impact**: LOW — architectural difference makes this a minor code quality item.
+
+---
+
+## Already Adopted (No Action Needed)
+
+| Upstream Change | Status |
+|---|---|
+| Tool parameter consistency (PR #362): `int_convert`, `list_globals`, `set_comments`, `dbg_step_into/over` naming | Already uses these names |
+| HTTP Host/Origin validation (PR #352) | Already implemented in `http.py` |
+| `@unsafe` flag gating in idalib (PR #335) | Implemented via `is_idalib_available()` + worker `--unsafe` flag |
+| `survey_binary` | Ported (PR #2) |
+| `api_composite` (4 tools) | Ported (PR #3) |
+| `append_comments`, `define_func/code`, `undefine` | Ported (PR #4) |
+| `func_query`, `xref_query`, `insn_query`, `analyze_batch` | Implemented (PR #7) |
+| `imports_query`, `idb_save`, `enum_upsert` | Implemented (PR #7) |
+| `server_health`, `server_warmup` | Implemented (PR #7) |
+| IDA 8.3–9.3 compat shims | `compat.py` with try/import fallback |
+
+---
+
+## ida-multi-mcp Unique Features (Not in Upstream)
+
+| Feature | Description |
+|---|---|
+| Multi-instance router | Single MCP endpoint proxying to N IDA instances |
+| `instance_id` routing | Explicit per-call instance targeting |
+| Auto-select single instance | Omit `instance_id` when only 1 instance registered |
+| `compare_binaries` | Router-level diff of two instances |
+| `classify_functions` | Batch function classification (thunk/wrapper/leaf/dispatcher/complex) |
+| `func_profile` | Per-function metrics with sort/pagination |
+| `list_cached_outputs` | Browse truncated output cache |
+| `decompile_to_file` | Batch decompile to disk (router-orchestrated) |
+| idalib subprocess model | One process per binary, true parallelism |
+| IDA installation auto-detection | `--install` scans filesystem for IDA directory |
+| Benchmark script | `scripts/benchmark.py` for latency + token measurement |
+
+---
+
+## Adoption Roadmap
+
+| # | Item | Priority | Effort |
+|---|---|---|---|
+| 1 | BSS read fix (`read_bytes_bss_safe`) | HIGH | S |
+| 2 | Whitespace compaction (`compact_whitespace`) | HIGH | S |
+| 3 | Compact JSON serialization | HIGH | S |
+| 4 | `parse_address` symbol resolution | MED | S |
+| 5 | Lazy cache initialization | MED | S |
+| 6 | `is_idaq()` detection | LOW | S |

--- a/src/ida_multi_mcp/ida_mcp/api_memory.py
+++ b/src/ida_multi_mcp/ida_mcp/api_memory.py
@@ -19,6 +19,8 @@ from .utils import (
     MemoryRead,
     normalize_list_input,
     parse_address,
+    read_bytes_bss_safe,
+    read_int_bss_safe,
 )
 
 
@@ -53,7 +55,7 @@ def get_bytes(regions: list[MemoryRead] | MemoryRead) -> list[dict]:
             if size < 0 or size > _MAX_READ_SIZE:
                 raise ValueError(f"Size must be between 0 and {_MAX_READ_SIZE} (got {size})")
             ea = parse_address(addr)
-            data = " ".join(f"{x:#02x}" for x in ida_bytes.get_bytes(ea, size))
+            data = " ".join(f"{x:#02x}" for x in read_bytes_bss_safe(ea, size))
             results.append({"addr": addr, "data": data})
         except Exception as e:
             results.append({"addr": addr, "data": None, "error": str(e)})
@@ -123,8 +125,8 @@ def get_int(
             bits, signed, byte_order, normalized = _parse_int_class(ty)
             ea = parse_address(addr)
             size = bits // 8
-            data = ida_bytes.get_bytes(ea, size)
-            if not data or len(data) != size:
+            data = read_bytes_bss_safe(ea, size)
+            if len(data) != size:
                 raise ValueError(f"Failed to read {size} bytes at {addr}")
 
             value = int.from_bytes(data, byte_order, signed=signed)
@@ -188,16 +190,10 @@ def get_global_variable_value_internal(ea: int) -> str:
             return "\"\""
         return_string = raw.decode("utf-8", errors="replace").strip()
         return f'"{return_string}"'
-    elif size == 1:
-        return hex(ida_bytes.get_byte(ea))
-    elif size == 2:
-        return hex(ida_bytes.get_word(ea))
-    elif size == 4:
-        return hex(ida_bytes.get_dword(ea))
-    elif size == 8:
-        return hex(ida_bytes.get_qword(ea))
+    elif size in (1, 2, 4, 8):
+        return hex(read_int_bss_safe(ea, size))
     else:
-        return " ".join(hex(x) for x in ida_bytes.get_bytes(ea, size))
+        return " ".join(hex(x) for x in read_bytes_bss_safe(ea, size))
 
 
 @tool

--- a/src/ida_multi_mcp/ida_mcp/api_types.py
+++ b/src/ida_multi_mcp/ida_mcp/api_types.py
@@ -21,6 +21,8 @@ from .utils import (
     StructureDefinition,
     StructRead,
     TypeEdit,
+    read_bytes_bss_safe,
+    read_int_bss_safe,
 )
 
 
@@ -164,31 +166,17 @@ def read_struct(queries: list[StructRead] | StructRead) -> list[dict]:
                     if member.type.is_ptr():
                         from . import compat
                         is_64bit = compat.inf_is_64bit()
-                        if is_64bit:
-                            value = idaapi.get_qword(member_addr)
-                            value_str = f"0x{value:016X}"
-                        else:
-                            value = idaapi.get_dword(member_addr)
-                            value_str = f"0x{value:08X}"
-                    elif member_size == 1:
-                        value = idaapi.get_byte(member_addr)
-                        value_str = f"0x{value:02X} ({value})"
-                    elif member_size == 2:
-                        value = idaapi.get_word(member_addr)
-                        value_str = f"0x{value:04X} ({value})"
-                    elif member_size == 4:
-                        value = idaapi.get_dword(member_addr)
-                        value_str = f"0x{value:08X} ({value})"
-                    elif member_size == 8:
-                        value = idaapi.get_qword(member_addr)
-                        value_str = f"0x{value:016X} ({value})"
+                        ptr_size = 8 if is_64bit else 4
+                        value = read_int_bss_safe(member_addr, ptr_size)
+                        value_str = f"0x{value:0{ptr_size * 2}X}"
+                    elif member_size in (1, 2, 4, 8):
+                        value = read_int_bss_safe(member_addr, member_size)
+                        value_str = f"0x{value:0{member_size * 2}X} ({value})"
                     else:
-                        bytes_data = []
-                        for i in range(min(member_size, 16)):
-                            try:
-                                bytes_data.append(f"{idaapi.get_byte(member_addr + i):02X}")
-                            except Exception:
-                                break
+                        bytes_data = [
+                            f"{byte:02X}"
+                            for byte in read_bytes_bss_safe(member_addr, min(member_size, 16))
+                        ]
                         value_str = f"[{' '.join(bytes_data)}{'...' if member_size > 16 else ''}]"
                 except Exception:
                     value_str = "<failed to read>"

--- a/src/ida_multi_mcp/ida_mcp/utils.py
+++ b/src/ida_multi_mcp/ida_mcp/utils.py
@@ -20,6 +20,7 @@ from typing import (
 
 import ida_funcs
 import ida_hexrays
+import ida_bytes
 import ida_kernwin
 import ida_nalt
 import ida_typeinf
@@ -458,6 +459,31 @@ def parse_address(addr: str | int) -> int:
     if result < 0 or result > _MAX_ADDRESS:
         raise IDAError(f"Address out of range: must be 0..0x{_MAX_ADDRESS:X}")
     return result
+
+
+def read_bytes_bss_safe(ea: int, size: int) -> bytes:
+    """Read bytes from the IDB, substituting zeros for unloaded BSS bytes."""
+    out = bytearray(size)
+    for offset in range(size):
+        current_ea = ea + offset
+        if ida_bytes.is_loaded(current_ea):
+            out[offset] = ida_bytes.get_byte(current_ea)
+    return bytes(out)
+
+
+def read_int_bss_safe(ea: int, size: int) -> int:
+    """Read a sized integer, treating unloaded BSS bytes as zero."""
+    if not ida_bytes.is_loaded(ea):
+        return 0
+    if size == 1:
+        return ida_bytes.get_byte(ea)
+    if size == 2:
+        return ida_bytes.get_word(ea)
+    if size == 4:
+        return ida_bytes.get_dword(ea)
+    if size == 8:
+        return ida_bytes.get_qword(ea)
+    raise ValueError(f"unsupported integer size: {size}")
 
 
 MAX_BATCH_SIZE = 500  # Security: prevent DoS via unbounded batch requests

--- a/tests/test_utils_pure.py
+++ b/tests/test_utils_pure.py
@@ -19,7 +19,7 @@ import pytest
 # ---------------------------------------------------------------------------
 
 _IDA_MODULES = [
-    "ida_funcs", "ida_hexrays", "ida_kernwin", "ida_nalt", "ida_typeinf",
+    "ida_bytes", "ida_funcs", "ida_hexrays", "ida_kernwin", "ida_nalt", "ida_typeinf",
     "ida_ida", "ida_lines", "idaapi", "idautils", "idc",
 ]
 
@@ -63,7 +63,10 @@ from ida_multi_mcp.ida_mcp.utils import (
     looks_like_address,
     pattern_filter,
     paginate,
+    read_bytes_bss_safe,
+    read_int_bss_safe,
 )
+import ida_multi_mcp.ida_mcp.utils as utils
 
 
 # ---------------------------------------------------------------------------
@@ -89,6 +92,32 @@ class TestParseAddress:
     def test_out_of_range(self):
         with pytest.raises(IDAError, match="out of range"):
             parse_address(-1)
+
+
+class TestBssSafeReads:
+    def test_read_bytes_bss_safe_zero_fills_unloaded(self):
+        load_map = {0x1000: True, 0x1001: False, 0x1002: True, 0x1003: False}
+        value_map = {0x1000: 0x41, 0x1002: 0x43}
+
+        utils.ida_bytes.is_loaded.side_effect = lambda ea: load_map.get(ea, False)
+        utils.ida_bytes.get_byte.side_effect = lambda ea: value_map[ea]
+
+        assert read_bytes_bss_safe(0x1000, 4) == b"A\x00C\x00"
+
+    def test_read_int_bss_safe_returns_zero_for_unloaded_start(self):
+        utils.ida_bytes.is_loaded.side_effect = lambda ea: False
+
+        assert read_int_bss_safe(0x2000, 1) == 0
+        assert read_int_bss_safe(0x2000, 2) == 0
+        assert read_int_bss_safe(0x2000, 4) == 0
+        assert read_int_bss_safe(0x2000, 8) == 0
+
+    def test_read_int_bss_safe_uses_sized_reader_when_loaded(self):
+        utils.ida_bytes.is_loaded.side_effect = lambda ea: True
+        utils.ida_bytes.get_qword.return_value = 0x1122334455667788
+
+        assert read_int_bss_safe(0x3000, 8) == 0x1122334455667788
+        utils.ida_bytes.get_qword.assert_called_once_with(0x3000)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- port upstream BSS-safe read helpers from ida-pro-mcp commit 2fee2795e7eb9e888af281d978590352e05280c7
- use zero-filled reads for unloaded/BSS memory in get_bytes, get_int, get_global_value, and read_struct
- add pure unit coverage for the new helpers so unloaded bytes are treated as zero instead of IDA's 0xFF sentinel

## Testing
- pytest
