### PR TITLE
Fix false "binary path changed" error when opening IDB files

### DIFF
--- a/src/ida_multi_mcp/idalib_manager.py
+++ b/src/ida_multi_mcp/idalib_manager.py
@@ -15,7 +15,7 @@ import sys
 import time
 from typing import TYPE_CHECKING
 
-from .health import is_process_alive, ping_instance
+from .health import is_process_alive, ping_instance, query_binary_metadata
 
 if TYPE_CHECKING:
     from .registry import InstanceRegistry
@@ -179,8 +179,12 @@ class IdalibManager:
                 )
             }
 
-        # Register in the shared registry.
-        binary_name = os.path.basename(resolved_path)
+        # Ask the worker for its canonical module name so the registry matches
+        # what the metadata resource reports. Falls back to basename when the
+        # input was an IDB (e.g. foo.exe.i64 → module is "foo.exe") or query fails.
+        metadata = query_binary_metadata(host, port, timeout=5.0)
+        module_name = (metadata or {}).get("module") if metadata else None
+        binary_name = module_name or os.path.basename(resolved_path)
         instance_id = self.registry.register(
             pid=proc.pid,
             port=port,

--- a/src/ida_multi_mcp/router.py
+++ b/src/ida_multi_mcp/router.py
@@ -118,6 +118,9 @@ class InstanceRouter:
         if instance_id in self._binary_path_cache:
             cached_name, cached_time = self._binary_path_cache[instance_id]
             if now - cached_time < self._cache_timeout:
+                # Benefit of doubt when the last query couldn't resolve a name.
+                if cached_name is None:
+                    return True
                 return cached_name == _normalize_binary_name(instance_info.get("binary_name"))
 
         # Query fresh binary metadata

--- a/tests/test_idalib_manager.py
+++ b/tests/test_idalib_manager.py
@@ -80,6 +80,30 @@ class TestIdalibManagerSpawn:
         assert info is not None
         assert info["type"] == "idalib"
 
+    @patch("ida_multi_mcp.idalib_manager.query_binary_metadata",
+           return_value={"module": "test.exe", "path": "/tmp/test.exe.i64"})
+    @patch("ida_multi_mcp.idalib_manager.subprocess.Popen")
+    @patch("ida_multi_mcp.idalib_manager.ping_instance", return_value=True)
+    def test_spawn_on_idb_uses_canonical_module_name(
+        self, mock_ping, mock_popen, mock_meta, tmp_path, tmp_registry,
+    ):
+        """Opening an IDB (.i64) must register the original binary name so the
+        router's metadata-resource check doesn't flag the instance as stale."""
+        idb = tmp_path / "test.exe.i64"
+        idb.write_bytes(b"\x00" * 16)
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 77777
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
+        mgr = IdalibManager(tmp_registry)
+        result = mgr.spawn_session(str(idb))
+
+        assert "error" not in result
+        info = tmp_registry.get_instance(result["instance_id"])
+        assert info["binary_name"] == "test.exe"
+
     @patch("ida_multi_mcp.idalib_manager.subprocess.Popen")
     @patch("ida_multi_mcp.idalib_manager.ping_instance", return_value=False)
     def test_spawn_timeout(self, mock_ping, mock_popen, tmp_path, tmp_registry):

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -118,6 +118,17 @@ class TestVerificationCache:
             router._verify_binary_path(iid, info)
             assert mock_query.call_count == 2  # cache expired
 
+    def test_cached_none_preserves_benefit_of_doubt(self, router_env):
+        """A cached None (query failed) must not turn into a stale-instance error."""
+        _, router, iid = router_env
+        info = {"binary_name": "test.exe", "host": "127.0.0.1", "port": 7000}
+        with patch("ida_multi_mcp.router.query_binary_metadata",
+                   return_value=None):
+            first = router._verify_binary_path(iid, info)
+            second = router._verify_binary_path(iid, info)
+        assert first is True
+        assert second is True
+
 
 class TestSendRequest:
     def test_strips_instance_id(self, router_env):


### PR DESCRIPTION
## Bug

Calling any tool on an instance opened via `idalib_open("foo.exe.i64")` returns: Instance 'xxxx' binary path changed. Instance may be stale. Two root causes:

1. **IDB suffix mismatch** — `IdalibManager` registers `binary_name="foo.exe.i64"` (basename of input path), but the `ida://idb/metadata` resource reports `module="foo.exe"` (from `ida_nalt.get_root_filename()`). The router compares the two and always sees a mismatch.

2. **Cached `None` defeats benefit-of-doubt** — when `query_binary_metadata` times out (e.g. IDA busy decompiling), the first call correctly returns `True`, but `None` gets cached and the next call within 5s evaluates `None == "foo.exe"` → `False`.

## Fix
1. After the idalib worker is ready, query its metadata resource and use the returned `module` as `binary_name`. Falls back to basename if the query fails.
2. In `_verify_binary_path`, treat a cached `None` the same as a fresh `None`: return `True`.


Tested on Windows machine