### PR TITLE
Detect headless IDA runtime and extend refresh_caches timeout

### DIFF
--- a/src/ida_multi_mcp/ida_mcp/api_core.py
+++ b/src/ida_multi_mcp/ida_mcp/api_core.py
@@ -16,7 +16,7 @@ import ida_segment
 import idc
 
 from .rpc import tool
-from .sync import idasync
+from .sync import idasync, tool_timeout
 
 # Cached strings list: [(ea, text), ...]
 _strings_cache: list[tuple[int, str]] | None = None
@@ -91,6 +91,7 @@ def init_caches():
 
 @tool
 @idasync
+@tool_timeout(120.0)
 def refresh_caches() -> dict:
     """Force-refresh all caches (strings, functions, globals)."""
     invalidate_strings_cache()

--- a/src/ida_multi_mcp/plugin/ida_multi_mcp.py
+++ b/src/ida_multi_mcp/plugin/ida_multi_mcp.py
@@ -13,6 +13,7 @@ import threading
 from pathlib import Path
 
 import idaapi
+import ida_kernwin
 
 # Import registration functions (add parent to path for ida_multi_mcp imports)
 _pkg_dir = str(Path(__file__).parent.parent.parent)
@@ -25,6 +26,17 @@ from ida_multi_mcp.plugin.registration import (
     update_heartbeat,
     get_binary_metadata,
 )
+
+
+def _is_gui_runtime() -> bool:
+    """Return True when running inside the interactive IDA GUI."""
+    checker = getattr(ida_kernwin, "is_idaq", None)
+    if checker is None:
+        return True
+    try:
+        return bool(checker())
+    except Exception:
+        return True
 
 
 def _load_ida_mcp():
@@ -68,7 +80,10 @@ class IdaMultiMcpPlugin(idaapi.plugin_t):
 
     def init(self):
         """Plugin initialization — install hooks, start if DB already open."""
-        print("[ida-multi-mcp] Plugin loaded (PLUGIN_FIX)")
+        if _is_gui_runtime():
+            print("[ida-multi-mcp] Plugin loaded (PLUGIN_FIX)")
+        else:
+            print("[ida-multi-mcp] Plugin loaded (headless mode, server managed externally)")
 
         # Install hooks for database lifecycle events
         self.idb_hooks = IdbHooks(self)
@@ -78,7 +93,7 @@ class IdaMultiMcpPlugin(idaapi.plugin_t):
         self.hooks_installed = True
 
         # If database is already open, start immediately
-        if idaapi.get_input_file_path():
+        if _is_gui_runtime() and idaapi.get_input_file_path():
             self.start_server()
 
         return idaapi.PLUGIN_KEEP
@@ -240,7 +255,8 @@ class UiHooks(idaapi.UI_Hooks):
     def database_inited(self, is_new_database, idc_script):
         """Called when a new database is initialized — start server."""
         print("[ida-multi-mcp] Database initialized")
-        self.plugin.start_server()
+        if _is_gui_runtime():
+            self.plugin.start_server()
         return 0
 
 

--- a/tests/test_lazy_cache_init.py
+++ b/tests/test_lazy_cache_init.py
@@ -71,6 +71,7 @@ def ida_mcp_modules(monkeypatch):
 
     sync.IDAError = IDAError
     sync.idasync = lambda func: func
+    sync.tool_timeout = lambda seconds: (lambda func: setattr(func, "__ida_mcp_timeout_sec__", seconds) or func)
     monkeypatch.setitem(sys.modules, "ida_multi_mcp.ida_mcp.sync", sync)
 
     utils = types.ModuleType("ida_multi_mcp.ida_mcp.utils")
@@ -166,6 +167,11 @@ class TestApiCoreLazyCaches:
         assert result["functions"] == 1
         assert result["globals"] == 1
         assert result["time_ms"] >= 0
+
+    def test_refresh_caches_has_extended_timeout(self, ida_mcp_modules):
+        api_core, _ = ida_mcp_modules
+
+        assert getattr(api_core.refresh_caches, "__ida_mcp_timeout_sec__", None) == 120.0
 
 
 class TestApiModifyCacheInvalidation:

--- a/tests/test_plugin_headless_detection.py
+++ b/tests/test_plugin_headless_detection.py
@@ -1,0 +1,98 @@
+"""Tests for GUI vs headless detection in the IDA plugin wrapper."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+
+def _load_plugin_module(monkeypatch, *, is_idaq: bool, input_path: str = "sample.bin"):
+    for name in list(sys.modules):
+        if name == "ida_multi_mcp.plugin.ida_multi_mcp":
+            sys.modules.pop(name, None)
+
+    idaapi = types.ModuleType("idaapi")
+    idaapi.plugin_t = type("plugin_t", (), {})
+    idaapi.IDB_Hooks = type("IDB_Hooks", (), {"hook": lambda self: None, "unhook": lambda self: None})
+    idaapi.UI_Hooks = type("UI_Hooks", (), {"hook": lambda self: None, "unhook": lambda self: None})
+    idaapi.PLUGIN_FIX = 1
+    idaapi.PLUGIN_KEEP = 2
+    idaapi.get_input_file_path = lambda: input_path
+    monkeypatch.setitem(sys.modules, "idaapi", idaapi)
+
+    ida_kernwin = types.ModuleType("ida_kernwin")
+    ida_kernwin.is_idaq = lambda: is_idaq
+    monkeypatch.setitem(sys.modules, "ida_kernwin", ida_kernwin)
+
+    registration = types.ModuleType("ida_multi_mcp.plugin.registration")
+    registration.register_instance = MagicMock(return_value="abcd")
+    registration.unregister_instance = MagicMock()
+    registration.update_heartbeat = MagicMock()
+    registration.get_binary_metadata = MagicMock(
+        return_value={
+            "idb_path": "sample.i64",
+            "binary_path": "sample.bin",
+            "binary_name": "sample.bin",
+            "arch": "metapc-64",
+        }
+    )
+    monkeypatch.setitem(sys.modules, "ida_multi_mcp.plugin.registration", registration)
+
+    module = importlib.import_module("ida_multi_mcp.plugin.ida_multi_mcp")
+    importlib.reload(module)
+    return module
+
+
+def test_plugin_init_autostarts_only_in_gui(monkeypatch):
+    module = _load_plugin_module(monkeypatch, is_idaq=True)
+    plugin = module.IdaMultiMcpPlugin()
+    plugin.start_server = MagicMock()
+
+    rc = plugin.init()
+
+    assert rc == module.idaapi.PLUGIN_KEEP
+    plugin.start_server.assert_called_once()
+
+
+def test_plugin_init_skips_autostart_in_headless(monkeypatch):
+    module = _load_plugin_module(monkeypatch, is_idaq=False)
+    plugin = module.IdaMultiMcpPlugin()
+    plugin.start_server = MagicMock()
+
+    rc = plugin.init()
+
+    assert rc == module.idaapi.PLUGIN_KEEP
+    plugin.start_server.assert_not_called()
+
+
+def test_database_inited_starts_only_in_gui(monkeypatch):
+    module = _load_plugin_module(monkeypatch, is_idaq=True)
+    plugin = module.IdaMultiMcpPlugin()
+    plugin.start_server = MagicMock()
+
+    hooks = module.UiHooks(plugin)
+    rc = hooks.database_inited(False, "")
+
+    assert rc == 0
+    plugin.start_server.assert_called_once()
+
+
+def test_database_inited_skips_in_headless(monkeypatch):
+    module = _load_plugin_module(monkeypatch, is_idaq=False)
+    plugin = module.IdaMultiMcpPlugin()
+    plugin.start_server = MagicMock()
+
+    hooks = module.UiHooks(plugin)
+    rc = hooks.database_inited(False, "")
+
+    assert rc == 0
+    plugin.start_server.assert_not_called()


### PR DESCRIPTION
## Summary
- detect GUI vs headless runtime via ida_kernwin.is_idaq() and skip plugin autostart in headless mode
- extend refresh_caches tool timeout so large IDBs do not fail with IDASyncError
- add regression tests for headless detection and refresh timeout metadata

## Verification
- pytest tests/test_lazy_cache_init.py tests/test_server_integration.py tests/test_plugin_headless_detection.py -q
- live IDA check: refresh_caches(instance_id="livu") succeeded on Client_dump_SCY.exe and returned cache counts
- install/restart check: GUI instance re-registered after reinstall/restart