### PR TITLE
Trim analysis whitespace and compact JSON

### DIFF
--- a/src/ida_multi_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_multi_mcp/ida_mcp/api_analysis.py
@@ -27,6 +27,7 @@ from .utils import (
     get_prototype,
     get_stack_frame_variables_internal,
     decompile_function_safe,
+    compact_whitespace,
     get_assembly_lines,
     get_all_xrefs,
     get_all_comments,
@@ -235,7 +236,7 @@ def disasm(
             if len(lines) < max_instructions:
                 line = ida_lines.generate_disasm_line(ea, 0)
                 instruction = ida_lines.tag_remove(line) if line else ""
-                lines.append(f"{ea:x}  {instruction}")
+                lines.append(f"{ea:x}  {compact_whitespace(instruction)}")
                 seen += 1
                 return True
             more = True
@@ -1430,7 +1431,7 @@ def insn_query(
                 ea = int(addr_hex, 16)
                 matches.append({
                     "addr": addr_hex,
-                    "disasm": idc.GetDisasm(ea) if idaapi.is_loaded(ea) else None,
+                    "disasm": compact_whitespace(idc.GetDisasm(ea)) if idaapi.is_loaded(ea) else None,
                     "fn": get_function(ea, raise_error=False),
                 })
 

--- a/src/ida_multi_mcp/ida_mcp/utils.py
+++ b/src/ida_multi_mcp/ida_mcp/utils.py
@@ -932,6 +932,29 @@ def get_stack_frame_variables_internal(
     return members
 
 
+_STRING_OR_SPACES_RE = re.compile(
+    r'"(?:[^"\\]|\\.)*"'
+    r"|'(?:[^'\\]|\\.)*'"
+    r"|[ \t]{2,}"
+)
+
+
+def compact_whitespace(line: str) -> str:
+    """Collapse runs of internal spaces while preserving string literals."""
+    stripped = line.lstrip(" \t")
+    if not stripped:
+        return line
+    lead = line[: len(line) - len(stripped)]
+
+    def _repl(match: re.Match[str]) -> str:
+        text = match.group()
+        if text[0] in ('"', "'"):
+            return text
+        return " "
+
+    return lead + _STRING_OR_SPACES_RE.sub(_repl, stripped)
+
+
 def decompile_checked(addr: int):
     """Decompile a function and raise IDAError on failure (uses cache)"""
     if not ida_hexrays.init_hexrays_plugin():
@@ -979,7 +1002,7 @@ def decompile_function_safe(ea: int) -> Optional[str]:
                             line_ea = int(ds[0], 16)
                         except ValueError:
                             pass
-            text = ida_lines.tag_remove(sl.line)
+            text = compact_whitespace(ida_lines.tag_remove(sl.line))
             if line_ea is not None:
                 lines.append(f"{text} /*{line_ea:#x}*/")
             else:
@@ -1011,7 +1034,7 @@ def get_assembly_lines(ea: int) -> str:
             if idc.get_operand_type(item_ea, n) == idaapi.o_void:
                 break
             ops.append(idc.print_operand(item_ea, n) or "")
-        instruction = f"{mnem} {', '.join(ops)}".rstrip()
+        instruction = compact_whitespace(f"{mnem} {', '.join(ops)}".rstrip())
         lines_str += f"\n{item_ea:x}  {instruction}"
 
     return lines_str

--- a/src/ida_multi_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_multi_mcp/ida_mcp/zeromcp/mcp.py
@@ -533,7 +533,7 @@ class McpServer:
 
             result = tool_response.get("result") if tool_response else None
             return {
-                "content": [{"type": "text", "text": json.dumps(result, indent=2)}],
+                "content": [{"type": "text", "text": json.dumps(result, separators=(",", ":"))}],
                 "structuredContent": result,
                 "isError": False,
             }
@@ -614,7 +614,7 @@ class McpServer:
                         "contents": [{
                             "uri": uri,
                             "mimeType": "application/json",
-                            "text": json.dumps({"error": error.get("message", "Unknown error")}, indent=2),
+                            "text": json.dumps({"error": error.get("message", "Unknown error")}, separators=(",", ":")),
                         }],
                         "isError": True,
                     }
@@ -624,7 +624,7 @@ class McpServer:
                     "contents": [{
                         "uri": uri,
                         "mimeType": "application/json",
-                        "text": json.dumps(result, indent=2),
+                        "text": json.dumps(result, separators=(",", ":")),
                     }]
                 }
 
@@ -637,7 +637,7 @@ class McpServer:
                 "text": json.dumps({
                     "error": f"Resource not found: {uri}",
                     "available_patterns": available,
-                }, indent=2),
+                }, separators=(",", ":")),
             }],
             "isError": True,
         }
@@ -679,7 +679,7 @@ class McpServer:
 
         # Convert non-string results to JSON
         if not isinstance(result, str):
-            result = json.dumps(result, indent=2)
+            result = json.dumps(result, separators=(",", ":"))
         return {
             "messages": [
                 {

--- a/src/ida_multi_mcp/server.py
+++ b/src/ida_multi_mcp/server.py
@@ -110,14 +110,14 @@ class IdaMultiMcpServer:
             return structured
 
         def _json_text(value: Any) -> str:
-            return json.dumps(value, indent=2)
+            return json.dumps(value, separators=(",", ":"))
 
         def _schema_preserving_preview(value: Any, max_chars: int) -> Any:
             """Return a smaller value of the same JSON type (str/list/dict) when huge."""
             if max_chars <= 0:
                 return value
             try:
-                if len(json.dumps(value)) <= max_chars:
+                if len(_json_text(value)) <= max_chars:
                     return value
             except Exception:
                 return value
@@ -130,7 +130,7 @@ class IdaMultiMcpServer:
                 for item in value:
                     out.append(item)
                     try:
-                        if len(json.dumps(out)) > max_chars:
+                        if len(_json_text(out)) > max_chars:
                             out.pop()
                             break
                     except Exception:
@@ -176,7 +176,7 @@ class IdaMultiMcpServer:
             if name == "list_instances":
                 result = management.list_instances()
                 return {
-                    "content": [{"type": "text", "text": json.dumps(result, indent=2)}],
+                    "content": [{"type": "text", "text": _json_text(result)}],
                     "structuredContent": result,
                     "isError": False
                 }
@@ -184,7 +184,7 @@ class IdaMultiMcpServer:
             elif name == "refresh_tools":
                 result = management.refresh_tools()
                 return {
-                    "content": [{"type": "text", "text": json.dumps(result, indent=2)}],
+                    "content": [{"type": "text", "text": _json_text(result)}],
                     "structuredContent": result,
                     "isError": False
                 }
@@ -211,7 +211,7 @@ class IdaMultiMcpServer:
             elif name == "compare_binaries":
                 result = management.compare_binaries(arguments)
                 return {
-                    "content": [{"type": "text", "text": json.dumps(result, indent=2)}],
+                    "content": [{"type": "text", "text": _json_text(result)}],
                     "structuredContent": result,
                     "isError": "error" in result,
                 }
@@ -220,7 +220,7 @@ class IdaMultiMcpServer:
                 cache = get_cache()
                 result = {"entries": cache.list_entries(), **cache.stats()}
                 return {
-                    "content": [{"type": "text", "text": json.dumps(result, indent=2)}],
+                    "content": [{"type": "text", "text": _json_text(result)}],
                     "structuredContent": result,
                     "isError": False,
                 }
@@ -228,7 +228,7 @@ class IdaMultiMcpServer:
             elif name == "decompile_to_file":
                 result = self._handle_decompile_to_file(arguments)
                 return {
-                    "content": [{"type": "text", "text": json.dumps(result, indent=2)}],
+                    "content": [{"type": "text", "text": _json_text(result)}],
                     "structuredContent": result,
                     "isError": "error" in result
                 }
@@ -243,7 +243,7 @@ class IdaMultiMcpServer:
                 if name == "idalib_open" and not is_error:
                     self._refresh_tools()
                 return {
-                    "content": [{"type": "text", "text": json.dumps(result, indent=2)}],
+                    "content": [{"type": "text", "text": _json_text(result)}],
                     "structuredContent": result,
                     "isError": is_error,
                 }
@@ -282,7 +282,7 @@ class IdaMultiMcpServer:
                 # Format response
                 if "error" in ida_response:
                     return {
-                        "content": [{"type": "text", "text": f"Error: {json.dumps(ida_response, indent=2)}"}],
+                        "content": [{"type": "text", "text": f"Error: {_json_text(ida_response)}"}],
                         "isError": True
                     }
 

--- a/src/ida_multi_mcp/vendor/zeromcp/mcp.py
+++ b/src/ida_multi_mcp/vendor/zeromcp/mcp.py
@@ -531,7 +531,7 @@ class McpServer:
             if result is not None and not isinstance(result, dict):
                 structured = {"result": result}
             return {
-                "content": [{"type": "text", "text": json.dumps(result, indent=2)}],
+                "content": [{"type": "text", "text": json.dumps(result, separators=(",", ":"))}],
                 "structuredContent": structured,
                 "isError": False,
             }
@@ -617,7 +617,7 @@ class McpServer:
                         "contents": [{
                             "uri": uri,
                             "mimeType": "application/json",
-                            "text": json.dumps({"error": error.get("message", "Unknown error")}, indent=2),
+                            "text": json.dumps({"error": error.get("message", "Unknown error")}, separators=(",", ":")),
                         }],
                         "isError": True,
                     }
@@ -627,7 +627,7 @@ class McpServer:
                     "contents": [{
                         "uri": uri,
                         "mimeType": "application/json",
-                        "text": json.dumps(result, indent=2),
+                        "text": json.dumps(result, separators=(",", ":")),
                     }]
                 }
 
@@ -640,7 +640,7 @@ class McpServer:
                 "text": json.dumps({
                     "error": f"Resource not found: {uri}",
                     "available_patterns": available,
-                }, indent=2),
+                }, separators=(",", ":")),
             }],
             "isError": True,
         }
@@ -682,7 +682,7 @@ class McpServer:
 
         # Convert non-string results to JSON
         if not isinstance(result, str):
-            result = json.dumps(result, indent=2)
+            result = json.dumps(result, separators=(",", ":"))
         return {
             "messages": [
                 {

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -25,6 +25,11 @@ def mcp():
         return a + b
 
     @server.tool
+    def info() -> dict:
+        """Return structured object data."""
+        return {"status": "ok", "count": 1}
+
+    @server.tool
     def failing():
         """Always fails."""
         raise McpToolError("Something went wrong")
@@ -98,6 +103,12 @@ class TestToolCall:
         result = resp["result"]
         assert result["isError"] is False
         assert "hi" in result["content"][0]["text"]
+
+    def test_structured_content_is_compact_json(self, mcp):
+        resp = _dispatch(mcp, "tools/call", {"name": "info"})
+        result = resp["result"]
+        assert result["isError"] is False
+        assert result["content"][0]["text"] == '{"status":"ok","count":1}'
 
     def test_mcp_tool_error(self, mcp):
         resp = _dispatch(mcp, "tools/call", {"name": "failing"})

--- a/tests/test_server_integration.py
+++ b/tests/test_server_integration.py
@@ -52,6 +52,7 @@ class TestToolsCall:
         structured = result["structuredContent"]
         assert "count" in structured
         assert "instances" in structured
+        assert result["content"][0]["text"] == json.dumps(structured, separators=(",", ":"))
 
     def test_get_cached_output_miss(self, server):
         resp = _call(server, "tools/call",

--- a/tests/test_utils_pure.py
+++ b/tests/test_utils_pure.py
@@ -57,6 +57,7 @@ for _sub in _SUBMODULES:
 # through our real _sync_stub above, and all ida_* modules are MagicMocks.
 # The __init__.py imports of api_* etc. will hit our MagicMock stubs harmlessly.
 from ida_multi_mcp.ida_mcp.utils import (
+    compact_whitespace,
     parse_address,
     normalize_list_input,
     normalize_dict_list,
@@ -93,7 +94,6 @@ class TestParseAddress:
         with pytest.raises(IDAError, match="out of range"):
             parse_address(-1)
 
-
 class TestBssSafeReads:
     def test_read_bytes_bss_safe_zero_fills_unloaded(self):
         load_map = {0x1000: True, 0x1001: False, 0x1002: True, 0x1003: False}
@@ -118,6 +118,17 @@ class TestBssSafeReads:
 
         assert read_int_bss_safe(0x3000, 8) == 0x1122334455667788
         utils.ida_bytes.get_qword.assert_called_once_with(0x3000)
+
+
+class TestCompactWhitespace:
+    def test_collapses_internal_spaces(self):
+        assert compact_whitespace("mov     eax,     ebx") == "mov eax, ebx"
+
+    def test_preserves_string_literals(self):
+        assert compact_whitespace('db "a   b",    0') == 'db "a   b", 0'
+
+    def test_preserves_leading_indent(self):
+        assert compact_whitespace("    if   (x)\t\treturn  1;") == "    if (x) return 1;"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- port upstream PR 341 token optimizations by adding whitespace compaction for decompile and disasm output
- switch zeromcp JSON text serialization to compact separators in both vendored copies
- apply the same compact JSON policy in the multi-instance proxy layer so routed tool output gets the same reduction
- add regression tests for whitespace compaction and compact JSON responses

## Testing
- pytest
