### PR TITLE
Resolve parse_address symbol names

### DIFF
--- a/src/ida_multi_mcp/ida_mcp/api_types.py
+++ b/src/ida_multi_mcp/ida_mcp/api_types.py
@@ -96,21 +96,18 @@ def read_struct(queries: list[StructRead] | StructRead) -> list[dict]:
                 )
                 continue
 
-            # Try to parse as address, then try name resolution
             try:
                 addr = parse_address(addr_str)
             except Exception:
-                addr = idaapi.get_name_ea(idaapi.BADADDR, addr_str)
-                if addr == idaapi.BADADDR:
-                    results.append(
-                        {
-                            "addr": addr_str,
-                            "struct": struct_name,
-                            "members": None,
-                            "error": f"Failed to resolve address: {addr_str}",
-                        }
-                    )
-                    continue
+                results.append(
+                    {
+                        "addr": addr_str,
+                        "struct": struct_name,
+                        "members": None,
+                        "error": f"Failed to resolve address: {addr_str}",
+                    }
+                )
+                continue
 
             # Auto-detect struct type from address if not provided
             if not struct_name:

--- a/src/ida_multi_mcp/ida_mcp/utils.py
+++ b/src/ida_multi_mcp/ida_mcp/utils.py
@@ -447,13 +447,18 @@ def parse_address(addr: str | int) -> int:
     if isinstance(addr, int):
         result = addr
     else:
+        text = addr.strip()
         try:
-            result = int(addr, 0)
+            result = int(text, 0)
         except ValueError:
-            for ch in addr:
-                if ch not in "0123456789abcdefABCDEF":
-                    raise IDAError(f"Failed to parse address: {addr}")
-            raise IDAError(f"Failed to parse address (missing 0x prefix): {addr}")
+            ea = idaapi.get_name_ea(idaapi.BADADDR, text)
+            if ea != idaapi.BADADDR:
+                result = ea
+            else:
+                for ch in text:
+                    if ch not in "0123456789abcdefABCDEF":
+                        raise IDAError(f"Not found: {addr!r}")
+                raise IDAError(f"Failed to parse address (missing 0x prefix): {addr}")
 
     # Security: validate address range to prevent integer overflow in IDA C APIs
     if result < 0 or result > _MAX_ADDRESS:

--- a/tests/test_utils_pure.py
+++ b/tests/test_utils_pure.py
@@ -69,6 +69,9 @@ from ida_multi_mcp.ida_mcp.utils import (
 )
 import ida_multi_mcp.ida_mcp.utils as utils
 
+utils.idaapi.BADADDR = -1
+utils.idaapi.get_name_ea.side_effect = lambda _badaddr, _name: -1
+
 
 # ---------------------------------------------------------------------------
 # parse_address
@@ -86,8 +89,18 @@ class TestParseAddress:
     def test_int_passthrough(self):
         assert parse_address(42) == 42
 
+    def test_symbol_name_resolution(self):
+        utils.idaapi.get_name_ea.side_effect = None
+        utils.idaapi.get_name_ea.return_value = 0x401000
+
+        assert parse_address("main") == 0x401000
+        utils.idaapi.get_name_ea.assert_called_with(-1, "main")
+
+        utils.idaapi.get_name_ea.reset_mock()
+        utils.idaapi.get_name_ea.side_effect = lambda _badaddr, _name: -1
+
     def test_invalid_raises(self):
-        with pytest.raises(IDAError):
+        with pytest.raises(IDAError, match="Not found"):
             parse_address("not_an_address")
 
     def test_out_of_range(self):


### PR DESCRIPTION
## Summary
- resolve symbol names in parse_address() before failing numeric parsing
- route read_struct() through parse_address() instead of duplicating name lookup
- add unit coverage for symbol-name resolution and invalid-name errors

## Verification
- pytest
- live IDA check with symbol input `start` for disasm/decompile/get_bytes/xrefs_to
