### PR TITLE
Preserve valid Codex TOML on install

### DIFF
--- a/src/ida_multi_mcp/__main__.py
+++ b/src/ida_multi_mcp/__main__.py
@@ -23,6 +23,7 @@ SERVER_NAME = "ida-multi-mcp"
 # ---------------------------------------------------------------------------
 
 _IDA_VERSION_RE = re.compile(r"(\d+\.\d+)")
+_TOML_BARE_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def _detect_ida_dir() -> str | None:
@@ -823,30 +824,50 @@ def install_mcp_servers(uninstall=False, quiet=False):
         print_mcp_config()
 
 
-def _write_toml_fallback(f, config, prefix=""):
+def _toml_quote_key(key: str) -> str:
+    """Quote TOML keys when they are not valid bare keys."""
+    if _TOML_BARE_KEY_RE.fullmatch(key):
+        return key
+    return json.dumps(key, ensure_ascii=False)
+
+
+def _toml_format_value(value):
+    """Serialize a Python value as TOML."""
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, list):
+        return "[" + ", ".join(_toml_format_value(item) for item in value) + "]"
+    if isinstance(value, (int, float)):
+        return str(value)
+    raise TypeError(f"Unsupported TOML value type: {type(value).__name__}")
+
+
+def _write_toml_fallback(f, config, prefix=()):
     """Minimal TOML writer fallback when tomli_w is not available."""
+    scalar_items = []
+    table_items = []
     for key, value in config.items():
-        full_key = f"{prefix}.{key}" if prefix else key
         if isinstance(value, dict):
-            f.write(f"[{full_key}]\n")
-            for k, v in value.items():
-                if isinstance(v, dict):
-                    _write_toml_fallback(f, {k: v}, full_key)
-                elif isinstance(v, str):
-                    f.write(f'{k} = "{v}"\n')
-                elif isinstance(v, list):
-                    items = ", ".join(f'"{i}"' if isinstance(i, str) else str(i) for i in v)
-                    f.write(f"{k} = [{items}]\n")
-                elif isinstance(v, bool):
-                    f.write(f"{k} = {'true' if v else 'false'}\n")
-                else:
-                    f.write(f"{k} = {v}\n")
-        elif isinstance(value, str):
-            f.write(f'{key} = "{value}"\n')
-        elif isinstance(value, bool):
-            f.write(f"{key} = {'true' if value else 'false'}\n")
+            table_items.append((key, value))
         else:
-            f.write(f"{key} = {value}\n")
+            scalar_items.append((key, value))
+
+    if prefix:
+        table_name = ".".join(_toml_quote_key(part) for part in prefix)
+        f.write(f"[{table_name}]\n")
+
+    for key, value in scalar_items:
+        f.write(f"{_toml_quote_key(key)} = {_toml_format_value(value)}\n")
+
+    if prefix and scalar_items and table_items:
+        f.write("\n")
+
+    for index, (key, value) in enumerate(table_items):
+        if prefix or index > 0 or scalar_items:
+            f.write("\n")
+        _write_toml_fallback(f, value, (*prefix, key))
 
 
 def cmd_list(args):

--- a/tests/test_install_codex_toml.py
+++ b/tests/test_install_codex_toml.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+sys.path.insert(0, str(SRC_ROOT))
+
+
+class TestInstallMcpServersCodexToml(unittest.TestCase):
+    def test_windows_codex_config_remains_valid_toml(self):
+        from ida_multi_mcp.__main__ import SERVER_NAME, install_mcp_servers
+
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            codex_dir = home / ".codex"
+            codex_dir.mkdir(parents=True, exist_ok=True)
+            config_path = codex_dir / "config.toml"
+            config_path.write_text(
+                r"""
+[projects.'\\?\C:\Git\MeroZemory\tidy-up']
+trust_level = "trusted"
+
+[model_reasoning_effort]
+"gpt-5.2-codex" = "gpt-5.3-codex"
+"gpt-5.2" = "gpt-5.3-codex"
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            old_env = dict(os.environ)
+            try:
+                os.environ["HOME"] = str(home)
+                os.environ["USERPROFILE"] = str(home)
+                os.environ["APPDATA"] = str(home / "AppData" / "Roaming")
+
+                with (
+                    mock.patch("ida_multi_mcp.__main__.sys.platform", "win32"),
+                    mock.patch("ida_multi_mcp.__main__.os.path.expanduser", return_value=str(home)),
+                    mock.patch(
+                        "ida_multi_mcp.__main__.get_python_executable",
+                        return_value=r"C:\Users\MeroZemory\AppData\Local\Programs\Python\Python311\python.exe",
+                    ),
+                ):
+                    install_mcp_servers(quiet=True)
+
+                raw = config_path.read_text(encoding="utf-8")
+                parsed = tomllib.loads(raw)
+
+                self.assertEqual(
+                    parsed["projects"][r"\\?\C:\Git\MeroZemory\tidy-up"]["trust_level"],
+                    "trusted",
+                )
+                self.assertEqual(
+                    parsed["mcp_servers"][SERVER_NAME]["command"],
+                    r"C:\Users\MeroZemory\AppData\Local\Programs\Python\Python311\python.exe",
+                )
+                self.assertEqual(
+                    parsed["mcp_servers"][SERVER_NAME]["args"],
+                    ["-m", "ida_multi_mcp"],
+                )
+            finally:
+                os.environ.clear()
+                os.environ.update(old_env)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix the fallback TOML writer so Windows-style keys and paths are quoted safely
- preserve existing Codex project trust entries and Python command paths during install
- add a Windows Codex config regression test

## Verification
- pytest
- reinstall locally and confirm ~/.codex/config.toml remains parseable after --install
