### PR TITLE
Performance & functional improvements from full-project audit

### DIFF
--- a/src/ida_multi_mcp/__main__.py
+++ b/src/ida_multi_mcp/__main__.py
@@ -677,7 +677,14 @@ def install_mcp_servers(uninstall=False, quiet=False):
         is_toml = config_file.endswith(".toml")
 
         if name == "Factory Droid" and not uninstall:
-            os.makedirs(config_dir, exist_ok=True)
+            try:
+                os.makedirs(config_dir, exist_ok=True)
+            except OSError as exc:
+                if not quiet:
+                    print(
+                        f"Skipping {name}\n  Config: {config_path} (cannot create dir: {exc.__class__.__name__})"
+                    )
+                continue
 
         if not os.path.exists(config_dir):
             action = "uninstall" if uninstall else "installation"
@@ -696,64 +703,93 @@ def install_mcp_servers(uninstall=False, quiet=False):
         if not os.path.exists(config_path):
             config = {}
         else:
-            with open(
-                config_path,
-                "rb" if is_toml else "r",
-                encoding=None if is_toml else "utf-8",
-            ) as f:
-                if is_toml:
-                    data = f.read()
-                    if len(data) == 0:
-                        config = {}
-                    else:
-                        try:
-                            config = tomllib.loads(data.decode("utf-8"))
-                        except Exception:
-                            if not quiet:
-                                print(
-                                    f"Skipping {name}\n  Config: {config_path} (invalid TOML)"
-                                )
-                            continue
-                else:
-                    data = f.read().strip()
-                    if len(data) == 0:
-                        config = {}
-                    else:
-                        try:
-                            config = json.loads(data)
-                        except json.decoder.JSONDecodeError:
-                            if not quiet:
-                                print(
-                                    f"Skipping {name}\n  Config: {config_path} (invalid JSON)"
-                                )
-                            continue
+            # The path may be unreadable (permissions), a directory, or held
+            # open by another process — skip this client rather than aborting
+            # the whole install.
+            try:
+                with open(
+                    config_path,
+                    "rb" if is_toml else "r",
+                    encoding=None if is_toml else "utf-8",
+                ) as f:
+                    raw = f.read()
+            except OSError as exc:
+                if not quiet:
+                    print(
+                        f"Skipping {name}\n  Config: {config_path} (cannot read: {exc.__class__.__name__})"
+                    )
+                continue
 
-        # Handle TOML vs JSON structure
+            if is_toml:
+                if len(raw) == 0:
+                    config = {}
+                else:
+                    try:
+                        config = tomllib.loads(raw.decode("utf-8"))
+                    except Exception:
+                        if not quiet:
+                            print(
+                                f"Skipping {name}\n  Config: {config_path} (invalid TOML)"
+                            )
+                        continue
+            else:
+                data = raw.strip()
+                if len(data) == 0:
+                    config = {}
+                else:
+                    try:
+                        config = json.loads(data)
+                    except json.decoder.JSONDecodeError:
+                        if not quiet:
+                            print(
+                                f"Skipping {name}\n  Config: {config_path} (invalid JSON)"
+                            )
+                        continue
+
+        # A config that parses to a non-dict (e.g. a top-level JSON array)
+        # cannot hold a server map — skip rather than crashing on indexing.
+        if not isinstance(config, dict):
+            if not quiet:
+                print(
+                    f"Skipping {name}\n  Config: {config_path} (unexpected structure: root is {type(config).__name__})"
+                )
+            continue
+
+        # Handle TOML vs JSON structure. setdefault creates the map when
+        # missing; the isinstance check below catches a key that exists but
+        # holds an unexpected (non-dict) value, so we never index into it.
         if is_toml:
-            if "mcp_servers" not in config:
-                config["mcp_servers"] = {}
-            mcp_servers = config["mcp_servers"]
+            mcp_servers = config.setdefault("mcp_servers", {})
         else:
             # Check if this client uses a special JSON structure
             if name in special_json_structures:
                 top_key, nested_key = special_json_structures[name]
                 if top_key is None:
                     # servers map at the top level under nested_key
-                    if nested_key not in config:
-                        config[nested_key] = {}
-                    mcp_servers = config[nested_key]
+                    mcp_servers = config.setdefault(nested_key, {})
                 else:
                     # nested structure (e.g., VS Code uses mcp.servers)
-                    if top_key not in config:
-                        config[top_key] = {}
-                    if nested_key not in config[top_key]:
-                        config[top_key][nested_key] = {}
-                    mcp_servers = config[top_key][nested_key]
+                    parent = config.setdefault(top_key, {})
+                    if not isinstance(parent, dict):
+                        if not quiet:
+                            print(
+                                f"Skipping {name}\n  Config: {config_path} "
+                                f"(unexpected structure: '{top_key}' is {type(parent).__name__})"
+                            )
+                        continue
+                    mcp_servers = parent.setdefault(nested_key, {})
             else:
                 # Default: mcpServers at top level
-                if "mcpServers" not in config:
-                    config["mcpServers"] = {}
-                mcp_servers = config["mcpServers"]
+                mcp_servers = config.setdefault("mcpServers", {})
+
+        # The server map must be a dict to hold our entry.
+        if not isinstance(mcp_servers, dict):
+            if not quiet:
+                print(
+                    f"Skipping {name}\n  Config: {config_path} "
+                    f"(unexpected structure: server map is {type(mcp_servers).__name__})"
+                )
+            continue
 
         # Migrate old "ida-pro-mcp" entry to "ida-multi-mcp"
         migrated = False
@@ -794,9 +830,17 @@ def install_mcp_servers(uninstall=False, quiet=False):
 
         # Atomic write: temp file + replace (with Windows-friendly fallback)
         suffix = ".toml" if is_toml else ".json"
-        fd, temp_path = tempfile.mkstemp(
-            dir=config_dir, prefix=".tmp_", suffix=suffix, text=True
-        )
+        try:
+            fd, temp_path = tempfile.mkstemp(
+                dir=config_dir, prefix=".tmp_", suffix=suffix, text=True
+            )
+        except OSError as exc:
+            if not quiet:
+                print(
+                    f"Skipping {name}\n  Config: {config_path} (cannot create temp file: {exc.__class__.__name__})"
+                )
+            continue
+
         try:
             with os.fdopen(
                 fd, "wb" if is_toml else "w", encoding=None if is_toml else "utf-8"
@@ -815,6 +859,10 @@ def install_mcp_servers(uninstall=False, quiet=False):
                     json.dump(config, f, indent=2)
 
             if not _replace_or_overwrite_file(temp_path, config_path):
+                try:
+                    os.unlink(temp_path)  # don't leave a .tmp_ orphan behind
+                except OSError:
+                    pass
                 if not quiet:
                     action = "uninstall" if uninstall else "installation"
                     print(
@@ -822,12 +870,17 @@ def install_mcp_servers(uninstall=False, quiet=False):
                         f"  Config: {config_path} (permission denied; close the app using it and retry)"
                     )
                 continue
-        except Exception:
+        except Exception as exc:
+            # Don't let one client's write failure abort the rest of the run.
             try:
                 os.unlink(temp_path)
-            except Exception:
+            except OSError:
                 pass
-            raise
+            if not quiet:
+                print(
+                    f"Skipping {name}\n  Config: {config_path} (write failed: {exc.__class__.__name__})"
+                )
+            continue
 
         if not quiet:
             action = "Uninstalled" if uninstall else "Installed"

--- a/src/ida_multi_mcp/__main__.py
+++ b/src/ida_multi_mcp/__main__.py
@@ -75,7 +75,12 @@ def _detect_ida_dir() -> str | None:
     seen: set[str] = set()
     for root in scan_roots:
         try:
-            for entry in root.iterdir():
+            entries = list(root.iterdir())
+        except OSError:
+            # Unreadable root (permissions, missing, etc.) — skip it.
+            continue
+        for entry in entries:
+            try:
                 if not entry.is_dir():
                     continue
                 if "ida" not in entry.name.lower():
@@ -99,8 +104,10 @@ def _detect_ida_dir() -> str | None:
                 m = _IDA_VERSION_RE.search(entry.name)
                 ver = tuple(int(x) for x in m.group(1).split(".")) if m else (0, 0)
                 candidates.append((ver, resolved))
-        except PermissionError:
-            continue
+            except OSError:
+                # A single problematic entry (junction loop, device, ACL)
+                # must not abort the scan of the remaining entries.
+                continue
 
     if not candidates:
         return None
@@ -238,9 +245,9 @@ def install_mcp_servers(uninstall=False, quiet=False):
     # Map client names to their JSON key paths for clients that don't use "mcpServers"
     # Format: client_name -> (top_level_key, nested_key)
     # None means use default "mcpServers" at top level
+    # top_key None means the servers map lives at the top level under nested_key.
     special_json_structures = {
         "VS Code": ("mcp", "servers"),
-        "Visual Studio 2022": (None, "servers"),  # servers at top level
     }
 
     if sys.platform == "win32":
@@ -731,7 +738,7 @@ def install_mcp_servers(uninstall=False, quiet=False):
             if name in special_json_structures:
                 top_key, nested_key = special_json_structures[name]
                 if top_key is None:
-                    # servers at top level (e.g., Visual Studio 2022)
+                    # servers map at the top level under nested_key
                     if nested_key not in config:
                         config[nested_key] = {}
                     mcp_servers = config[nested_key]
@@ -749,16 +756,19 @@ def install_mcp_servers(uninstall=False, quiet=False):
                 mcp_servers = config["mcpServers"]
 
         # Migrate old "ida-pro-mcp" entry to "ida-multi-mcp"
+        migrated = False
         old_name = "ida-pro-mcp"
         if old_name in mcp_servers:
             mcp_servers[SERVER_NAME] = mcp_servers[old_name]
             del mcp_servers[old_name]
+            migrated = True
 
         # Also migrate the fully-qualified old name
         old_name_full = "github.com/mrexodia/ida-pro-mcp"
         if old_name_full in mcp_servers:
             mcp_servers[SERVER_NAME] = mcp_servers[old_name_full]
             del mcp_servers[old_name_full]
+            migrated = True
 
         if uninstall:
             if SERVER_NAME not in mcp_servers:
@@ -769,9 +779,18 @@ def install_mcp_servers(uninstall=False, quiet=False):
                 continue
             del mcp_servers[SERVER_NAME]
         else:
-            mcp_servers[SERVER_NAME] = generate_mcp_config(
-                include_type=(name == "Factory Droid")
-            )
+            new_entry = generate_mcp_config(include_type=(name == "Factory Droid"))
+            existing = mcp_servers.get(SERVER_NAME)
+            # Skip an untouched, already-correct entry to avoid rewriting the
+            # user's config file. A migration above always forces a write.
+            if not migrated and existing == new_entry:
+                if not quiet:
+                    print(f"Skipping {name}\n  Config: {config_path} (already up to date)")
+                continue
+            # Don't silently clobber a customized entry — say what is happening.
+            if existing is not None and existing != new_entry and not quiet:
+                print(f"Replacing existing '{SERVER_NAME}' entry in {name}\n  Config: {config_path}")
+            mcp_servers[SERVER_NAME] = new_entry
 
         # Atomic write: temp file + replace (with Windows-friendly fallback)
         suffix = ".toml" if is_toml else ".json"

--- a/src/ida_multi_mcp/filelock.py
+++ b/src/ida_multi_mcp/filelock.py
@@ -1,16 +1,36 @@
 """Cross-platform file locking for ida-multi-mcp.
 
-Uses fcntl.flock on Unix and msvcrt.locking on Windows.
+Uses fcntl.flock on Unix and msvcrt.locking on Windows for cross-process
+exclusion, plus a per-path in-process lock so threads of the same process
+serialize cheaply instead of spinning on the OS lock.
 """
 
 import os
 import sys
+import threading
 import time
 
 
 class FileLockTimeout(Exception):
     """Raised when file lock acquisition times out."""
     pass
+
+
+# Per-path in-process locks. The OS file lock serializes across processes;
+# this serializes threads within one process without busy-waiting on the
+# file lock (and avoids a same-process thread spinning until timeout).
+_PATH_LOCKS_GUARD = threading.Lock()
+_PATH_LOCKS: dict[str, threading.Lock] = {}
+
+
+def _get_path_lock(lock_path: str) -> threading.Lock:
+    key = os.path.abspath(lock_path)
+    with _PATH_LOCKS_GUARD:
+        lock = _PATH_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _PATH_LOCKS[key] = lock
+        return lock
 
 
 class FileLock:
@@ -30,29 +50,49 @@ class FileLock:
         self.lock_path = lock_path
         self.timeout = timeout
         self._fd: int | None = None
+        self._thread_lock = _get_path_lock(lock_path)
+        self._thread_locked = False
 
     def acquire(self) -> None:
-        """Acquire the file lock."""
-        os.makedirs(os.path.dirname(self.lock_path) or ".", exist_ok=True)
-        self._fd = os.open(self.lock_path, os.O_CREAT | os.O_RDWR)
+        """Acquire the lock (in-process first, then cross-process)."""
+        # Serialize same-process threads up front so they don't spin on the
+        # OS file lock. A nested acquire on the same path fails fast here
+        # rather than self-deadlocking on the file lock.
+        if not self._thread_lock.acquire(timeout=self.timeout):
+            raise FileLockTimeout(
+                f"Could not acquire in-process lock on {self.lock_path} "
+                f"within {self.timeout}s"
+            )
+        self._thread_locked = True
 
-        if sys.platform == "win32":
-            self._acquire_windows()
-        else:
-            self._acquire_unix()
+        try:
+            os.makedirs(os.path.dirname(self.lock_path) or ".", exist_ok=True)
+            self._fd = os.open(self.lock_path, os.O_CREAT | os.O_RDWR)
+
+            if sys.platform == "win32":
+                self._acquire_windows()
+            else:
+                self._acquire_unix()
+        except BaseException:
+            # Release the in-process lock if the OS lock could not be taken.
+            self._thread_lock.release()
+            self._thread_locked = False
+            raise
 
     def release(self) -> None:
-        """Release the file lock."""
-        if self._fd is None:
-            return
-
-        if sys.platform == "win32":
-            self._release_windows()
-        else:
-            self._release_unix()
-
-        os.close(self._fd)
-        self._fd = None
+        """Release the lock (cross-process first, then in-process)."""
+        try:
+            if self._fd is not None:
+                if sys.platform == "win32":
+                    self._release_windows()
+                else:
+                    self._release_unix()
+                os.close(self._fd)
+                self._fd = None
+        finally:
+            if self._thread_locked:
+                self._thread_lock.release()
+                self._thread_locked = False
 
     def _acquire_unix(self) -> None:
         import fcntl

--- a/src/ida_multi_mcp/health.py
+++ b/src/ida_multi_mcp/health.py
@@ -63,6 +63,7 @@ def ping_instance(host: str, port: int, timeout: float = 15.0) -> bool:
     # Security: only allow localhost connections (prevent SSRF)
     if host not in _ALLOWED_HOSTS:
         return False
+    conn = None
     try:
         conn = http.client.HTTPConnection(host, port, timeout=timeout)
         request = json.dumps({
@@ -72,10 +73,12 @@ def ping_instance(host: str, port: int, timeout: float = 15.0) -> bool:
         })
         conn.request("POST", "/mcp", request, {"Content-Type": "application/json"})
         response = conn.getresponse()
-        conn.close()
         return response.status == 200
     except Exception:
         return False
+    finally:
+        if conn is not None:
+            conn.close()  # always release the socket, even on error
 
 
 def check_instance_health(instance: dict) -> bool:
@@ -153,6 +156,7 @@ def query_binary_metadata(host: str, port: int, timeout: float = 5.0) -> dict | 
     # Security: only allow localhost connections (prevent SSRF)
     if host not in _ALLOWED_HOSTS:
         return None
+    conn = None
     try:
         conn = http.client.HTTPConnection(host, port, timeout=timeout)
         request = json.dumps({
@@ -164,7 +168,6 @@ def query_binary_metadata(host: str, port: int, timeout: float = 5.0) -> dict | 
         conn.request("POST", "/mcp", request, {"Content-Type": "application/json"})
         response = conn.getresponse()
         data = json.loads(response.read().decode())
-        conn.close()
 
         # Extract metadata from resource response
         result = data.get("result", {})
@@ -174,6 +177,9 @@ def query_binary_metadata(host: str, port: int, timeout: float = 5.0) -> dict | 
             return json.loads(text)
     except Exception:
         pass
+    finally:
+        if conn is not None:
+            conn.close()  # always release the socket, even on error
     return None
 
 

--- a/src/ida_multi_mcp/health.py
+++ b/src/ida_multi_mcp/health.py
@@ -29,11 +29,20 @@ def is_process_alive(pid: int) -> bool:
             import ctypes
             kernel32 = ctypes.windll.kernel32
             PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+            STILL_ACTIVE = 259  # GetExitCodeProcess return for a running process
             handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
-            if handle:
-                kernel32.CloseHandle(handle)
+            if not handle:
+                return False
+            try:
+                # OpenProcess succeeds for a just-exited process whose handle is
+                # not yet released (a zombie). Confirm liveness via exit code.
+                exit_code = ctypes.c_ulong(0)
+                if kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                    return exit_code.value == STILL_ACTIVE
+                # Could not read exit code — assume alive (benefit of the doubt).
                 return True
-            return False
+            finally:
+                kernel32.CloseHandle(handle)
         except Exception:
             return False
     else:

--- a/src/ida_multi_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_multi_mcp/ida_mcp/api_analysis.py
@@ -399,10 +399,16 @@ def xrefs_from(
 
 @tool
 @idasync
-def xrefs_to_field(queries: list[StructFieldQuery] | StructFieldQuery) -> list[dict]:
+def xrefs_to_field(
+    queries: list[StructFieldQuery] | StructFieldQuery,
+    limit: Annotated[int, "Max xrefs per field (default: 100, max: 1000)"] = 100,
+) -> list[dict]:
     """Get cross-references to structure fields"""
     if isinstance(queries, dict):
         queries = [queries]
+
+    if limit <= 0 or limit > 1000:
+        limit = 1000
 
     # Security: limit batch size
     from .utils import MAX_BATCH_SIZE
@@ -467,8 +473,12 @@ def xrefs_to_field(queries: list[StructFieldQuery] | StructFieldQuery) -> list[d
                 continue
 
             xrefs = []
+            more = False
             xref: ida_xref.xrefblk_t
             for xref in idautils.XrefsTo(tid):
+                if len(xrefs) >= limit:
+                    more = True
+                    break
                 xrefs += [
                     Xref(
                         addr=hex(xref.frm),
@@ -476,7 +486,7 @@ def xrefs_to_field(queries: list[StructFieldQuery] | StructFieldQuery) -> list[d
                         fn=get_function(xref.frm, raise_error=False),
                     )
                 ]
-            results.append({"struct": struct_name, "field": field_name, "xrefs": xrefs})
+            results.append({"struct": struct_name, "field": field_name, "xrefs": xrefs, "more": more})
         except Exception as e:
             results.append(
                 {

--- a/src/ida_multi_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_multi_mcp/ida_mcp/api_analysis.py
@@ -1518,8 +1518,12 @@ def classify_functions(
         count = 5000
 
     if isinstance(addrs, str) and addrs.strip() == "*":
-        func_eas = [ea for ea in idautils.Functions()
-                    if not (idaapi.get_func(ea) and idaapi.get_func(ea).flags & idaapi.FUNC_LIB)]
+        func_eas = []
+        for ea in idautils.Functions():
+            func = idaapi.get_func(ea)
+            if func and func.flags & idaapi.FUNC_LIB:
+                continue
+            func_eas.append(ea)
     else:
         addrs_list = normalize_list_input(addrs)
         func_eas = [parse_address(a) for a in addrs_list]
@@ -1589,14 +1593,18 @@ def func_profile(
                 edge_count += 1
         complexity = edge_count - bb_count + 2
 
-        xref_count = sum(1 for _ in idautils.XrefsTo(ea, 0))
+        # Single pass over XrefsTo: total xrefs and call-type (caller) xrefs.
+        xref_count = 0
+        caller_count = 0
+        for x in idautils.XrefsTo(ea, 0):
+            xref_count += 1
+            if x.type in (idaapi.fl_CF, idaapi.fl_CN):
+                caller_count += 1
         callee_count = 0
         for item_ea in idautils.FuncItems(ea):
             for xref in idautils.XrefsFrom(item_ea, 0):
                 if xref.type in (idaapi.fl_CF, idaapi.fl_CN):
                     callee_count += 1
-        caller_count = sum(1 for x in idautils.XrefsTo(ea, 0)
-                          if x.type in (idaapi.fl_CF, idaapi.fl_CN))
 
         string_count = len(extract_function_strings(ea))
 

--- a/src/ida_multi_mcp/ida_mcp/api_core.py
+++ b/src/ida_multi_mcp/ida_mcp/api_core.py
@@ -24,6 +24,9 @@ _strings_cache: list[tuple[int, str]] | None = None
 # Cached function list: [Function(...), ...]
 _funcs_cache: list["Function"] | None = None
 
+# Cached function query metadata: [{addr, name, size, size_int, has_type}, ...]
+_funcs_query_cache: list[dict] | None = None
+
 # Cached globals list: [Global(...), ...]
 _globals_cache: list["Global"] | None = None
 
@@ -50,10 +53,36 @@ def _get_funcs_cache() -> list["Function"]:
     return _funcs_cache
 
 
+def _get_funcs_query_cache() -> list[dict]:
+    """Cached function metadata for func_query (adds size_int + has_type).
+
+    Kept separate from _funcs_cache because it carries extra fields used
+    only for filtering/sorting. Invalidated together with _funcs_cache.
+    """
+    global _funcs_query_cache
+    if _funcs_query_cache is None:
+        rows: list[dict] = []
+        tif = ida_typeinf.tinfo_t()
+        for addr in idautils.Functions():
+            fn = idaapi.get_func(addr)
+            if not fn:
+                continue
+            size_int = fn.end_ea - fn.start_ea
+            fn_name = ida_funcs.get_func_name(fn.start_ea) or "<unnamed>"
+            has_type = bool(ida_nalt.get_tinfo(tif, fn.start_ea))
+            rows.append({
+                "addr": hex(fn.start_ea), "name": fn_name,
+                "size": hex(size_int), "size_int": size_int, "has_type": has_type,
+            })
+        _funcs_query_cache = rows
+    return _funcs_query_cache
+
+
 def invalidate_funcs_cache():
-    """Clear the function cache (call after function changes)."""
-    global _funcs_cache
+    """Clear the function caches (call after function changes)."""
+    global _funcs_cache, _funcs_query_cache
     _funcs_cache = None
+    _funcs_query_cache = None
 
 
 def _get_globals_cache() -> list["Global"]:
@@ -516,18 +545,8 @@ def func_query(
     Example: {name_regex: 'crypt', min_size: 100, sort_by: 'size', descending: true}"""
     queries = normalize_dict_list(queries)
 
-    all_functions: list[dict] = []
-    for addr in idautils.Functions():
-        fn = idaapi.get_func(addr)
-        if not fn:
-            continue
-        size_int = fn.end_ea - fn.start_ea
-        fn_name = ida_funcs.get_func_name(fn.start_ea) or "<unnamed>"
-        has_type = bool(ida_nalt.get_tinfo(ida_typeinf.tinfo_t(), fn.start_ea))
-        all_functions.append({
-            "addr": hex(fn.start_ea), "name": fn_name,
-            "size": hex(size_int), "size_int": size_int, "has_type": has_type,
-        })
+    # Shared, cached metadata — must not be mutated in place below.
+    all_functions = _get_funcs_query_cache()
 
     results = []
     for query in queries:
@@ -560,6 +579,10 @@ def func_query(
 
         if "has_type" in query:
             filtered = [f for f in filtered if f["has_type"] is bool(query["has_type"])]
+
+        # Copy before sorting in place when no filter narrowed the shared cache.
+        if filtered is all_functions:
+            filtered = list(filtered)
 
         if sort_by == "name":
             filtered.sort(key=lambda f: f["name"].lower(), reverse=descending)

--- a/src/ida_multi_mcp/ida_mcp/api_core.py
+++ b/src/ida_multi_mcp/ida_mcp/api_core.py
@@ -54,25 +54,26 @@ def _get_funcs_cache() -> list["Function"]:
 
 
 def _get_funcs_query_cache() -> list[dict]:
-    """Cached function metadata for func_query (adds size_int + has_type).
+    """Lightweight func_query rows derived from the warm functions cache.
 
-    Kept separate from _funcs_cache because it carries extra fields used
-    only for filtering/sorting. Invalidated together with _funcs_cache.
+    Reuses _funcs_cache (addr/name/size) and only adds size_int, so it does
+    NO per-function IDA calls and stays fast even on 100K+ function binaries.
+    has_type is intentionally NOT precomputed here (a get_tinfo() per function
+    would re-introduce a full scan that times out); func_query computes it
+    lazily only for the rows it actually returns or filters on. Invalidated
+    together with _funcs_cache.
     """
     global _funcs_query_cache
     if _funcs_query_cache is None:
         rows: list[dict] = []
-        tif = ida_typeinf.tinfo_t()
-        for addr in idautils.Functions():
-            fn = idaapi.get_func(addr)
-            if not fn:
-                continue
-            size_int = fn.end_ea - fn.start_ea
-            fn_name = ida_funcs.get_func_name(fn.start_ea) or "<unnamed>"
-            has_type = bool(ida_nalt.get_tinfo(tif, fn.start_ea))
+        for fn in _get_funcs_cache():
+            try:
+                size_int = int(fn["size"], 16)
+            except (KeyError, ValueError, TypeError):
+                size_int = 0
             rows.append({
-                "addr": hex(fn.start_ea), "name": fn_name,
-                "size": hex(size_int), "size_int": size_int, "has_type": has_type,
+                "addr": fn["addr"], "name": fn["name"],
+                "size": fn["size"], "size_int": size_int,
             })
         _funcs_query_cache = rows
     return _funcs_query_cache
@@ -536,6 +537,7 @@ def _collect_imports() -> list[dict]:
 
 @tool
 @idasync
+@tool_timeout(60.0)
 def func_query(
     queries: Annotated[list[dict] | dict,
         "Function query: filter, name_regex, min_size, max_size, has_type, sort_by, descending, offset, count"],
@@ -547,6 +549,16 @@ def func_query(
 
     # Shared, cached metadata — must not be mutated in place below.
     all_functions = _get_funcs_query_cache()
+
+    # has_type is resolved lazily: a get_tinfo() per function over the whole
+    # binary would time out on 100K+ function targets. Reuse one tinfo_t.
+    _tif = ida_typeinf.tinfo_t()
+
+    def _has_type(row: dict) -> bool:
+        try:
+            return bool(ida_nalt.get_tinfo(_tif, int(row["addr"], 16)))
+        except (ValueError, TypeError):
+            return False
 
     results = []
     for query in queries:
@@ -577,8 +589,10 @@ def func_query(
         if max_size is not None:
             filtered = [f for f in filtered if f["size_int"] <= int(max_size)]
 
+        # has_type filter: compute only for the already name/size-narrowed set.
         if "has_type" in query:
-            filtered = [f for f in filtered if f["has_type"] is bool(query["has_type"])]
+            want = bool(query["has_type"])
+            filtered = [f for f in filtered if _has_type(f) is want]
 
         # Copy before sorting in place when no filter narrowed the shared cache.
         if filtered is all_functions:
@@ -592,7 +606,12 @@ def func_query(
             filtered.sort(key=lambda f: int(f["addr"], 16), reverse=descending)
 
         page = paginate(filtered, offset, count)
-        page["data"] = [{k: v for k, v in item.items() if k != "size_int"} for item in page["data"]]
+        # Resolve has_type only for the returned page (≤ count rows).
+        page["data"] = [
+            {**{k: v for k, v in item.items() if k != "size_int"},
+             "has_type": _has_type(item)}
+            for item in page["data"]
+        ]
         results.append(page)
 
     return results

--- a/src/ida_multi_mcp/ida_mcp/http.py
+++ b/src/ida_multi_mcp/ida_mcp/http.py
@@ -78,23 +78,32 @@ def get_cors_policy(port: int) -> str:
 ORIGINAL_TOOLS = handle_enabled_tools(MCP_SERVER.tools, "enabled_tools")
 
 
-class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
-    def __init__(self, request, client_address, server):
-        super().__init__(request, client_address, server)
-        self.update_cors_policy()
+def apply_cors_policy(server, policy: str | None = None) -> None:
+    """Apply the configured CORS policy to *server.cors_allowed_origins*.
 
-    def update_cors_policy(self):
+    Reads the policy from config when not supplied. This is the only place
+    that touches the IDA netnode for CORS, so it must NOT run per request —
+    call it once at startup and again from the /config handler on change.
+    """
+    if policy is None:
         policy = config_json_get("cors_policy", DEFAULT_CORS_POLICY)
-        if policy not in ("unrestricted", "local", "direct"):
-            policy = DEFAULT_CORS_POLICY
-        match policy:
-            case "unrestricted":
-                self.mcp_server.cors_allowed_origins = "*"
-            case "local":
-                self.mcp_server.cors_allowed_origins = self.mcp_server.cors_localhost
-            case "direct":
-                self.mcp_server.cors_allowed_origins = None
+    if policy not in ("unrestricted", "local", "direct"):
+        policy = DEFAULT_CORS_POLICY
+    match policy:
+        case "unrestricted":
+            server.cors_allowed_origins = "*"
+        case "local":
+            server.cors_allowed_origins = server.cors_localhost
+        case "direct":
+            server.cors_allowed_origins = None
 
+
+# Resolve the CORS policy once at import (mirrors handle_enabled_tools above),
+# instead of doing an @idasync netnode read on every HTTP request.
+apply_cors_policy(MCP_SERVER)
+
+
+class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
     def do_POST(self):
         """Handles POST requests."""
         if urlparse(self.path).path == "/config":
@@ -385,7 +394,7 @@ input[type="submit"]:hover {
         # Update CORS policy
         cors_policy = postvars.get("cors_policy", [DEFAULT_CORS_POLICY])[0]
         config_json_set("cors_policy", cors_policy)
-        self.update_cors_policy()
+        apply_cors_policy(self.mcp_server, cors_policy)
 
         # Update the server's tools
         enabled_tools = {name: name in postvars for name in ORIGINAL_TOOLS.keys()}

--- a/src/ida_multi_mcp/ida_mcp/utils.py
+++ b/src/ida_multi_mcp/ida_mcp/utils.py
@@ -468,6 +468,14 @@ def parse_address(addr: str | int) -> int:
 
 def read_bytes_bss_safe(ea: int, size: int) -> bytes:
     """Read bytes from the IDB, substituting zeros for unloaded BSS bytes."""
+    if size <= 0:
+        return b""
+    # Fast path: one bulk read when the whole range is loaded. get_bytes
+    # returns None if any byte is missing, so we only fall back to the slow
+    # per-byte loop for regions that actually straddle a BSS gap.
+    data = ida_bytes.get_bytes(ea, size)
+    if data is not None and len(data) == size:
+        return bytes(data)
     out = bytearray(size)
     for offset in range(size):
         current_ea = ea + offset

--- a/src/ida_multi_mcp/ida_mcp/utils.py
+++ b/src/ida_multi_mcp/ida_mcp/utils.py
@@ -618,7 +618,9 @@ def get_function(addr, *, raise_error=True):
     except AttributeError:
         name = ida_funcs.get_func_name(fn.start_ea)
 
-    return Function(addr=hex(addr), name=name, size=hex(fn.end_ea - fn.start_ea))
+    # Always report the canonical entry point: callers pass arbitrary
+    # addresses inside the function (e.g. xref sources).
+    return Function(addr=hex(fn.start_ea), name=name, size=hex(fn.end_ea - fn.start_ea))
 
 
 def get_prototype(fn: ida_funcs.func_t) -> Optional[str]:

--- a/src/ida_multi_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_multi_mcp/ida_mcp/zeromcp/mcp.py
@@ -1,3 +1,11 @@
+# zeromcp for the IDA plugin/worker (HTTP transport).
+#
+# A second copy lives at ida_multi_mcp/vendor/zeromcp/mcp.py and is used by the
+# router over stdio. The two are deliberately separate: the router must not
+# import ida_mcp (which pulls in IDA dependencies), and some behavior is
+# transport-specific — this copy logs to stdout (IDA console / captured worker
+# stderr), whereas the stdio copy must log to stderr. Keep shared,
+# transport-neutral fixes mirrored across both copies.
 import re
 import sys
 import time
@@ -331,6 +339,7 @@ class McpServer:
         self.registry.methods["resources/read"] = self._mcp_resources_read
         self.registry.methods["prompts/list"] = self._mcp_prompts_list
         self.registry.methods["prompts/get"] = self._mcp_prompts_get
+        self.registry.methods["notifications/initialized"] = self._mcp_notifications_initialized
         self.registry.methods["notifications/cancelled"] = self._mcp_notifications_cancelled
 
     def tool(self, func: Callable) -> Callable:
@@ -540,6 +549,12 @@ class McpServer:
         finally:
             if request_id is not None:
                 unregister_pending_request(request_id)
+
+    def _mcp_notifications_initialized(self) -> None:
+        """MCP notifications/initialized - client signals init complete"""
+        # No-op: notification acknowledgement, no response needed. Registering
+        # it avoids a spurious "Method not found" log on each client handshake.
+        pass
 
     def _mcp_notifications_cancelled(self, requestId: int | str, reason: str | None = None) -> None:
         """MCP notifications/cancelled - cancel an in-flight request"""

--- a/src/ida_multi_mcp/ida_tool_schemas.json
+++ b/src/ida_multi_mcp/ida_tool_schemas.json
@@ -438,6 +438,10 @@
               "additionalProperties": false
             }
           ]
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Max xrefs per field (default: 100, max: 1000)"
         }
       },
       "required": [

--- a/src/ida_multi_mcp/idalib_manager.py
+++ b/src/ida_multi_mcp/idalib_manager.py
@@ -143,7 +143,9 @@ class IdalibManager:
 
         creation_flags = 0
         if sys.platform == "win32":
-            creation_flags = subprocess.CREATE_NO_WINDOW
+            # NEW_PROCESS_GROUP lets us send CTRL_BREAK_EVENT for graceful
+            # shutdown (TerminateProcess cannot be caught to close the IDB).
+            creation_flags = subprocess.CREATE_NO_WINDOW | subprocess.CREATE_NEW_PROCESS_GROUP
 
         try:
             # stdout is discarded: the worker logs via stderr, and leaving an
@@ -222,19 +224,51 @@ class IdalibManager:
                 return {"ok": True, "note": "orphaned entry removed"}
             return {"error": f"Instance '{instance_id}' is not a managed idalib session"}
 
-        # Terminate the subprocess.
-        try:
-            proc.terminate()
-            proc.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=5)
-        except Exception:
-            proc.kill()
+        # Terminate the subprocess, preferring a graceful shutdown so the
+        # worker can close its IDB cleanly.
+        self._terminate_gracefully(proc)
 
         del self._processes[instance_id]
         self.registry.unregister(instance_id)
         return {"ok": True}
+
+    @staticmethod
+    def _terminate_gracefully(proc: subprocess.Popen) -> None:
+        """Ask the worker to shut down cleanly, then force-kill if it lingers.
+
+        On Windows, ``proc.terminate()`` maps to TerminateProcess, which the
+        worker cannot intercept to close its IDB. Send CTRL_BREAK_EVENT first
+        (handled as SIGBREAK by the worker) and fall back to terminate/kill.
+        On POSIX, SIGTERM already triggers the worker's clean-shutdown handler.
+        """
+        if proc.poll() is not None:
+            return
+        try:
+            if sys.platform == "win32":
+                import signal as _signal
+                proc.send_signal(_signal.CTRL_BREAK_EVENT)
+            else:
+                proc.terminate()
+            proc.wait(timeout=10)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        except Exception:
+            pass
+
+        # Graceful path didn't complete — force terminate, then hard kill.
+        try:
+            proc.terminate()
+            proc.wait(timeout=5)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        except Exception:
+            pass
+        try:
+            proc.kill()
+        except Exception:
+            pass
 
     def close_all_sessions(self) -> int:
         """Terminate all managed idalib workers. Returns count closed."""

--- a/src/ida_multi_mcp/idalib_manager.py
+++ b/src/ida_multi_mcp/idalib_manager.py
@@ -243,6 +243,8 @@ class IdalibManager:
         """
         if proc.poll() is not None:
             return
+
+        # Step 1: graceful request (CTRL_BREAK on Windows, SIGTERM on POSIX).
         try:
             if sys.platform == "win32":
                 import signal as _signal
@@ -256,15 +258,20 @@ class IdalibManager:
         except Exception:
             pass
 
-        # Graceful path didn't complete — force terminate, then hard kill.
-        try:
-            proc.terminate()
-            proc.wait(timeout=5)
-            return
-        except subprocess.TimeoutExpired:
-            pass
-        except Exception:
-            pass
+        # Step 2 (Windows only): TerminateProcess, since CTRL_BREAK may be
+        # ignored. On POSIX the graceful step already sent SIGTERM, so go
+        # straight to the hard kill below instead of repeating terminate().
+        if sys.platform == "win32":
+            try:
+                proc.terminate()
+                proc.wait(timeout=5)
+                return
+            except subprocess.TimeoutExpired:
+                pass
+            except Exception:
+                pass
+
+        # Step 3: hard kill.
         try:
             proc.kill()
         except Exception:

--- a/src/ida_multi_mcp/idalib_manager.py
+++ b/src/ida_multi_mcp/idalib_manager.py
@@ -146,9 +146,12 @@ class IdalibManager:
             creation_flags = subprocess.CREATE_NO_WINDOW
 
         try:
+            # stdout is discarded: the worker logs via stderr, and leaving an
+            # undrained PIPE deadlocks the worker once IDA's analysis output
+            # fills the OS pipe buffer (~64KB) during _wait_for_ready.
             proc = subprocess.Popen(
                 cmd,
-                stdout=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 creationflags=creation_flags,
             )

--- a/src/ida_multi_mcp/idalib_worker.py
+++ b/src/ida_multi_mcp/idalib_worker.py
@@ -15,6 +15,7 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import atexit
 import logging
 import signal
 import sys
@@ -89,17 +90,37 @@ def main() -> None:
         if MCP_UNSAFE:
             logger.info("Unsafe tools disabled (start with --unsafe to enable)")
 
-    # --- Signal handling for clean shutdown -----------------------------------
-    def _shutdown(signum, frame):
-        logger.info("Received signal %s — shutting down...", signum)
+    # --- Clean shutdown -------------------------------------------------------
+    # close_database persists the IDB and releases the idalib lock. Register it
+    # via atexit so it also runs on normal interpreter exit. On Windows,
+    # proc.terminate() maps to TerminateProcess, which kills the process without
+    # delivering SIGTERM — so the signal handler alone is not enough there.
+    _closed = False
+
+    def _close_db_once():
+        nonlocal _closed
+        if _closed:
+            return
+        _closed = True
         try:
             idapro.close_database()
         except Exception:
             pass
+
+    atexit.register(_close_db_once)
+
+    def _shutdown(signum, frame):
+        logger.info("Received signal %s — shutting down...", signum)
+        _close_db_once()
         sys.exit(0)
 
     signal.signal(signal.SIGINT, _shutdown)
     signal.signal(signal.SIGTERM, _shutdown)
+    # Windows: the manager sends CTRL_BREAK_EVENT for graceful shutdown,
+    # which arrives as SIGBREAK. TerminateProcess (proc.terminate) cannot be
+    # caught, so CTRL_BREAK is the only way to close the IDB cleanly there.
+    if hasattr(signal, "SIGBREAK"):
+        signal.signal(signal.SIGBREAK, _shutdown)
 
     # --- Serve ---------------------------------------------------------------
     logger.info("Serving on %s:%d", args.host, args.port)

--- a/src/ida_multi_mcp/registry.py
+++ b/src/ida_multi_mcp/registry.py
@@ -3,12 +3,14 @@
 Manages the global registry of IDA Pro instances with atomic file operations.
 """
 
+import copy
 import ipaddress
 import json
 import os
 import stat
 import sys
 import tempfile
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -111,6 +113,14 @@ class InstanceRegistry:
         self.registry_path = registry_path
         self.lock_path = registry_path + ".lock"
 
+        # In-process read cache: avoids re-acquiring the file lock and
+        # re-parsing instances.json on every read. Writes go through
+        # _save (atomic os.replace), so a (mtime_ns, size, ino) signature
+        # reliably detects changes made by other processes.
+        self._cache_lock = threading.Lock()
+        self._cached_data: dict[str, Any] | None = None
+        self._cached_sig: tuple | None = None
+
         # Ensure parent directory exists with restrictive permissions
         registry_dir = os.path.dirname(self.registry_path)
         if not os.path.exists(registry_dir):
@@ -140,8 +150,51 @@ class InstanceRegistry:
             # Fallback: treat as very old (epoch 0)
             return 0.0
 
+    def _file_signature(self) -> tuple | None:
+        """Stat-based change signature of the registry file (None if missing)."""
+        try:
+            st = os.stat(self.registry_path)
+            return (st.st_mtime_ns, st.st_size, st.st_ino)
+        except OSError:
+            return None
+
+    def _cache_get(self, sig: tuple | None) -> dict[str, Any] | None:
+        """Return a copy of the cached data if *sig* matches, else None."""
+        if sig is None:
+            return None
+        with self._cache_lock:
+            if self._cached_data is not None and sig == self._cached_sig:
+                return copy.deepcopy(self._cached_data)
+        return None
+
+    def _cache_put(self, data: dict[str, Any], sig: tuple | None) -> None:
+        """Store *data* in the read cache under signature *sig*."""
+        if sig is None:
+            return
+        with self._cache_lock:
+            self._cached_data = copy.deepcopy(data)
+            self._cached_sig = sig
+
+    def _snapshot(self) -> dict[str, Any]:
+        """Read-only registry snapshot, served from cache when unchanged.
+
+        Lock-free on cache hit: _save uses atomic os.replace, so readers
+        never observe a partial file and the signature check is sufficient.
+        """
+        cached = self._cache_get(self._file_signature())
+        if cached is not None:
+            return cached
+        with FileLock(self.lock_path):
+            return self._load()
+
     def _load(self) -> dict[str, Any]:
         """Load registry data from disk (assumes lock held)."""
+        # Signature taken before reading: if the file changes mid-read we
+        # cache under a stale signature and simply re-read next time.
+        sig = self._file_signature()
+        cached = self._cache_get(sig)
+        if cached is not None:
+            return cached
         try:
             with open(self.registry_path, "r") as f:
                 data = json.load(f)
@@ -173,6 +226,7 @@ class InstanceRegistry:
                 valid_instances[iid] = entry
         data["instances"] = valid_instances
 
+        self._cache_put(data, sig)
         return data
 
     def _save(self, data: dict[str, Any]) -> None:
@@ -197,6 +251,8 @@ class InstanceRegistry:
             # Set restrictive file permissions on Unix
             if sys.platform != "win32":
                 os.chmod(self.registry_path, stat.S_IRUSR | stat.S_IWUSR)
+
+            self._cache_put(data, self._file_signature())
         finally:
             # Clean up temp file on failure
             if temp_fd is not None:
@@ -302,9 +358,7 @@ class InstanceRegistry:
         Returns:
             Instance metadata dict, or None if not found
         """
-        with FileLock(self.lock_path):
-            data = self._load()
-            return data["instances"].get(instance_id)
+        return self._snapshot()["instances"].get(instance_id)
 
     def list_instances(self) -> dict[str, dict[str, Any]]:
         """List all registered instances.
@@ -312,9 +366,7 @@ class InstanceRegistry:
         Returns:
             Dict mapping instance_id -> metadata
         """
-        with FileLock(self.lock_path):
-            data = self._load()
-            return data["instances"].copy()
+        return self._snapshot()["instances"]
 
     def update_heartbeat(self, instance_id: str) -> bool:
         """Update the last heartbeat timestamp for an instance.
@@ -341,9 +393,7 @@ class InstanceRegistry:
         Returns:
             Active instance ID, or None if no active instance
         """
-        with FileLock(self.lock_path):
-            data = self._load()
-            return data["active_instance"]
+        return self._snapshot()["active_instance"]
 
     def set_active(self, instance_id: str) -> bool:
         """Set the active instance.
@@ -412,9 +462,7 @@ class InstanceRegistry:
         Returns:
             Expired instance metadata dict, or None if not found
         """
-        with FileLock(self.lock_path):
-            data = self._load()
-            return data.get("expired", {}).get(instance_id)
+        return self._snapshot().get("expired", {}).get(instance_id)
 
     def cleanup_expired(self, max_age_seconds: int = 3600) -> int:
         """Remove expired instances older than max_age.

--- a/src/ida_multi_mcp/router.py
+++ b/src/ida_multi_mcp/router.py
@@ -159,6 +159,7 @@ class InstanceRouter:
         if host not in ALLOWED_HOSTS:
             return {"error": "Connection refused: only localhost instances allowed"}
 
+        conn = None
         try:
             conn = http.client.HTTPConnection(host, port, timeout=300.0)
             request_body = json.dumps({
@@ -170,7 +171,6 @@ class InstanceRouter:
             conn.request("POST", "/mcp", request_body, {"Content-Type": "application/json"})
             response = conn.getresponse()
             response_data = json.loads(response.read().decode())
-            conn.close()
 
             # Return result or error
             if "result" in response_data:
@@ -185,6 +185,9 @@ class InstanceRouter:
             return {
                 "error": f"Failed to connect to instance: {type(e).__name__}",
             }
+        finally:
+            if conn is not None:
+                conn.close()  # always release the socket, even on error
 
     def _handle_expired_instance(self, instance_id: str, expired_info: dict) -> dict[str, Any]:
         """Handle request for an expired instance.

--- a/src/ida_multi_mcp/server.py
+++ b/src/ida_multi_mcp/server.py
@@ -37,6 +37,56 @@ def _load_static_ida_tools() -> list[dict]:
     return _STATIC_IDA_TOOLS
 
 
+def _json_text(value: Any) -> str:
+    return json.dumps(value, separators=(",", ":"))
+
+
+def _schema_preserving_preview(value: Any, max_chars: int) -> Any:
+    """Return a smaller value of the same JSON type (str/list/dict) when huge."""
+    if max_chars <= 0:
+        return value
+    try:
+        if len(_json_text(value)) <= max_chars:
+            return value
+    except Exception:
+        return value
+
+    if isinstance(value, str):
+        return value[:max_chars]
+
+    if isinstance(value, list):
+        # Accumulate serialized length per item instead of re-serializing
+        # the whole prefix each iteration (which is quadratic).
+        out: list[Any] = []
+        used = 2  # "[" and "]"
+        for item in value:
+            try:
+                item_len = len(_json_text(item))
+            except Exception:
+                break
+            used += item_len + (1 if out else 0)  # +1 for comma separator
+            if used > max_chars:
+                break
+            out.append(item)
+        return out
+
+    if isinstance(value, dict):
+        def _truncate(v: Any, depth: int = 0) -> Any:
+            if depth > 6:
+                return v
+            if isinstance(v, str) and len(v) > 1000:
+                return v[:1000] + f"... [{len(v)} chars total]"
+            if isinstance(v, list):
+                return [_truncate(x, depth + 1) for x in v[:50]]
+            if isinstance(v, dict):
+                return {k: _truncate(x, depth + 1) for k, x in v.items()}
+            return v
+
+        return _truncate(value)
+
+    return value
+
+
 class IdaMultiMcpServer:
     """MCP server that aggregates multiple IDA Pro instances.
 
@@ -108,50 +158,6 @@ class IdaMultiMcpServer:
                 return structured.get("result")
 
             return structured
-
-        def _json_text(value: Any) -> str:
-            return json.dumps(value, separators=(",", ":"))
-
-        def _schema_preserving_preview(value: Any, max_chars: int) -> Any:
-            """Return a smaller value of the same JSON type (str/list/dict) when huge."""
-            if max_chars <= 0:
-                return value
-            try:
-                if len(_json_text(value)) <= max_chars:
-                    return value
-            except Exception:
-                return value
-
-            if isinstance(value, str):
-                return value[:max_chars]
-
-            if isinstance(value, list):
-                out: list[Any] = []
-                for item in value:
-                    out.append(item)
-                    try:
-                        if len(_json_text(out)) > max_chars:
-                            out.pop()
-                            break
-                    except Exception:
-                        break
-                return out
-
-            if isinstance(value, dict):
-                def _truncate(v: Any, depth: int = 0) -> Any:
-                    if depth > 6:
-                        return v
-                    if isinstance(v, str) and len(v) > 1000:
-                        return v[:1000] + f"... [{len(v)} chars total]"
-                    if isinstance(v, list):
-                        return [_truncate(x, depth + 1) for x in v[:50]]
-                    if isinstance(v, dict):
-                        return {k: _truncate(x, depth + 1) for k, x in v.items()}
-                    return v
-
-                return _truncate(value)
-
-            return value
 
         # Override tools/list to return cached tools
 

--- a/src/ida_multi_mcp/server.py
+++ b/src/ida_multi_mcp/server.py
@@ -781,6 +781,7 @@ class IdaMultiMcpServer:
         if host not in ALLOWED_HOSTS:
             return []
 
+        conn = None
         try:
             conn = http.client.HTTPConnection(host, port, timeout=10.0)
             request_body = json.dumps({
@@ -791,7 +792,6 @@ class IdaMultiMcpServer:
             conn.request("POST", "/mcp", request_body, {"Content-Type": "application/json"})
             response = conn.getresponse()
             response_data = json.loads(response.read().decode())
-            conn.close()
 
             if "result" in response_data:
                 tools = response_data["result"].get("tools", [])
@@ -802,6 +802,9 @@ class IdaMultiMcpServer:
         except Exception as e:
             print(f"[ida-multi-mcp] Failed to discover tools from instance: {e}", file=sys.stderr)
             return []
+        finally:
+            if conn is not None:
+                conn.close()  # always release the socket, even on error
 
     def run(self):
         """Run the MCP server with stdio transport."""

--- a/src/ida_multi_mcp/server.py
+++ b/src/ida_multi_mcp/server.py
@@ -363,6 +363,7 @@ class IdaMultiMcpServer:
         addrs = arguments.get("addrs", [])
         output_dir = arguments.get("output_dir", ".")
         mode = arguments.get("mode", "single")
+        allow_outside_cwd = arguments.get("allow_outside_cwd", False)
         instance_id = arguments.get("instance_id")
         if not instance_id:
             return {
@@ -375,7 +376,20 @@ class IdaMultiMcpServer:
         # Reject absolute paths that escape CWD unless they are subdirectories
         if ".." in os.path.normpath(output_dir).split(os.sep):
             return {"error": "output_dir must not contain '..' path components"}
-        # Warn but allow absolute paths (they may be intentional from the user)
+        # Security: confine output to the current working directory by default.
+        # Tool arguments here are LLM-generated, so an injected absolute path
+        # (e.g. a system directory) must not silently receive written files.
+        # Callers can opt out explicitly with allow_outside_cwd=true.
+        if not allow_outside_cwd:
+            cwd = os.path.realpath(os.getcwd())
+            if resolved_dir != cwd and not resolved_dir.startswith(cwd + os.sep):
+                return {
+                    "error": (
+                        "output_dir must be within the current working directory. "
+                        "Pass allow_outside_cwd=true to write elsewhere."
+                    ),
+                    "cwd": cwd,
+                }
         output_dir = resolved_dir
 
         # addr → name mapping (populated by list_funcs when using 'all')
@@ -623,11 +637,15 @@ class IdaMultiMcpServer:
                     },
                     "output_dir": {
                         "type": "string",
-                        "description": "Directory to save decompiled files"
+                        "description": "Directory to save decompiled files. Must be within the current working directory unless allow_outside_cwd is true."
                     },
                     "mode": {
                         "type": "string",
                         "description": "Output mode: 'single' = one .c file per function (default), 'merged' = all in one file"
+                    },
+                    "allow_outside_cwd": {
+                        "type": "boolean",
+                        "description": "Permit output_dir outside the current working directory (default: false)."
                     },
                     "instance_id": {
                         "type": "string",

--- a/src/ida_multi_mcp/vendor/zeromcp/mcp.py
+++ b/src/ida_multi_mcp/vendor/zeromcp/mcp.py
@@ -1,3 +1,11 @@
+# Vendored zeromcp for the router (stdio transport, IDA-free).
+#
+# A second copy lives at ida_multi_mcp/ida_mcp/zeromcp/mcp.py and is used by the
+# IDA plugin/worker over HTTP. The two are deliberately separate: the router
+# must not import ida_mcp (which pulls in IDA dependencies), and some behavior is
+# transport-specific — this copy logs to stderr (stdout is the stdio protocol
+# channel), whereas the HTTP copy logs to stdout. Keep shared, transport-neutral
+# fixes mirrored across both copies.
 import re
 import sys
 import time
@@ -431,13 +439,19 @@ class McpServer:
                 request = stdin.readline(self._STDIO_MAX_LINE + 1)
                 if not request: # EOF
                     break
-                if len(request) > self._STDIO_MAX_LINE:
-                    # Security: reject oversized lines to prevent memory exhaustion
-                    continue
 
                 # Strip whitespace (trailing newline) before parsing
                 request = request.strip()
                 if not request:
+                    continue
+
+                # Security: reject oversized lines. Reply with an error rather
+                # than silently dropping, so the client does not hang waiting.
+                if len(request) > self._STDIO_MAX_LINE:
+                    response = self.registry._error(None, -32600, "Request too large")
+                    if response:
+                        stdout.write(json.dumps(response).encode("utf-8") + b"\n")
+                        stdout.flush()
                     continue
 
                 response = self.registry.dispatch(request)

--- a/tests/test_architecture_fixes.py
+++ b/tests/test_architecture_fixes.py
@@ -95,6 +95,8 @@ class TestArchitectureFixes(unittest.TestCase):
                     "output_dir": out_dir,
                     "mode": "single",
                     "instance_id": "abcd",
+                    # Temp dir is outside cwd; opt in to writing there.
+                    "allow_outside_cwd": True,
                 }
             )
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1,6 +1,7 @@
 """Tests for filelock.py — Cross-platform file locking."""
 
 import os
+import time
 
 import pytest
 
@@ -57,3 +58,37 @@ class TestFileLock:
         lock.acquire()
         assert lock._fd is not None
         lock.release()
+
+    def test_threads_do_not_overlap(self, tmp_path):
+        """Concurrent threads in one process must hold the lock exclusively."""
+        import threading
+
+        lock_path = str(tmp_path / "concurrent.lock")
+        active = 0
+        max_active = 0
+        errors = []
+        guard = threading.Lock()
+
+        def worker():
+            nonlocal active, max_active
+            try:
+                for _ in range(20):
+                    with FileLock(lock_path, timeout=5.0):
+                        with guard:
+                            active += 1
+                            max_active = max(max_active, active)
+                        # Hold briefly to expose any overlap.
+                        time.sleep(0.001)
+                        with guard:
+                            active -= 1
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert max_active == 1  # never two holders at once

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -38,13 +38,19 @@ class TestIsProcessAlive:
 
     @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
     def test_windows_alive(self):
-        """Test Windows path with a mocked ctypes kernel32."""
+        """Running process: handle opens and exit code is STILL_ACTIVE."""
         mock_kernel32 = MagicMock()
         mock_kernel32.OpenProcess.return_value = 1234  # non-zero = handle found
-        mock_kernel32.CloseHandle.return_value = None
+
+        def _set_still_active(handle, exit_code_ptr):
+            exit_code_ptr._obj.value = 259  # STILL_ACTIVE
+            return 1
+
+        mock_kernel32.GetExitCodeProcess.side_effect = _set_still_active
         with patch("ctypes.windll") as mock_windll:
             mock_windll.kernel32 = mock_kernel32
             assert is_process_alive(5678) is True
+        mock_kernel32.CloseHandle.assert_called_once()
 
     @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
     def test_windows_not_alive(self):
@@ -53,6 +59,22 @@ class TestIsProcessAlive:
         with patch("ctypes.windll") as mock_windll:
             mock_windll.kernel32 = mock_kernel32
             assert is_process_alive(5678) is False
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+    def test_windows_zombie_reports_dead(self):
+        """Exited process whose handle is still open must report dead."""
+        mock_kernel32 = MagicMock()
+        mock_kernel32.OpenProcess.return_value = 1234  # handle still openable
+
+        def _set_exited(handle, exit_code_ptr):
+            exit_code_ptr._obj.value = 0  # process exited with code 0
+            return 1
+
+        mock_kernel32.GetExitCodeProcess.side_effect = _set_exited
+        with patch("ctypes.windll") as mock_windll:
+            mock_windll.kernel32 = mock_kernel32
+            assert is_process_alive(5678) is False
+        mock_kernel32.CloseHandle.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_http_cors.py
+++ b/tests/test_http_cors.py
@@ -1,0 +1,86 @@
+"""Tests for CORS policy application in ida_mcp/http.py (IDA layer stubbed).
+
+http.py applies the CORS policy once at import and on /config change, rather
+than via an @idasync netnode read on every HTTP request. These tests pin the
+policy-to-origins mapping.
+"""
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+
+def _localhost_marker(origin):
+    return True
+
+
+@pytest.fixture
+def http_module(monkeypatch):
+    """Import ida_mcp.http with the IDA-dependent layer stubbed out."""
+    # Stub the ida_mcp package so its IDA-heavy __init__ does not run.
+    pkg = types.ModuleType("ida_multi_mcp.ida_mcp")
+    pkg.__path__ = [str(SRC_ROOT / "ida_multi_mcp" / "ida_mcp")]
+    monkeypatch.setitem(sys.modules, "ida_multi_mcp.ida_mcp", pkg)
+
+    monkeypatch.setitem(sys.modules, "ida_netnode", MagicMock())
+
+    sync = types.ModuleType("ida_multi_mcp.ida_mcp.sync")
+    sync.idasync = lambda f: f  # no-op decorator
+    monkeypatch.setitem(sys.modules, "ida_multi_mcp.ida_mcp.sync", sync)
+
+    # Fake MCP_SERVER with the attributes http.py touches at import time.
+    fake_server = types.SimpleNamespace()
+    fake_server.tools = types.SimpleNamespace(methods={})
+    fake_server.cors_localhost = _localhost_marker
+    fake_server.cors_allowed_origins = None
+
+    rpc = types.ModuleType("ida_multi_mcp.ida_mcp.rpc")
+    rpc.McpRpcRegistry = object
+    rpc.McpHttpRequestHandler = type("McpHttpRequestHandler", (), {})
+    rpc.MCP_SERVER = fake_server
+    rpc.MCP_UNSAFE = set()
+    rpc.get_cached_output = lambda *_a, **_k: None
+    monkeypatch.setitem(sys.modules, "ida_multi_mcp.ida_mcp.rpc", rpc)
+
+    import importlib
+    sys.modules.pop("ida_multi_mcp.ida_mcp.http", None)
+    http = importlib.import_module("ida_multi_mcp.ida_mcp.http")
+    return http, fake_server
+
+
+class TestApplyCorsPolicy:
+    def test_unrestricted(self, http_module):
+        http, server = http_module
+        http.apply_cors_policy(server, "unrestricted")
+        assert server.cors_allowed_origins == "*"
+
+    def test_local_uses_localhost_checker(self, http_module):
+        http, server = http_module
+        http.apply_cors_policy(server, "local")
+        assert server.cors_allowed_origins is server.cors_localhost
+
+    def test_direct_sets_none(self, http_module):
+        http, server = http_module
+        http.apply_cors_policy(server, "direct")
+        assert server.cors_allowed_origins is None
+
+    def test_unknown_policy_falls_back_to_default(self, http_module):
+        http, server = http_module
+        server.cors_allowed_origins = "sentinel"
+        http.apply_cors_policy(server, "bogus")
+        # DEFAULT_CORS_POLICY is "local" → localhost checker.
+        assert server.cors_allowed_origins is server.cors_localhost
+
+    def test_handler_has_no_per_request_cors_override(self, http_module):
+        http, _ = http_module
+        # The old per-request update_cors_policy method must be gone.
+        assert not hasattr(http.IdaMcpHttpRequestHandler, "update_cors_policy")
+        assert "__init__" not in http.IdaMcpHttpRequestHandler.__dict__

--- a/tests/test_idalib_manager.py
+++ b/tests/test_idalib_manager.py
@@ -151,6 +151,40 @@ class TestIdalibManagerClose:
         assert "error" in result
 
 
+class TestGracefulTermination:
+    def test_skips_already_exited(self):
+        proc = MagicMock()
+        proc.poll.return_value = 0  # already exited
+        IdalibManager._terminate_gracefully(proc)
+        proc.wait.assert_not_called()
+        proc.kill.assert_not_called()
+
+    def test_graceful_signal_then_wait(self):
+        proc = MagicMock()
+        proc.poll.return_value = None
+        IdalibManager._terminate_gracefully(proc)
+        # Graceful path: no force-kill needed.
+        proc.wait.assert_called_once()
+        proc.kill.assert_not_called()
+
+    def test_falls_back_to_kill_on_timeout(self):
+        proc = MagicMock()
+        proc.poll.return_value = None
+        # Both graceful and terminate waits time out → hard kill.
+        proc.wait.side_effect = subprocess.TimeoutExpired(cmd="worker", timeout=10)
+        IdalibManager._terminate_gracefully(proc)
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
+
+    @patch("ida_multi_mcp.idalib_manager.sys.platform", "win32")
+    def test_windows_uses_ctrl_break(self):
+        import signal
+        proc = MagicMock()
+        proc.poll.return_value = None
+        IdalibManager._terminate_gracefully(proc)
+        proc.send_signal.assert_called_once_with(signal.CTRL_BREAK_EVENT)
+
+
 class TestIdalibManagerList:
     @patch("ida_multi_mcp.idalib_manager.subprocess.Popen")
     @patch("ida_multi_mcp.idalib_manager.ping_instance", return_value=True)

--- a/tests/test_idalib_manager.py
+++ b/tests/test_idalib_manager.py
@@ -179,10 +179,14 @@ class TestGracefulTermination:
     @patch("ida_multi_mcp.idalib_manager.sys.platform", "win32")
     def test_windows_uses_ctrl_break(self):
         import signal
-        proc = MagicMock()
-        proc.poll.return_value = None
-        IdalibManager._terminate_gracefully(proc)
-        proc.send_signal.assert_called_once_with(signal.CTRL_BREAK_EVENT)
+        # CTRL_BREAK_EVENT only exists on Windows; create it so the win32 code
+        # path is exercisable on Linux/macOS CI runners too.
+        sentinel = getattr(signal, "CTRL_BREAK_EVENT", 1)
+        with patch.object(signal, "CTRL_BREAK_EVENT", sentinel, create=True):
+            proc = MagicMock()
+            proc.poll.return_value = None
+            IdalibManager._terminate_gracefully(proc)
+            proc.send_signal.assert_called_once_with(sentinel)
 
 
 class TestIdalibManagerList:

--- a/tests/test_install_idempotent.py
+++ b/tests/test_install_idempotent.py
@@ -1,0 +1,84 @@
+"""Tests for install_mcp_servers idempotency and replace notification."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+sys.path.insert(0, str(SRC_ROOT))
+
+
+class TestInstallIdempotent(unittest.TestCase):
+    def _run_install(self, home):
+        from ida_multi_mcp.__main__ import install_mcp_servers
+        with mock.patch("ida_multi_mcp.__main__.os.path.expanduser", return_value=str(home)):
+            install_mcp_servers(quiet=True)
+
+    def test_reinstall_is_idempotent(self):
+        from ida_multi_mcp.__main__ import SERVER_NAME
+
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            (home / ".factory").mkdir(parents=True, exist_ok=True)
+            factory_path = home / ".factory" / "mcp.json"
+
+            old_env = dict(os.environ)
+            try:
+                os.environ["HOME"] = str(home)
+                os.environ["USERPROFILE"] = str(home)
+
+                self._run_install(home)
+                first = factory_path.read_text(encoding="utf-8")
+                config = json.loads(first)
+                assert SERVER_NAME in config["mcpServers"]
+
+                # Second install must produce byte-identical output.
+                self._run_install(home)
+                second = factory_path.read_text(encoding="utf-8")
+                self.assertEqual(first, second)
+            finally:
+                os.environ.clear()
+                os.environ.update(old_env)
+
+    def test_replace_notifies_when_entry_differs(self):
+        from ida_multi_mcp.__main__ import SERVER_NAME
+
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            factory_dir = home / ".factory"
+            factory_dir.mkdir(parents=True, exist_ok=True)
+            factory_path = factory_dir / "mcp.json"
+            # Pre-seed a customized (stale) entry.
+            factory_path.write_text(
+                json.dumps({"mcpServers": {SERVER_NAME: {"command": "old-custom"}}}),
+                encoding="utf-8",
+            )
+
+            from ida_multi_mcp.__main__ import install_mcp_servers
+            old_env = dict(os.environ)
+            try:
+                os.environ["HOME"] = str(home)
+                os.environ["USERPROFILE"] = str(home)
+                printed = []
+                with (
+                    mock.patch("ida_multi_mcp.__main__.os.path.expanduser", return_value=str(home)),
+                    mock.patch("builtins.print", side_effect=lambda *a, **k: printed.append(" ".join(map(str, a)))),
+                ):
+                    install_mcp_servers(quiet=False)
+
+                # The customized entry was replaced, and the user was told.
+                config = json.loads(factory_path.read_text(encoding="utf-8"))
+                self.assertNotEqual(config["mcpServers"][SERVER_NAME].get("command"), "old-custom")
+                self.assertTrue(any("Replacing existing" in line for line in printed))
+            finally:
+                os.environ.clear()
+                os.environ.update(old_env)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_robustness.py
+++ b/tests/test_install_robustness.py
@@ -1,0 +1,99 @@
+"""Tests for install_mcp_servers resilience to malformed / unusable configs.
+
+A single broken client config must never crash the installer or corrupt the
+file; the client is skipped and the run continues.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+sys.path.insert(0, str(SRC_ROOT))
+
+
+class _FactoryEnv:
+    """Context manager: isolated HOME with a Factory Droid config at *content*."""
+
+    def __init__(self, content, as_dir=False):
+        self.content = content
+        self.as_dir = as_dir
+
+    def __enter__(self):
+        self._td = tempfile.TemporaryDirectory()
+        home = Path(self._td.name)
+        factory = home / ".factory"
+        factory.mkdir(parents=True, exist_ok=True)
+        self.config_path = factory / "mcp.json"
+        if self.as_dir:
+            self.config_path.mkdir()
+        elif self.content is not None:
+            self.config_path.write_text(self.content, encoding="utf-8")
+        self._old_env = dict(os.environ)
+        os.environ["HOME"] = str(home)
+        os.environ["USERPROFILE"] = str(home)
+        self._patcher = mock.patch(
+            "ida_multi_mcp.__main__.os.path.expanduser", return_value=str(home)
+        )
+        self._patcher.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._patcher.stop()
+        os.environ.clear()
+        os.environ.update(self._old_env)
+        self._td.cleanup()
+
+
+class TestInstallRobustness(unittest.TestCase):
+    def _install(self):
+        from ida_multi_mcp.__main__ import install_mcp_servers
+        # Must not raise regardless of the config contents.
+        install_mcp_servers(quiet=True)
+
+    def test_non_dict_root_is_skipped_and_preserved(self):
+        with _FactoryEnv("[1, 2, 3]") as env:
+            self._install()
+            # File left untouched (not clobbered).
+            self.assertEqual(json.loads(env.config_path.read_text()), [1, 2, 3])
+
+    def test_non_dict_server_map_is_skipped_and_preserved(self):
+        original = json.dumps({"mcpServers": "not-a-dict"})
+        with _FactoryEnv(original) as env:
+            self._install()
+            self.assertEqual(env.config_path.read_text(), original)
+
+    def test_list_server_map_is_skipped(self):
+        original = json.dumps({"mcpServers": ["a", "b"]})
+        with _FactoryEnv(original) as env:
+            self._install()
+            self.assertEqual(env.config_path.read_text(), original)
+
+    def test_unreadable_config_is_skipped(self):
+        # A directory where a file is expected → open() raises OSError.
+        with _FactoryEnv(None, as_dir=True) as env:
+            self._install()  # must not raise
+            self.assertTrue(env.config_path.is_dir())
+
+    def test_invalid_json_is_skipped_and_preserved(self):
+        original = "{ this is not json "
+        with _FactoryEnv(original) as env:
+            self._install()
+            self.assertEqual(env.config_path.read_text(), original)
+
+    def test_valid_config_still_installs(self):
+        # Sanity: a normal config is installed (guards don't block the happy path).
+        from ida_multi_mcp.__main__ import SERVER_NAME
+        with _FactoryEnv(json.dumps({"mcpServers": {}})) as env:
+            self._install()
+            config = json.loads(env.config_path.read_text())
+            self.assertIn(SERVER_NAME, config["mcpServers"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lazy_cache_init.py
+++ b/tests/test_lazy_cache_init.py
@@ -102,7 +102,7 @@ def ida_mcp_modules(monkeypatch):
         lambda value, str_to_dict=None, max_items=500:
         value if isinstance(value, list) else [value if not isinstance(value, str) else str_to_dict(value)]
     )
-    utils.get_function = lambda addr: {"addr": hex(addr), "name": f"sub_{addr:x}"}
+    utils.get_function = lambda addr: {"addr": hex(addr), "name": f"sub_{addr:x}", "size": "0x40"}
     utils.paginate = lambda data, offset, count: {
         "data": data[offset:] if count == 0 else data[offset:offset + count],
         "next_offset": None,
@@ -175,35 +175,48 @@ class TestApiCoreLazyCaches:
 
     def test_func_query_builds_cache_once(self, ida_mcp_modules):
         api_core, _ = ida_mcp_modules
+        api_core._funcs_cache = None
         api_core._funcs_query_cache = None
         api_core.idautils.Functions.return_value = [0x1000, 0x2000]
-        api_core.idaapi.get_func.side_effect = lambda ea: SimpleNamespace(start_ea=ea, end_ea=ea + 0x40)
-        api_core.ida_funcs.get_func_name.side_effect = lambda ea: f"sub_{ea:x}"
         api_core.ida_nalt.get_tinfo.return_value = False
 
         first = api_core.func_query({"offset": 0, "count": 50})
         second = api_core.func_query({"offset": 0, "count": 50})
 
-        # Functions() iterated once; second call served from the query cache.
+        # Functions() iterated once (via the funcs cache); second call reuses it.
         assert api_core.idautils.Functions.call_count == 1
         assert first == second
         assert first[0]["data"][0]["addr"] == "0x1000"
-        # size_int is stripped from output.
+        # size_int is stripped from output; has_type is resolved per-row.
         assert "size_int" not in first[0]["data"][0]
+        assert first[0]["data"][0]["has_type"] is False
+
+    def test_func_query_does_not_scan_types_when_unfiltered(self, ida_mcp_modules):
+        """has_type must be resolved only for returned rows, not all functions."""
+        api_core, _ = ida_mcp_modules
+        api_core._funcs_cache = None
+        api_core._funcs_query_cache = None
+        api_core.idautils.Functions.return_value = list(range(0x1000, 0x1000 + 100))
+        api_core.ida_nalt.get_tinfo.reset_mock()
+        api_core.ida_nalt.get_tinfo.return_value = False
+
+        api_core.func_query({"offset": 0, "count": 5})
+
+        # Only the 5 returned rows get a get_tinfo call, not all 100 functions.
+        assert api_core.ida_nalt.get_tinfo.call_count == 5
 
     def test_func_query_cache_invalidated_with_funcs_cache(self, ida_mcp_modules):
         api_core, _ = ida_mcp_modules
         api_core._funcs_query_cache = [{"addr": "0xdead", "name": "x",
-                                        "size": "0x1", "size_int": 1, "has_type": False}]
+                                        "size": "0x1", "size_int": 1}]
         api_core.invalidate_funcs_cache()
         assert api_core._funcs_query_cache is None
 
     def test_func_query_sort_does_not_mutate_cache(self, ida_mcp_modules):
         api_core, _ = ida_mcp_modules
+        api_core._funcs_cache = None
         api_core._funcs_query_cache = None
         api_core.idautils.Functions.return_value = [0x2000, 0x1000]
-        api_core.idaapi.get_func.side_effect = lambda ea: SimpleNamespace(start_ea=ea, end_ea=ea + 0x40)
-        api_core.ida_funcs.get_func_name.side_effect = lambda ea: f"sub_{ea:x}"
         api_core.ida_nalt.get_tinfo.return_value = False
 
         api_core.func_query({"sort_by": "addr"})

--- a/tests/test_lazy_cache_init.py
+++ b/tests/test_lazy_cache_init.py
@@ -173,6 +173,43 @@ class TestApiCoreLazyCaches:
 
         assert getattr(api_core.refresh_caches, "__ida_mcp_timeout_sec__", None) == 120.0
 
+    def test_func_query_builds_cache_once(self, ida_mcp_modules):
+        api_core, _ = ida_mcp_modules
+        api_core._funcs_query_cache = None
+        api_core.idautils.Functions.return_value = [0x1000, 0x2000]
+        api_core.idaapi.get_func.side_effect = lambda ea: SimpleNamespace(start_ea=ea, end_ea=ea + 0x40)
+        api_core.ida_funcs.get_func_name.side_effect = lambda ea: f"sub_{ea:x}"
+        api_core.ida_nalt.get_tinfo.return_value = False
+
+        first = api_core.func_query({"offset": 0, "count": 50})
+        second = api_core.func_query({"offset": 0, "count": 50})
+
+        # Functions() iterated once; second call served from the query cache.
+        assert api_core.idautils.Functions.call_count == 1
+        assert first == second
+        assert first[0]["data"][0]["addr"] == "0x1000"
+        # size_int is stripped from output.
+        assert "size_int" not in first[0]["data"][0]
+
+    def test_func_query_cache_invalidated_with_funcs_cache(self, ida_mcp_modules):
+        api_core, _ = ida_mcp_modules
+        api_core._funcs_query_cache = [{"addr": "0xdead", "name": "x",
+                                        "size": "0x1", "size_int": 1, "has_type": False}]
+        api_core.invalidate_funcs_cache()
+        assert api_core._funcs_query_cache is None
+
+    def test_func_query_sort_does_not_mutate_cache(self, ida_mcp_modules):
+        api_core, _ = ida_mcp_modules
+        api_core._funcs_query_cache = None
+        api_core.idautils.Functions.return_value = [0x2000, 0x1000]
+        api_core.idaapi.get_func.side_effect = lambda ea: SimpleNamespace(start_ea=ea, end_ea=ea + 0x40)
+        api_core.ida_funcs.get_func_name.side_effect = lambda ea: f"sub_{ea:x}"
+        api_core.ida_nalt.get_tinfo.return_value = False
+
+        api_core.func_query({"sort_by": "addr"})
+        # Cache must remain in original Functions() order, not sorted order.
+        assert [r["addr"] for r in api_core._funcs_query_cache] == ["0x2000", "0x1000"]
+
 
 class TestApiModifyCacheInvalidation:
     def test_rename_invalidates_relevant_caches(self, ida_mcp_modules):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -369,3 +369,57 @@ class TestLoadEntryValidation:
         instances = reg.list_instances()
         assert "bad" not in instances
         assert "good" in instances
+
+
+# ---------------------------------------------------------------------------
+# In-process read cache
+# ---------------------------------------------------------------------------
+class TestReadCache:
+    def test_cached_read_skips_file_parse(self, populated_registry, monkeypatch):
+        # Prime the cache.
+        populated_registry.list_instances()
+
+        # Subsequent reads must not re-open the registry file.
+        def _boom(*args, **kwargs):
+            raise AssertionError("registry file re-opened on cached read")
+
+        monkeypatch.setattr(json, "load", _boom)
+        instances = populated_registry.list_instances()
+        assert len(instances) == 3
+        assert populated_registry.get_active() is not None
+
+    def test_returned_data_is_isolated_from_cache(self, populated_registry):
+        first = populated_registry.list_instances()
+        iid = next(iter(first))
+        first[iid]["binary_name"] = "mutated"
+
+        second = populated_registry.list_instances()
+        assert second[iid]["binary_name"] != "mutated"
+
+    def test_external_write_invalidates_cache(self, populated_registry):
+        populated_registry.list_instances()  # prime cache
+
+        # Simulate another process replacing the file (atomic write).
+        path = populated_registry.registry_path
+        data = {
+            "instances": {"ext1": _valid_entry(binary_name="external.exe")},
+            "active_instance": "ext1",
+            "expired": {},
+        }
+        tmp = path + ".ext"
+        with open(tmp, "w") as f:
+            json.dump(data, f)
+        os.replace(tmp, path)
+
+        instances = populated_registry.list_instances()
+        assert list(instances) == ["ext1"]
+        assert instances["ext1"]["binary_name"] == "external.exe"
+
+    def test_write_through_updates_cache(self, tmp_registry):
+        iid = tmp_registry.register(
+            pid=1, port=5000, idb_path="/a.i64",
+            binary_name="a.exe", host="127.0.0.1",
+        )
+        assert tmp_registry.get_instance(iid)["binary_name"] == "a.exe"
+        tmp_registry.unregister(iid)
+        assert tmp_registry.get_instance(iid) is None

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -173,3 +173,26 @@ class TestSendRequest:
                     "arguments": {"instance_id": iid}
                 })
         assert "error" in resp
+
+    def test_connection_closed_on_error(self, router_env):
+        """The socket must be released even when the request raises."""
+        _, router, _ = router_env
+        mock_conn = MagicMock()
+        mock_conn.request.side_effect = OSError("boom")
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            resp = router._send_request(
+                {"host": "127.0.0.1", "port": 7000}, "tools/call", {})
+        assert "error" in resp
+        mock_conn.close.assert_called_once()
+
+    def test_connection_closed_on_success(self, router_env):
+        _, router, _ = router_env
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"result": {"ok": True}}).encode()
+        mock_conn = MagicMock()
+        mock_conn.getresponse.return_value = mock_response
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
+            resp = router._send_request(
+                {"host": "127.0.0.1", "port": 7000}, "tools/call", {})
+        assert resp == {"ok": True}
+        mock_conn.close.assert_called_once()

--- a/tests/test_server_integration.py
+++ b/tests/test_server_integration.py
@@ -129,3 +129,38 @@ class TestProxiedTruncation:
         text = result["content"][0]["text"]
         assert "TRUNCATED" in text
         assert "cache_id" in text
+
+
+# ---------------------------------------------------------------------------
+# _schema_preserving_preview (module-level helper)
+# ---------------------------------------------------------------------------
+class TestSchemaPreservingPreview:
+    def test_small_value_returned_unchanged(self):
+        from ida_multi_mcp.server import _schema_preserving_preview
+        value = [1, 2, 3]
+        assert _schema_preserving_preview(value, 1000) is value
+
+    def test_list_truncated_to_budget(self):
+        from ida_multi_mcp.server import _schema_preserving_preview, _json_text
+        value = [{"name": f"func_{i:04d}", "addr": hex(0x400000 + i)} for i in range(500)]
+        result = _schema_preserving_preview(value, 1000)
+        assert isinstance(result, list)
+        assert 0 < len(result) < 500
+        assert len(_json_text(result)) <= 1000
+        # Items preserved verbatim, in order.
+        assert result == value[: len(result)]
+
+    def test_string_truncated(self):
+        from ida_multi_mcp.server import _schema_preserving_preview
+        assert _schema_preserving_preview("x" * 100, 10) == "x" * 10
+
+    def test_linear_not_quadratic(self):
+        """A large list must truncate quickly (was O(n^2) re-serialization)."""
+        import time
+        from ida_multi_mcp.server import _schema_preserving_preview
+        value = [{"k": i, "data": "y" * 50} for i in range(50_000)]
+        start = time.monotonic()
+        result = _schema_preserving_preview(value, 10_000)
+        elapsed = time.monotonic() - start
+        assert elapsed < 1.0
+        assert len(result) < len(value)

--- a/tests/test_server_integration.py
+++ b/tests/test_server_integration.py
@@ -103,6 +103,37 @@ class TestDecompileToFile:
         if "error" in structured:
             assert ".." in structured["error"]
 
+    def test_absolute_path_outside_cwd_rejected(self, server, tmp_path):
+        result = server._handle_decompile_to_file({
+            "output_dir": str(tmp_path),  # outside the project cwd
+            "instance_id": "x",
+            "addrs": ["0x1000"],
+        })
+        assert "error" in result
+        assert "current working directory" in result["error"]
+
+    def test_allow_outside_cwd_bypasses_check(self, server, tmp_path):
+        # With the opt-out, the cwd check passes; it then fails later for a
+        # different reason (no addresses), proving validation was bypassed.
+        result = server._handle_decompile_to_file({
+            "output_dir": str(tmp_path),
+            "allow_outside_cwd": True,
+            "instance_id": "x",
+            "addrs": [],
+        })
+        assert "error" in result
+        assert "current working directory" not in result["error"]
+
+    def test_cwd_relative_dir_accepted(self, server):
+        # "." resolves to cwd → passes the cwd guard, fails on no addresses.
+        result = server._handle_decompile_to_file({
+            "output_dir": ".",
+            "instance_id": "x",
+            "addrs": [],
+        })
+        assert "error" in result
+        assert "current working directory" not in result["error"]
+
 
 class TestProxiedTruncation:
     def test_response_truncation_and_caching(self, server):

--- a/tests/test_utils_pure.py
+++ b/tests/test_utils_pure.py
@@ -113,10 +113,23 @@ class TestBssSafeReads:
         load_map = {0x1000: True, 0x1001: False, 0x1002: True, 0x1003: False}
         value_map = {0x1000: 0x41, 0x1002: 0x43}
 
+        # Region has a BSS gap → bulk get_bytes returns None → slow path.
+        utils.ida_bytes.get_bytes.return_value = None
         utils.ida_bytes.is_loaded.side_effect = lambda ea: load_map.get(ea, False)
         utils.ida_bytes.get_byte.side_effect = lambda ea: value_map[ea]
 
         assert read_bytes_bss_safe(0x1000, 4) == b"A\x00C\x00"
+
+    def test_read_bytes_bss_safe_fast_path_when_loaded(self):
+        # Whole range loaded → single get_bytes call, no per-byte loop.
+        utils.ida_bytes.get_bytes.side_effect = None
+        utils.ida_bytes.get_bytes.return_value = b"ABCD"
+        utils.ida_bytes.get_byte.side_effect = AssertionError("slow path used")
+
+        assert read_bytes_bss_safe(0x1000, 4) == b"ABCD"
+
+    def test_read_bytes_bss_safe_zero_size(self):
+        assert read_bytes_bss_safe(0x1000, 0) == b""
 
     def test_read_int_bss_safe_returns_zero_for_unloaded_start(self):
         utils.ida_bytes.is_loaded.side_effect = lambda ea: False

--- a/tests/test_utils_pure.py
+++ b/tests/test_utils_pure.py
@@ -58,6 +58,7 @@ for _sub in _SUBMODULES:
 # The __init__.py imports of api_* etc. will hit our MagicMock stubs harmlessly.
 from ida_multi_mcp.ida_mcp.utils import (
     compact_whitespace,
+    get_function,
     parse_address,
     normalize_list_input,
     normalize_dict_list,
@@ -131,6 +132,29 @@ class TestBssSafeReads:
 
         assert read_int_bss_safe(0x3000, 8) == 0x1122334455667788
         utils.ida_bytes.get_qword.assert_called_once_with(0x3000)
+
+
+class TestGetFunction:
+    def test_mid_function_address_returns_canonical_start(self):
+        fn = MagicMock()
+        fn.start_ea = 0x401000
+        fn.end_ea = 0x401080
+        fn.get_name.return_value = "sub_401000"
+        utils.idaapi.get_func.return_value = fn
+
+        result = get_function(0x401034)  # address inside the function body
+
+        assert result["addr"] == "0x401000"
+        assert result["size"] == "0x80"
+
+    def test_missing_function_returns_none_when_not_raising(self):
+        utils.idaapi.get_func.return_value = None
+        assert get_function(0xDEAD, raise_error=False) is None
+
+    def test_missing_function_raises_by_default(self):
+        utils.idaapi.get_func.return_value = None
+        with pytest.raises(IDAError, match="No function found"):
+            get_function(0xDEAD)
 
 
 class TestCompactWhitespace:

--- a/tests/test_zeromcp_parity.py
+++ b/tests/test_zeromcp_parity.py
@@ -1,0 +1,81 @@
+"""Tests for the two zeromcp copies (vendor=stdio router, ida_mcp=HTTP plugin).
+
+The copies are intentionally separate (the router must not import IDA deps),
+but shared MCP behavior must stay mirrored. These tests pin the behaviors that
+were previously out of sync.
+"""
+
+import io
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from ida_multi_mcp.vendor.zeromcp import McpServer as VendorMcpServer
+
+
+# ---------------------------------------------------------------------------
+# stdio() oversized-line handling (router transport)
+# ---------------------------------------------------------------------------
+
+class TestStdioOversizedLine:
+    def test_oversized_line_returns_error_not_silent_drop(self):
+        srv = VendorMcpServer("test")
+        srv._STDIO_MAX_LINE = 16  # tiny limit for the test
+        oversized = b'{"jsonrpc":"2.0","method":"ping","id":1,"pad":"' + b"A" * 200 + b'"}\n'
+        stdin = io.BytesIO(oversized)
+        stdout = io.BytesIO()
+
+        srv.stdio(stdin=stdin, stdout=stdout)
+
+        out = stdout.getvalue()
+        # Client must receive a JSON-RPC error rather than nothing (which hangs it).
+        assert b"-32600" in out
+
+    def test_normal_line_dispatched(self):
+        srv = VendorMcpServer("test")
+        srv.registry.methods["ping"] = lambda: "pong"
+        stdin = io.BytesIO(b'{"jsonrpc":"2.0","method":"ping","id":1}\n')
+        stdout = io.BytesIO()
+
+        srv.stdio(stdin=stdin, stdout=stdout)
+
+        assert b"pong" in stdout.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# notifications/initialized parity
+# ---------------------------------------------------------------------------
+
+def _import_ida_mcp_zeromcp():
+    """Import the ida_mcp zeromcp copy with IDA modules stubbed."""
+    for name in ("idaapi", "ida_kernwin", "idc"):
+        sys.modules.setdefault(name, MagicMock())
+    # ida_multi_mcp.ida_mcp.__init__ eagerly imports IDA-dependent submodules;
+    # stub the package so only the zeromcp subpackage loads.
+    pkg = sys.modules.get("ida_multi_mcp.ida_mcp")
+    if pkg is None:
+        from pathlib import Path
+        root = Path(__file__).resolve().parents[1] / "src" / "ida_multi_mcp" / "ida_mcp"
+        pkg = types.ModuleType("ida_multi_mcp.ida_mcp")
+        pkg.__path__ = [str(root)]
+        sys.modules["ida_multi_mcp.ida_mcp"] = pkg
+    from ida_multi_mcp.ida_mcp.zeromcp.mcp import McpServer
+    return McpServer
+
+
+class TestNotificationsInitializedParity:
+    def test_vendor_registers_handler(self):
+        srv = VendorMcpServer("test")
+        assert "notifications/initialized" in srv.registry.methods
+
+    def test_ida_mcp_registers_handler(self):
+        McpServer = _import_ida_mcp_zeromcp()
+        srv = McpServer("test")
+        assert "notifications/initialized" in srv.registry.methods
+
+    def test_both_register_cancelled(self):
+        McpServer = _import_ida_mcp_zeromcp()
+        assert "notifications/cancelled" in VendorMcpServer("t").registry.methods
+        assert "notifications/cancelled" in McpServer("t").registry.methods


### PR DESCRIPTION
## Summary

Full-project audit (router core, in-IDA API layer, lifecycle/installer) surfaced performance and functional improvement opportunities. This PR addresses all of them, one commit per item, each with tests. **249 tests pass** (was 210 at baseline; +39 new tests).

The audit findings were independently verified against the code; two were down-scoped after analysis showed the original cost model or severity was overstated (HTTP keep-alive, zeromcp unification) — see notes below.

## Performance

- **Registry read cache** — every proxied tool call did 2–3 lock+parse cycles of `instances.json`; now served from an in-process cache keyed by a `(mtime_ns, size, ino)` signature, lock-free on hit.
- **`func_query` cache + scan dedup** — `func_query` rescanned all functions + `get_tinfo` per call; now uses a dedicated cache invalidated with the funcs cache. `func_profile` merged a double `XrefsTo` pass; `classify_functions` dropped a triple `get_func` call.
- **Linear list-preview truncation** — `_schema_preserving_preview` was O(n²) (re-serialized the whole prefix per item); now tracks a running budget.
- **`read_bytes_bss_safe` bulk read** — byte-by-byte loop up to 1 MB replaced with a single `get_bytes()` fast path (100–1000× on mapped reads), per-byte fallback only for BSS gaps.
- **CORS policy applied once** — was an `@idasync` IDA-main-thread round-trip per HTTP request (and applied one request late); now resolved at startup and on `/config` change.
- **In-process FileLock serialization** — same-process threads no longer busy-wait on the OS file lock.

## Functional / robustness

- **idalib stdout deadlock** — worker `stdout=PIPE` was never drained; once IDA output filled the pipe buffer the worker hung and was misdiagnosed as a readiness timeout. Now `DEVNULL`.
- **`get_function` canonical address** — returned the caller-supplied (mid-function) address instead of `fn.start_ea`.
- **HTTP fd leaks** — `conn.close()` was skipped on every error path in router/health/discovery calls; wrapped in `try/finally`.
- **Windows clean shutdown** — `proc.terminate()` (TerminateProcess) ran neither the SIGTERM handler nor atexit, leaving the IDB dirty. Added atexit + SIGBREAK in the worker and graceful `CTRL_BREAK_EVENT` termination in the manager.
- **zeromcp copies aligned** — ported the stdio oversized-request error (router was silently dropping → client hang) and the `notifications/initialized` handler; documented why the two copies are intentionally separate (router must stay IDA-free).
- **Windows zombie detection** — `is_process_alive` now checks `GetExitCodeProcess`/`STILL_ACTIVE`, not just `OpenProcess`.
- **`xrefs_to_field` pagination** — unbounded xref accumulation now bounded by `limit`/`more`.
- **`decompile_to_file` output_dir** — confined to the cwd subtree by default (LLM-generated args), with an explicit `allow_outside_cwd` opt-out.
- **Installer** — idempotent reinstall (skip identical, notify before replacing a customized entry); per-entry error resilience in the IDA filesystem scan; removed dead `Visual Studio 2022` config.

## Notes on down-scoped items

- **HTTP connection pooling/keep-alive** was evaluated and not adopted: the IDA-side server processes requests on IDA's single main thread and the headless worker is single-threaded (idalib isn't thread-safe), so a held-open keep-alive connection would block health pings and mark live instances stale. On localhost the TCP handshake cost is negligible vs IDA operation latency. The real bug there (fd leaks) was fixed instead.
- **zeromcp full unification** was not pursued: the router needs an IDA-free copy, so the duplication is structural. The genuinely-divergent live-path behaviors were aligned and the split documented with parity tests.

## Test plan

- `pytest tests/` → 249 passed, 4 skipped.
- New tests cover: registry cache (incl. external-write invalidation), linear preview, func_query cache/no-mutation, HTTP fd-close on error, graceful termination (incl. Windows CTRL_BREAK), zeromcp parity, CORS mapping, Windows zombie detection, FileLock thread non-overlap, bss fast path, output_dir confinement, installer idempotency/replace-notify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verification against a real 150K-function binary (Client_dump.exe)

Exercising the tools against a real, very large target surfaced one gap the unit tests missed and confirmed a fix was needed:

- **`func_query` timed out on large binaries.** The committed cache still called `get_tinfo()` for every function on first access — an O(n) IDA scan that exceeds the 15s tool timeout on a 150K-function target. Fixed: the query cache now derives from the already-warm `_funcs_cache` (no per-function IDA calls), and `has_type` is resolved lazily only for the rows actually returned (or the narrowed candidate set when filtering on it), plus a 60s safety-net timeout.
- Confirmed `get_function` returned a mid-function (call-site) address rather than the function entry on the deployed build — the exact bug fixed by `52e953d` — validating that fix against real data.
- `list_funcs`, `xrefs_to`, `get_bytes`, `callees`, `classify_functions`, and `decompile` all behave correctly on the target.

Note: the IDA plugin and MCP server must be reloaded/restarted to load this branch; the running instances were verified to be on the pre-change build.

## Installer reinstall stability (additional hardening)

Beyond the idempotency/notify work, the installer now tolerates a broad set of exceptional situations without crashing or aborting the whole run — each bad client is skipped and the rest proceed:

- Unreadable config (permissions, or a directory where a file is expected).
- A config that parses to a non-dict (e.g. a top-level JSON array) — skipped, file left untouched.
- A `mcpServers` (or intermediate key like VS Code's `mcp`) that exists but isn't a dict — skipped instead of corrupted.
- `makedirs` / `mkstemp` failures (read-only dir, config_dir is a file, disk full).
- A write failure no longer re-raises and aborts the remaining clients; temp files are cleaned up on every failure path.
