### PR TITLE
feat: serve partial similar_functions() results during index builds

### DIFF
--- a/docs/superpowers/plans/2026-07-08-incremental-similarity-indexing-plan.md
+++ b/docs/superpowers/plans/2026-07-08-incremental-similarity-indexing-plan.md
@@ -1,0 +1,859 @@
+# Incremental / Partial Function-Similarity Indexing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Note for this run**: tasks are executed sequentially in the main session (not fresh subagents per task) because every task edits the same tightly-coupled closures in one file (`_start_background`/`_on_page`/`_run`/`_load_partial`/`similar_functions`) — parallel/isolated-worktree execution would conflict. Use `superpowers:executing-plans`'s batch-with-checkpoints style, run inline.
+
+**Goal:** Let `similar_functions()` serve results against whatever a background `index_functions()` build has processed so far, instead of returning `not_indexed` until the entire binary is done.
+
+**Architecture:** No new files, no new persisted formats. Tag each background build with a monotonic generation counter; expose its growing (in-place-mutated) `records` list on the job dict; add a debounced (2s TTL) helper that reuses the existing from-scratch `_assemble_index`/`build_anchor_index` functions over that list to build an ephemeral partial index on demand; wire it into `similar_functions()` as a fallback when no persisted index exists yet; clear the heavy state on completion; bound (not eliminate) exposure to a mid-build binary swap with a periodic fingerprint recheck.
+
+**Tech Stack:** Python 3.11+, stdlib only (`threading`, `itertools`, `time`) — no new dependencies. Tests: `unittest` (matches `tests/test_similarity.py`'s existing style, no pytest-specific features used).
+
+## Global Constraints
+
+- Zero new runtime dependencies (`pyproject.toml: dependencies = []` stays empty) — spec §Approach.
+- No new files, no new persisted index/sidecar formats — spec §Approach, §Non-goals.
+- `sim_score.py` and `index_store.py` are **not modified** — every partial-index computation reuses the existing from-scratch functions unchanged — spec §v1→v2 point 3, §Approach.
+- All new/modified shared-state access goes through the existing `_jobs_lock` — no new locks — spec throughout.
+- Every `_jobs[iid]` mutation or trust-based read after doing work off-lock must re-check `job.get("gen") == gen` (and `status` where noted) before acting — spec §v2→v3 finding 1, §Approach §1/§2/§4.
+- Full existing test suite (`pytest tests/` or `python -m unittest discover tests`) must stay green throughout — the final-index code path (`_assemble_index`, `write_index`) must remain byte-for-byte the same as today for any completed (non-error, non-superseded) build — spec §Testing.
+- Design spec of record: `docs/superpowers/specs/2026-07-08-incremental-similarity-indexing-design.md` (§Approach (v3) is authoritative for exact code shape; this plan mirrors it 1:1, including its post-review fix to `_load_partial`'s status check).
+- Line numbers cited in `Files:` blocks (e.g. `similarity.py:487-592`) are from the file's state **before this plan's edits**. Because Task 1 and Task 2 add code above `similar_functions`, later tasks' actual line numbers will have shifted down by the time you reach them — locate code by the shown before/after snippets (exact string match) via each step's own `Before:`/`After:` blocks, not by re-trusting a stale line number.
+
+---
+
+## File Structure
+
+- **Modify**: `src/ida_multi_mcp/tools/similarity.py` — all production code changes live here (module already owns `_jobs`, `_start_background`, `_load`, `similar_functions`).
+- **Modify**: `tests/test_similarity.py` — extend with a `PausableRouter` test double (semaphore-gated page delivery, needed to deterministically pause a background build mid-page) and a new `PartialIndexTest` test class. No other file changes.
+
+---
+
+## Task 1: Instrument the background build — generation counter, live records, completion cleanup, bounded binary-change guard
+
+**Files:**
+- Modify: `src/ida_multi_mcp/tools/similarity.py:10-17` (imports), `:356-414` (`_start_background`/`_on_page`/`_run`)
+- Test: `tests/test_similarity.py` (new `PausableRouter` class + new `PartialIndexTest` class)
+
+**Interfaces:**
+- Produces: `_jobs[iid]["gen"]` (int, monotonic per build), `_jobs[iid]["live_records"]` (the same `list` object `_build_records` is appending to — present once the first page lands, absent before), `_jobs[iid]["pages_seen"]` (int, count of pages processed by this build). On successful completion, `live_records`/`pages_seen`/`_partial_cache` (added in Task 2) are popped. `_FP_CHECK_EVERY_N_PAGES` (module constant, default 20, env-overridable via `IDA_MCP_SIM_FP_CHECK_EVERY_N_PAGES`) controls how often (in pages) a mid-build binary-fingerprint mismatch is detected; on mismatch, the job's `status` flips to `"error"` with a descriptive message, the page loop stops, and — new in this task — the final `_assemble_index`/`write_index` call is **skipped** (a build that errored or was superseded must never persist a final index from records it no longer trusts).
+- Consumes: existing `_jobs_lock`, `_instance_key`, `_build_records`, `_assemble_index`, `index_store.write_index`, `index_store.clear_vectors`, `_invalidate_cache`, `_valid_records` — all unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_similarity.py`, at the **end of the file**, after `class SimilarityErrorRecordTest` and before the `if __name__ == "__main__":` block — mirroring the file's existing convention of a helper class (`_ErrRouter`) immediately preceding the `TestCase` that uses it:
+
+```python
+def _wait_until(predicate, timeout=5.0, interval=0.01):
+    """Poll `predicate()` until truthy or `timeout` elapses; raise on timeout.
+
+    The background build genuinely runs on a separate thread (that is the
+    behavior under test), so tests synchronize on job-state, not sleeps.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+    raise AssertionError(f"condition not met within {timeout}s")
+
+
+class PausableRouter:
+    """Serves func_features / binary_fingerprint like MockRouter, but each
+    '*' (paginated) func_features call blocks on a counting semaphore until
+    the test calls release_pages(n) — lets tests pause a background build
+    mid-page and inspect/exercise partial state deterministically. Optional
+    swap_after_pages flips the fingerprint after that many pages have been
+    served, simulating a mid-build binary change.
+    """
+
+    def __init__(self, corpus):
+        self._corpus = corpus
+        self._budget = threading.Semaphore(0)
+        self.pages_served = 0
+        self.swap_after_pages = None
+        self._swapped = False
+
+    def release_pages(self, n):
+        for _ in range(n):
+            self._budget.release()
+
+    def route_request(self, method, params):
+        name = params.get("name")
+        args = params.get("arguments", {})
+        iid = args.get("instance_id")
+        feats = self._corpus.get(iid)
+        if feats is None:
+            return {"error": f"no instance {iid}"}
+        if name == "binary_fingerprint":
+            sha = f"sha-{iid}-swapped" if self._swapped else f"sha-{iid}"
+            payload = {"sha256": sha, "md5": None,
+                       "function_count": len(feats), "arch": "x86_64"}
+        elif name == "func_features":
+            addrs = args.get("addrs", "*")
+            if addrs == "*":
+                self._budget.acquire()
+                self.pages_served += 1
+                if (self.swap_after_pages is not None
+                        and self.pages_served > self.swap_after_pages):
+                    self._swapped = True
+                offset = int(args.get("offset", 0))
+                count = int(args.get("count", 500))
+                page = feats[offset:offset + count]
+                nxt = offset + len(page)
+                cursor = {"done": True} if nxt >= len(feats) else {"next": nxt}
+                payload = {"functions": page, "total": len(feats), "cursor": cursor}
+            else:
+                match = [f for f in feats if f["addr"] == str(addrs) or f["name"] == str(addrs)]
+                payload = {"functions": match[:1], "total": len(match),
+                           "cursor": {"done": True}}
+        else:
+            return {"error": f"unknown tool {name}"}
+        return {"content": [{"type": "text", "text": json.dumps(payload)}],
+                "structuredContent": payload}
+
+
+class PartialIndexTest(unittest.TestCase):
+    """Background-build instrumentation, partial-serving, and their race/edge
+    cases. Uses PausableRouter to deterministically pause a build mid-page —
+    real threading is exercised (this is the behavior under test), so tests
+    synchronize on `_jobs` state via `_wait_until`, never on sleeps alone.
+    """
+
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self._registry_path = os.path.join(self._td.name, "instances.json")
+        self._corpus = {"aaaa": _corpus()["aaaa"]}   # 6 functions
+        self._router = PausableRouter(self._corpus)
+        similarity.set_registry(MockRegistry(self._registry_path, self._corpus))
+        similarity.set_router(self._router)
+        similarity._jobs.clear()
+        similarity._loaded.clear()
+        self._orig_page = similarity.PAGE
+        similarity.PAGE = 2   # 6 functions / 2-per-page = 3 pages, so tests can pause mid-build
+
+    def tearDown(self):
+        similarity.PAGE = self._orig_page
+        similarity._jobs.clear()
+        similarity._loaded.clear()
+        self._td.cleanup()
+
+    def test_background_build_exposes_gen_and_live_records(self):
+        res = similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self.assertEqual(res["status"], "building")
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+
+        job = similarity._jobs["aaaa"]
+        self.assertIsInstance(job["gen"], int)
+        self.assertEqual(len(job["live_records"]), 2)   # exactly page 1's functions
+        self.assertEqual(job["status"], "building")
+
+        self._router.release_pages(2)   # let the remaining 2 pages through
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+        self.assertEqual(similarity._jobs["aaaa"]["pages_seen"], 3)
+
+    def test_completion_clears_live_records_and_partial_cache(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(3)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+        job = similarity._jobs["aaaa"]
+        self.assertNotIn("live_records", job)
+        self.assertNotIn("_partial_cache", job)
+
+    def test_binary_change_mid_build_stops_and_does_not_persist(self):
+        orig_key, _ = similarity._instance_key("aaaa")   # fingerprint BEFORE any swap
+        orig_n = similarity._FP_CHECK_EVERY_N_PAGES
+        similarity._FP_CHECK_EVERY_N_PAGES = 1   # check every page for a deterministic test
+        self._router.swap_after_pages = 1        # fingerprint flips once page 2 is requested
+        try:
+            similarity.index_functions({"instance_id": "aaaa", "background": True})
+            self._router.release_pages(3)
+            _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "error")
+        finally:
+            similarity._FP_CHECK_EVERY_N_PAGES = orig_n
+
+        job = similarity._jobs["aaaa"]
+        self.assertIn("binary changed", job["error"])
+        self.assertLessEqual(job["pages_seen"], 2)   # detected within the checked bound
+        rp = similarity._registry_path()
+        self.assertFalse(index_store.has_index(orig_key, rp),
+                          "an error/superseded build must not persist a final index")
+```
+
+Add these two imports at the top of `tests/test_similarity.py` (alongside the existing `import os`/`sys`/`tempfile`/`unittest`):
+```python
+import threading
+import time
+```
+And add this import alongside the existing `from ida_multi_mcp.tools import sim_score, similarity`:
+```python
+from ida_multi_mcp.tools import index_store, sim_score, similarity  # noqa: E402
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/merozemory/projects/MeroZemory/ida-multi-mcp
+python -m pytest tests/test_similarity.py::PartialIndexTest -v
+```
+Expected: all three `PartialIndexTest` tests FAIL — `test_background_build_exposes_gen_and_live_records` and `test_completion_clears_live_records_and_partial_cache` with `KeyError: 'gen'` (or similar, since `_jobs[iid]` doesn't have `gen`/`live_records`/`pages_seen` yet); `test_binary_change_mid_build_stops_and_does_not_persist` with the job never reaching `status == "error"` (times out in `_wait_until`, since there is no fingerprint-recheck yet).
+
+- [ ] **Step 3: Implement**
+
+In `src/ida_multi_mcp/tools/similarity.py`, add `itertools` to the imports (`:12`, alphabetical):
+```python
+import hashlib
+import itertools
+import json
+import os
+import threading
+import time
+```
+
+Add the new module-level constants right after `PAGE = int(os.environ.get("IDA_MCP_SIM_PAGE", "500"))` (`:33`):
+```python
+PAGE = int(os.environ.get("IDA_MCP_SIM_PAGE", "500"))
+
+# Monotonic build-generation counter: next()'d only while holding _jobs_lock,
+# in _start_background. Lets in-flight work (e.g. _load_partial, Task 2) tell
+# whether the job it read from is still the one it started with, so a slow
+# write-back from a superseded/finished build can never clobber newer state.
+_gen_counter = itertools.count()
+
+# How often (in pages) a background build re-verifies the instance's binary
+# fingerprint still matches the one it started with. Every page would add a
+# routed IDA round-trip per page (~262 for a 130K-function binary) contending
+# with func_features calls on the same single-threaded IDA main thread; this
+# bounds (does not eliminate) the window during which a mid-build binary swap
+# can produce results attributed to the wrong binary. See design spec §5.
+_FP_CHECK_EVERY_N_PAGES = int(os.environ.get("IDA_MCP_SIM_FP_CHECK_EVERY_N_PAGES", "20"))
+```
+
+Replace `_start_background` (`:356-414`) in full:
+```python
+def _start_background(iid: str, key: str, fp: dict, binary_name: str,
+                      rp: str | None, features_ready: bool = False) -> dict:
+    with _jobs_lock:
+        existing = _jobs.get(iid)
+        if existing and existing.get("status") == "building":
+            return {"index_id": key, "status": "building",
+                    "progress": existing.get("progress", 0.0), "note": "already building"}
+        if existing and existing.get("embed_status") == "embedding":
+            return {"index_id": key, "status": "ready", "embed_status": "embedding",
+                    "embed_done": existing.get("embed_done", 0),
+                    "embed_total": existing.get("embed_total", 0), "note": "already embedding"}
+        gen = next(_gen_counter)
+        _jobs[iid] = {"status": "ready" if features_ready else "building",
+                      "progress": 1.0 if features_ready else 0.0,
+                      "cancel": False, "error": None, "key": key,
+                      "gen": gen, "pages_seen": 0}
+
+    def _on_page(recs: list, total: int) -> bool:
+        with _jobs_lock:
+            job = _jobs.get(iid)
+            if job is None or job.get("gen") != gen:
+                return False   # a newer build superseded this one; stop
+            if total:
+                job["progress"] = min(len(recs) / total, 0.999)
+            job.setdefault("live_records", recs)   # same list object every call; no-op after page 1
+            job["pages_seen"] = n = job.get("pages_seen", 0) + 1
+            if job.get("cancel"):
+                return False
+        if n % _FP_CHECK_EVERY_N_PAGES == 0:
+            cur_key, _ = _instance_key(iid)
+            if cur_key != key:
+                with _jobs_lock:
+                    j = _jobs.get(iid)
+                    if j is not None and j.get("gen") == gen:
+                        j.update(status="error",
+                                 error=f"binary changed mid-build (was {key[:12]}…, now "
+                                       f"{cur_key[:12] if cur_key else '?'}…)")
+                return False
+        return True
+
+    def _run() -> None:
+        try:
+            if not features_ready:
+                index_store.clear_vectors(key, rp)   # fresh build -> fresh vectors
+                records = _build_records(iid, _on_page)
+                with _jobs_lock:
+                    job = _jobs.get(iid)
+                    superseded_or_errored = (
+                        job is None or job.get("gen") != gen or job.get("status") == "error"
+                    )
+                if superseded_or_errored:
+                    # _on_page stopped the loop (supersession, cancel, or a
+                    # detected binary-change mismatch) -- the collected
+                    # `records` are not trustworthy as a final index and must
+                    # not be persisted. Whatever partial results were already
+                    # served stay served (error path keeps live_records); we
+                    # just skip turning them into a bogus final write.
+                    return
+                index = _assemble_index(records, key, binary_name, fp)
+                index_store.write_index(index, rp)
+                _invalidate_cache(key)
+                valid_addrs = [r["addr"] for r in _valid_records(records)]
+                with _jobs_lock:
+                    job = _jobs.get(iid)
+                    if job is not None and job.get("gen") == gen:
+                        job.pop("live_records", None)
+                        job.pop("_partial_cache", None)
+                        job.update(status="ready", progress=1.0,
+                                  function_count=index["function_count"],
+                                  skipped_count=index["skipped_count"])
+            else:  # features already on disk -> resume embedding only
+                idx = index_store.read_index(key, rp) or {}
+                valid_addrs = list(idx.get("functions", {}).keys())
+                with _jobs_lock:
+                    _jobs[iid].update(status="ready", progress=1.0,
+                                      function_count=idx.get("function_count", len(valid_addrs)))
+            # Phase 2: neural vectors accrue in the background (non-blocking).
+            if _neural_enabled():
+                with _jobs_lock:
+                    _jobs[iid].update(embed_status="embedding",
+                                      embed_total=len(valid_addrs), embed_done=0)
+                _embed_incremental(iid, key, rp, valid_addrs)
+                with _jobs_lock:
+                    if not _jobs[iid].get("cancel"):
+                        _jobs[iid].update(embed_status="done")
+        except Exception as exc:  # noqa: BLE001 - report, don't crash the thread
+            with _jobs_lock:
+                _jobs[iid].update(status="error", error=str(exc))
+
+    threading.Thread(target=_run, daemon=True).start()
+    return {"index_id": key,
+            "status": "ready" if features_ready else "building",
+            "progress": 1.0 if features_ready else 0.0,
+            "embed_status": "embedding" if _neural_enabled() else None,
+            "background": True}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+python -m pytest tests/test_similarity.py::PartialIndexTest -v
+python -m pytest tests/test_similarity.py -v   # existing tests must still pass unchanged
+```
+Expected: all `PartialIndexTest` tests PASS; every pre-existing test in the file still PASSES (the `not features_ready` branch's final behavior for a normal, uninterrupted build is unchanged — same `_assemble_index`/`write_index` call, same returned dict shape, just gated by the new `superseded_or_errored` check which is `False` in the normal case).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ida_multi_mcp/tools/similarity.py tests/test_similarity.py
+git commit -m "feat: track build generation, expose live records, bound binary-change exposure
+
+Tags each background similarity-index build with a monotonic generation,
+stashes a reference to its growing records list on the job, clears that
+state on completion, and periodically re-verifies the binary fingerprint
+mid-build so a swap is caught (bounded window) instead of silently
+corrupting the final index. Lays the groundwork for serving partial
+similar_functions() results while a build is still in progress."
+```
+
+---
+
+## Task 2: `_load_partial()` — debounced ephemeral partial index
+
+**Files:**
+- Modify: `src/ida_multi_mcp/tools/similarity.py` (new function, placed after `_load`, `:458-472`)
+- Test: `tests/test_similarity.py` (extend `PartialIndexTest`)
+
+**Interfaces:**
+- Consumes: `_jobs`, `_jobs_lock` (from Task 1: `gen`, `live_records`, `status`), `_instance_key`, `_registry.get_instance`, `_assemble_index`, `sim_score.build_anchor_index` — all unchanged/existing.
+- Produces: `_load_partial(iid: str) -> dict | None`. Returns `None` if no build is running or has ever errored for `iid` (`_jobs.get(iid)` absent or `status` not in `("building", "error")`) or if no page has landed yet (`live_records` absent/empty). Otherwise returns the same shape `_load()` produces: `{"index": <dict with functions/df/zstats/lsh/function_count/...>, "anchor_index": <dict>}`, built from whatever `live_records` currently holds, debounced for `_PARTIAL_TTL_S` seconds (module constant, default 2.0, env `IDA_MCP_SIM_PARTIAL_TTL_S`) via `_jobs[iid]["_partial_cache"]`. The `"error"` status is included deliberately: `_run()`'s error handler (unchanged) leaves `live_records` in place specifically so the last-known-good partial data keeps being served after a build stalls, per the design spec §4 — an errored job's `live_records` are frozen (the build will not progress further under that `gen`), so caching a computed snapshot of them is always safe.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `PartialIndexTest` in `tests/test_similarity.py`:
+
+```python
+    def test_load_partial_returns_none_with_no_build(self):
+        self.assertIsNone(similarity._load_partial("aaaa"))
+
+    def test_load_partial_reflects_pages_seen_so_far(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+
+        entry = similarity._load_partial("aaaa")
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry["index"]["function_count"], 2)
+        self.assertIn("anchor_index", entry)
+
+        self._router.release_pages(2)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+
+    def test_load_partial_returns_none_once_build_completes(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(3)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+        self.assertIsNone(similarity._load_partial("aaaa"))
+
+    def test_load_partial_debounces_within_ttl(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+
+        first = similarity._load_partial("aaaa")
+        second = similarity._load_partial("aaaa")
+        self.assertIs(first, second, "within the TTL, the cached entry object must be reused")
+
+        self._router.release_pages(2)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+
+    def test_load_partial_still_serves_after_build_errors(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+        # Force the job into "error" directly (grey-box) rather than staging a
+        # real IDA-call failure -- isolates the status-gate behavior under test.
+        with similarity._jobs_lock:
+            similarity._jobs["aaaa"]["status"] = "error"
+            similarity._jobs["aaaa"]["error"] = "synthetic failure for this test"
+
+        entry = similarity._load_partial("aaaa")
+        self.assertIsNotNone(entry, "an errored build's last-known partial data must stay servable")
+        self.assertEqual(entry["index"]["function_count"], 2)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+python -m pytest tests/test_similarity.py::PartialIndexTest -v -k load_partial
+```
+Expected: all five FAIL with `AttributeError: module 'ida_multi_mcp.tools.similarity' has no attribute '_load_partial'`.
+
+- [ ] **Step 3: Implement**
+
+In `src/ida_multi_mcp/tools/similarity.py`, add the TTL constant next to `_FP_CHECK_EVERY_N_PAGES` (added in Task 1):
+```python
+_FP_CHECK_EVERY_N_PAGES = int(os.environ.get("IDA_MCP_SIM_FP_CHECK_EVERY_N_PAGES", "20"))
+_PARTIAL_TTL_S = float(os.environ.get("IDA_MCP_SIM_PARTIAL_TTL_S", "2.0"))
+```
+
+Add `_load_partial` immediately after `_load` (after `:472`, before `_cap_candidates`):
+```python
+def _load_partial(iid: str) -> dict | None:
+    """Ephemeral, debounced index+anchor_index entry from a build in progress
+    (or one that errored, serving its last-known-good state).
+
+    Reuses the exact from-scratch functions `_assemble_index`/`build_anchor_index`
+    already used for the final index, over whatever the background thread has
+    accumulated so far (`_jobs[iid]["live_records"]`, Task 1). Returns None if
+    no build is running/errored for `iid`, or none of its pages have landed yet.
+    """
+    with _jobs_lock:
+        job = _jobs.get(iid)
+        if not job or job.get("status") not in ("building", "error"):
+            return None
+        gen = job.get("gen")
+        recs = job.get("live_records")
+        cached = job.get("_partial_cache")
+    if not recs:
+        return None
+    now = time.time()
+    if cached and cached.get("gen") == gen and now - cached["at"] < _PARTIAL_TTL_S:
+        return cached["entry"]
+    key, fp = _instance_key(iid)
+    if not key:
+        return None
+    info = (_registry.get_instance(iid) or {}) if _registry else {}
+    idx = _assemble_index(list(recs), key, info.get("binary_name", ""), fp)
+    funcs = list(idx["functions"].values())
+    entry = {"index": idx, "anchor_index": sim_score.build_anchor_index(funcs)}
+    with _jobs_lock:
+        j = _jobs.get(iid)
+        # Only cache back if this is STILL the same build (gen match) and
+        # still in a state we're allowed to serve. A build that finished or
+        # was superseded by a NEWER generation while we were off the lock
+        # computing `entry` must not have its (now-stale, and for a finished
+        # build, un-freed) result written back. The caller still gets the
+        # freshly-computed `entry` for THIS call either way; only the cache
+        # write is conditional. See design spec §v2->v3 finding 1 and the
+        # "Post-review fix" note (error status must remain servable).
+        if j is not None and j.get("gen") == gen and j.get("status") in ("building", "error"):
+            j["_partial_cache"] = {"at": now, "gen": gen, "entry": entry}
+    return entry
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+python -m pytest tests/test_similarity.py::PartialIndexTest -v
+python -m pytest tests/test_similarity.py -v
+```
+Expected: all `PartialIndexTest` tests PASS (8 so far); all pre-existing tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ida_multi_mcp/tools/similarity.py tests/test_similarity.py
+git commit -m "feat: add debounced ephemeral partial-index loader
+
+_load_partial() reuses the existing from-scratch _assemble_index /
+build_anchor_index functions over a build's in-progress records, cached
+for 2s so repeated queries during a build don't each pay the assembly
+cost. Not wired into similar_functions() yet."
+```
+
+---
+
+## Task 3: Completion-race regression — `_load_partial`'s write-back must not resurrect cleared state
+
+**Files:**
+- Test only: `tests/test_similarity.py` (extend `PartialIndexTest`) — no production code change; this task proves Task 1 + Task 2's gen-guard actually closes the race the design spec calls out (§v2→v3 finding 1).
+
+**Interfaces:**
+- Consumes: `similarity._assemble_index` (monkeypatched for one call to make the race window observable and deterministic), `similarity._load_partial`, `similarity._jobs`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `PartialIndexTest`:
+```python
+    def test_load_partial_write_back_does_not_resurrect_cleared_state(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+
+        entered = threading.Event()
+        resume = threading.Event()
+        real_assemble = similarity._assemble_index
+        call_count = {"n": 0}
+
+        def blocking_assemble(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                entered.set()
+                resume.wait(timeout=5)
+            return real_assemble(*args, **kwargs)
+
+        similarity._assemble_index = blocking_assemble
+        try:
+            t = threading.Thread(target=similarity._load_partial, args=("aaaa",))
+            t.start()
+            self.assertTrue(entered.wait(timeout=5), "_load_partial did not reach _assemble_index")
+
+            # While _load_partial is blocked mid-computation, let the REAL
+            # background build finish (its own _assemble_index call is #2,
+            # which passes straight through).
+            self._router.release_pages(2)
+            _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+
+            resume.set()   # let _load_partial's blocked call proceed and try to write back
+            t.join(timeout=5)
+        finally:
+            similarity._assemble_index = real_assemble
+
+        job = similarity._jobs["aaaa"]
+        self.assertNotIn("live_records", job)
+        self.assertNotIn("_partial_cache", job,
+                          "a stale write-back must not resurrect cleared partial state")
+```
+
+- [ ] **Step 2: Run test to verify it fails against a naive (unguarded) implementation**
+
+This test validates the guard already implemented in Task 2. Run it now to confirm it PASSES against the real implementation:
+```bash
+python -m pytest tests/test_similarity.py::PartialIndexTest::test_load_partial_write_back_does_not_resurrect_cleared_state -v
+```
+Expected: PASS. (If you want to see it fail first to prove it's a real regression guard, temporarily remove the `j.get("gen") == gen and j.get("status") == "building"` condition in `_load_partial`'s write-back — replace with `if j is not None:` — rerun, observe FAIL with `AssertionError: '_partial_cache' unexpectedly found`, then restore the real condition.)
+
+- [ ] **Step 3: N/A — no implementation step, this task is regression coverage for Task 2's existing guard.**
+
+- [ ] **Step 4: Run full test file to confirm no regressions**
+
+```bash
+python -m pytest tests/test_similarity.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_similarity.py
+git commit -m "test: regression-cover the _load_partial completion-race guard
+
+Proves _load_partial's gen+status re-check before writing _partial_cache
+back actually prevents a slow, in-flight computation from resurrecting
+memory that the completing build already cleared."
+```
+
+---
+
+## Task 4: Retry/generation regression — a superseded build's write-back must not leak into the new one
+
+**Files:**
+- Test only: `tests/test_similarity.py` (extend `PartialIndexTest`).
+
+**Interfaces:**
+- Consumes: `similarity._jobs`, `similarity._jobs_lock`, `similarity._load_partial`, `similarity._assemble_index` (monkeypatched).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `PartialIndexTest`:
+```python
+    def test_load_partial_write_back_respects_generation_bump(self):
+        # Directly inject a "building" job (grey-box) so this test isolates
+        # the gen-mismatch guard itself, rather than staging a full realistic
+        # error-then-retry sequence (which would be racy/slow to set up).
+        similarity._jobs["aaaa"] = {
+            "status": "building", "gen": 1,
+            "live_records": _corpus()["aaaa"][:2],
+        }
+
+        entered = threading.Event()
+        resume = threading.Event()
+        real_assemble = similarity._assemble_index
+
+        def blocking_assemble(*args, **kwargs):
+            entered.set()
+            resume.wait(timeout=5)
+            return real_assemble(*args, **kwargs)
+
+        similarity._assemble_index = blocking_assemble
+        try:
+            t = threading.Thread(target=similarity._load_partial, args=("aaaa",))
+            t.start()
+            self.assertTrue(entered.wait(timeout=5))
+
+            # Simulate a retried build superseding this one (a fresh
+            # _start_background call always bumps gen -- Task 1).
+            with similarity._jobs_lock:
+                similarity._jobs["aaaa"]["gen"] = 2
+
+            resume.set()
+            t.join(timeout=5)
+        finally:
+            similarity._assemble_index = real_assemble
+
+        self.assertIsNone(similarity._jobs["aaaa"].get("_partial_cache"),
+                           "a write-back for a superseded generation must be dropped")
+```
+
+- [ ] **Step 2: Run test to verify it passes against the real implementation**
+
+```bash
+python -m pytest tests/test_similarity.py::PartialIndexTest::test_load_partial_write_back_respects_generation_bump -v
+```
+Expected: PASS (Task 2's `j.get("gen") == gen` check already covers this).
+
+- [ ] **Step 3: N/A — regression coverage only, no implementation change.**
+
+- [ ] **Step 4: Run full test file**
+
+```bash
+python -m pytest tests/test_similarity.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_similarity.py
+git commit -m "test: regression-cover _load_partial's generation-mismatch write guard"
+```
+
+---
+
+## Task 5: Wire `_load_partial` into `similar_functions()` — `partial` + `coverage`
+
+**Files:**
+- Modify: `src/ida_multi_mcp/tools/similarity.py:487-592` (`similar_functions`)
+- Test: `tests/test_similarity.py` (extend `PartialIndexTest`)
+
+**Interfaces:**
+- Produces: `similar_functions()`'s return dict gains `"partial": True` and `"coverage": {instance_id: {"done": int, "total": None}}` when any gallery instance was served from `_load_partial` instead of a persisted index. `coverage[giid]["done"]` is read from the exact `entry["index"]["function_count"]` used to score that instance's candidates — never a second, separately-timed lookup (design spec §v2→v3 finding 3).
+- Consumes: `_load` (unchanged), `_load_partial` (Task 2).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `PartialIndexTest`:
+```python
+    def test_similar_functions_serves_partial_results_mid_build(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)   # page 1 = addrs 0x1001, 0x1002 (the encrypt twins)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+
+        out = similarity.similar_functions({"instance_id": "aaaa", "func": "0x1001", "top_k": 5})
+        self.assertTrue(out.get("partial"))
+        self.assertEqual(out["coverage"]["aaaa"]["done"], 2)
+        self.assertIsNone(out["coverage"]["aaaa"]["total"])
+        addrs = [r["addr"] for r in out["results"]]
+        self.assertIn("0x1002", addrs)          # its twin landed in page 1
+        for a in addrs:
+            self.assertIn(a, ("0x1001", "0x1002"))   # nothing from later pages
+
+        self._router.release_pages(2)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+
+        out2 = similarity.similar_functions({"instance_id": "aaaa", "func": "0x1001", "top_k": 5})
+        self.assertFalse(out2.get("partial", False))
+        self.assertNotIn("coverage", out2)
+
+    def test_similar_functions_query_not_yet_covered_does_not_crash(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)   # page 1 only has 0x1001/0x1002
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+
+        # 0x1005 ("misc_z") is in page 3, not yet processed by the background
+        # loop -- but func_features resolves single-address queries directly
+        # (unrelated to the paginated '*' gate), so this must not crash.
+        out = similarity.similar_functions({"instance_id": "aaaa", "func": "0x1005", "top_k": 5})
+        self.assertNotIn("error", out)
+        self.assertTrue(out.get("partial"))
+        self.assertEqual(out["query"]["addr"], "0x1005")
+
+        self._router.release_pages(2)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+
+    def test_similar_functions_serves_partial_after_build_error(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+        with similarity._jobs_lock:
+            similarity._jobs["aaaa"]["status"] = "error"
+            similarity._jobs["aaaa"]["error"] = "synthetic failure for this test"
+
+        out = similarity.similar_functions({"instance_id": "aaaa", "func": "0x1001", "top_k": 5})
+        self.assertTrue(out.get("partial"))
+        self.assertNotIn("not_indexed", out)
+        self.assertIn("0x1002", [r["addr"] for r in out["results"]])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+python -m pytest tests/test_similarity.py::PartialIndexTest -v -k "serves_partial or not_yet_covered"
+```
+Expected: all three FAIL — `test_similar_functions_serves_partial_results_mid_build` because `out["partial"]`/`out["coverage"]` are absent and `out["results"]` is empty (today's `not_indexed` path fires instead); `test_similar_functions_query_not_yet_covered_does_not_crash` and `test_similar_functions_serves_partial_after_build_error` because `out` contains `"not_indexed": ["aaaa"]` and empty `results` instead of `partial: True`.
+
+- [ ] **Step 3: Implement**
+
+In `src/ida_multi_mcp/tools/similarity.py`, in `similar_functions()`, change the loop setup and the `entry is None` handling (`:525-536`):
+
+Before:
+```python
+    results: list[dict] = []
+    not_indexed: list[str] = []
+    gallery_size = 0
+    for giid in gallery_iids:
+        gkey, _ = _instance_key(giid)
+        if not gkey:
+            not_indexed.append(giid)
+            continue
+        entry = _load(gkey, rp)
+        if entry is None:
+            not_indexed.append(giid)
+            continue
+```
+
+After:
+```python
+    results: list[dict] = []
+    not_indexed: list[str] = []
+    partial_coverage: dict[str, int] = {}
+    gallery_size = 0
+    for giid in gallery_iids:
+        gkey, _ = _instance_key(giid)
+        if not gkey:
+            not_indexed.append(giid)
+            continue
+        entry = _load(gkey, rp)
+        partial = False
+        if entry is None:
+            entry = _load_partial(giid)
+            partial = entry is not None
+        if entry is None:
+            not_indexed.append(giid)
+            continue
+        if partial:
+            # Same `entry` used for scoring below -- never a second, separately
+            # -timed lookup into `_jobs` (design spec §v2->v3 finding 3).
+            partial_coverage[giid] = entry["index"]["function_count"]
+```
+
+Then, at the end of `similar_functions()` (`:583-592`), change:
+```python
+    results.sort(key=lambda r: r["score"], reverse=True)
+    out: dict[str, Any] = {
+        "query": {"instance_id": iid, "addr": q.get("addr"), "name": q.get("name", "")},
+        "gallery_size": gallery_size,
+        "results": results[:top_k],
+    }
+    if not_indexed:
+        out["not_indexed"] = not_indexed
+        out["hint"] = "Run index_functions on the listed instances first."
+    return out
+```
+to:
+```python
+    results.sort(key=lambda r: r["score"], reverse=True)
+    out: dict[str, Any] = {
+        "query": {"instance_id": iid, "addr": q.get("addr"), "name": q.get("name", "")},
+        "gallery_size": gallery_size,
+        "results": results[:top_k],
+    }
+    if partial_coverage:
+        out["partial"] = True
+        out["coverage"] = {giid: {"done": n, "total": None} for giid, n in partial_coverage.items()}
+    if not_indexed:
+        out["not_indexed"] = not_indexed
+        out["hint"] = "Run index_functions on the listed instances first."
+    return out
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+python -m pytest tests/test_similarity.py -v
+```
+Expected: all tests PASS, including both new ones and every pre-existing test (`entry = _load(gkey, rp)` still runs first and unchanged; `_load_partial` is only reached when `_load` returns `None`, so a fully-indexed instance's behavior is byte-for-byte unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ida_multi_mcp/tools/similarity.py tests/test_similarity.py
+git commit -m "feat: serve partial similar_functions() results while a build is in progress
+
+Falls back to _load_partial() when no persisted index exists yet, tagging
+the response with partial:true and per-instance coverage counts (derived
+from the same entry used for scoring, never a second lookup). A query
+function not yet reached by the background build still resolves normally
+via the existing direct-fetch path; it just won't itself be a candidate
+until its page is processed."
+```
+
+---
+
+## Task 6: Full regression run
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the complete test suite**
+
+```bash
+cd /Users/merozemory/projects/MeroZemory/ida-multi-mcp
+python -m pytest tests/ -v
+```
+Expected: every test PASSES, including all pre-existing suites (`test_index_store.py`, `test_similarity.py`'s original classes, `test_similarity_neural.py`, and everything else under `tests/`) and every test added in Tasks 1–5. No skips introduced by this change.
+
+- [ ] **Step 2: Confirm no stray debug output or leftover monkeypatches**
+
+```bash
+grep -rn "similarity\._assemble_index = " tests/test_similarity.py
+```
+Expected: every occurrence is inside a `try/finally` that restores `real_assemble` (Tasks 3 and 4) — confirm by reading the surrounding lines; there must be no test that monkeypatches `_assemble_index` without restoring it, since that would leak into other tests run in the same process.
+
+- [ ] **Step 3: Commit (if step 2 required any fixup; otherwise this task produces no diff and can be skipped)**
+
+If a fixup was needed:
+```bash
+git add tests/test_similarity.py
+git commit -m "test: restore monkeypatched _assemble_index in all cases"
+```
+
+---
+
+## Post-plan (not part of this plan's tasks, tracked separately)
+
+Per the active `/goal`, after this plan's tasks are all green: independent (adversarial) code review of the resulting diff, then push `feature/similarity-partial-indexing` and open a PR. That work is tracked outside this plan.

--- a/docs/superpowers/specs/2026-07-08-incremental-similarity-indexing-design.md
+++ b/docs/superpowers/specs/2026-07-08-incremental-similarity-indexing-design.md
@@ -114,6 +114,22 @@ guard rather than to `_on_page`'s early-stop (which is real but not the
 mechanism actually load-bearing here). No new CRITICAL/HIGH findings. Design
 considered converged.
 
+## Post-review fix (found during implementation planning)
+
+`_load_partial`'s guard (§2, as originally written) gated on
+`job.get("status") != "building"`, returning `None` for any other status —
+but §4 explicitly says the **error** path should keep serving the
+last-known partial data (`live_records`/`_partial_cache` are deliberately
+*not* cleared on error, specifically so `similar_functions` can keep
+returning it labeled `partial: true`). §2's code as written could never
+reach that data, since it always returned `None` once `status` left
+`"building"`. This contradiction survived all three review rounds. §2 below
+is corrected to check `status in ("building", "error")` in both the read
+guard and the write-back guard — an errored job's `live_records` are frozen
+(the build will not progress further under that `gen`), so caching a
+computed snapshot of them is always safe, not just a "still fresh enough"
+debounce.
+
 ## Approach (v3)
 
 No new files, no new persisted formats, no mutation of shared state.
@@ -178,7 +194,7 @@ def _load_partial(iid: str) -> dict | None:
     """
     with _jobs_lock:
         job = _jobs.get(iid)
-        if not job or job.get("status") != "building":
+        if not job or job.get("status") not in ("building", "error"):
             return None
         gen = job["gen"]
         recs = job.get("live_records")
@@ -197,14 +213,15 @@ def _load_partial(iid: str) -> dict | None:
     entry = {"index": idx, "anchor_index": sim_score.build_anchor_index(funcs)}
     with _jobs_lock:
         j = _jobs.get(iid)
-        # Only cache back if this is STILL the same build, still in progress.
-        # A build that finished/errored/was superseded while we were off the
-        # lock computing `entry` must not have its (now-stale, and for a
-        # finished build, un-freed) result written back — this is the v2→v3
-        # fix for the completion race (finding 1). The caller still gets the
-        # freshly-computed `entry` for THIS call either way; only the cache
-        # write is conditional.
-        if j is not None and j.get("gen") == gen and j.get("status") == "building":
+        # Only cache back if this is STILL the same build (gen match) and
+        # still in a state we're allowed to serve ("building" or "error" --
+        # a build that finished or was superseded by a NEWER generation
+        # while we were off the lock computing `entry` must not have its
+        # (now-stale, and for a finished build, un-freed) result written
+        # back — this is the v2→v3 fix for the completion race (finding 1).
+        # The caller still gets the freshly-computed `entry` for THIS call
+        # either way; only the cache write is conditional.
+        if j is not None and j.get("gen") == gen and j.get("status") in ("building", "error"):
             j["_partial_cache"] = {"at": now, "gen": gen, "entry": entry}
     return entry
 ```

--- a/docs/superpowers/specs/2026-07-08-incremental-similarity-indexing-design.md
+++ b/docs/superpowers/specs/2026-07-08-incremental-similarity-indexing-design.md
@@ -1,0 +1,398 @@
+# Incremental / Partial Function-Similarity Indexing — Design v3 (converged after three rounds of adversarial review)
+
+## Problem
+
+`ida_multi_mcp/tools/similarity.py: index_functions()` builds the per-binary
+similarity index as a background thread that pages through `func_features`
+(500 functions/page) via `_build_records()`, accumulating everything in a
+plain Python list, and only calls `_assemble_index()` +
+`index_store.write_index()` **once, at the end**. Until that single atomic
+write happens, `similar_functions()` returns `not_indexed` unconditionally
+— even if 99% of a 130K-function binary has already been processed.
+
+Goal: let `similar_functions()` serve results against whatever has been
+processed so far, while the background build continues.
+
+## v1 → v2: what changed after adversarial review
+
+Three independent reviewers (architect-lens, adversarial bug-hunt, simplicity/
+YAGNI) examined the first draft, which proposed incremental per-page merge
+functions (`RunningStats`, `df_merge`, `lsh_merge`, `anchor_index_merge`) plus
+an append-only `.features.partial.jsonl` resume sidecar mirroring
+`vectors.jsonl`. Converging findings that changed the design:
+
+1. **The O(n²)-per-query-recompute fear was never validated.** A from-scratch
+   `df_of`/`zstats_of`/`build_lsh`/`build_anchor_index` pass over 130,717
+   records is a few seconds total in pure Python (df/zstats: sub-second each;
+   `build_lsh`'s ~2M blake2b calls across 16 bands: low seconds). Queries
+   during a multi-minute build are rare, human-paced events — a **debounced
+   recompute from the existing from-scratch functions** is cheap enough and
+   needs zero new scoring code.
+2. **Resume-on-restart didn't save the expensive part anyway.** The dominant
+   build cost is IDA-side extraction (disasm/CFG/MinHash per function via
+   `func_features`), which a resumed build still has to redo in full — the
+   sidecar only would have saved the (already-cheap) Python-side merge work.
+   Not worth the new persistence format, resume/skip logic, and orphan
+   reconciliation it required. Cut entirely; matches this feature's own
+   `01-v1-production-design.md` §7 precedent ("ship full-rebuild first").
+3. **The proposed merge functions mutate arguments in place**
+   (`df[item] = df.get(item,0)+1` re-assigns existing keys;
+   `lsh`/`anchor_index` append into existing bucket lists) — this both
+   contradicts `sim_score.py`'s existing convention (every function there is
+   pure: builds and returns a fresh object, zero classes) and the user's
+   global coding-style rule ("ALWAYS create new objects, NEVER mutate
+   existing ones"). The debounced-recompute approach needs no merge
+   functions, so this conflict disappears.
+4. **A real bug survived simplification and must still be fixed**: nothing
+   in v1 ever released the accumulated partial state after a build
+   completed, so full per-instance record sets (up to 130K `FunctionFeature`
+   dicts + derived structures) would stay memory-resident for the life of
+   the process. v2 explicitly clears it on completion (§Memory below).
+5. **A pre-existing bug is made materially worse and gets a minimal,
+   in-scope mitigation**: if the analyzed binary changes mid-build (same
+   `instance_id`, different content — the router's binary-change guard
+   compares filename, not content, see `router.py`), today that would
+   corrupt one *silent* final write. With partial-serving, the corrupted
+   in-progress state would be **actively served to callers** for the whole
+   build duration instead. v2 adds a cheap per-page fingerprint re-check to
+   close this (§Binary-change guard below) since this change is what makes
+   the exposure meaningfully worse.
+
+## v2 → v3: round-2 review findings and fixes
+
+A second round of two independent reviewers, given v2, converged on three
+concrete implementation-detail bugs (not architectural — the core "reuse
+from-scratch functions, debounce, GIL-safe list read" shape was confirmed
+sound by both):
+
+1. **`_load_partial`'s unlock→compute→relock pattern races with completion.**
+   v2's helper reads `recs` under `_jobs_lock`, releases it to do the
+   (multi-hundred-ms) `_assemble_index`/`build_anchor_index` work, then
+   re-acquires the lock and unconditionally writes `_partial_cache` back.
+   If the real build finishes and the completion handler (§4) pops
+   `live_records`/`_partial_cache` during that window, this write silently
+   re-attaches a full heavy entry to a now-`"ready"` job — never read again
+   (the `status != "building"` guard prevents that), but never freed either.
+   **Fix**: tag each build with a monotonic generation counter; only write
+   the cache back if the generation and status still match what was read at
+   the start (§2 below).
+2. **Per-page fingerprint re-check was mis-located and its cost unvalidated.**
+   v2 said "top of `_run()`'s per-page loop," but `_run()` has no loop — the
+   page loop is inside `_build_records`, reachable only via the `on_page`
+   callback, which fires **after** `records.extend(funcs)` — so a check
+   there cannot prevent one page's worth of already-swapped data from being
+   appended before detection (a real, but bounded, TOCTOU gap). Separately,
+   `_instance_key` calls `binary_fingerprint` — a routed IDA round-trip —
+   so checking on literally every page (up to ~262 for a 130K-function
+   binary) adds that many extra round-trips competing with `func_features`
+   calls for the same single-threaded IDA main-thread, an unvalidated and
+   likely real cost regression. **Fix**: check every `N` pages (§5 below),
+   accepting a bounded (not eliminated) exposure window in exchange for a
+   bounded, small number of extra round-trips — documented as a known,
+   deliberate trade-off, not silently swept under "cheap."
+3. **`coverage.done` was read from `_jobs[giid]["live_records"]` directly,
+   unlocked, after the gallery loop** — a `KeyError` if the build completed
+   and popped that key in the meantime, and even when it doesn't error, a
+   value that can disagree with the (possibly `_PARTIAL_TTL_S`-stale)
+   `entry` actually used to compute `results`, since the two reads aren't
+   from the same snapshot. **Fix**: derive `coverage` from the same `entry`
+   already used for scoring (`entry["index"]["function_count"]`) instead of
+   a second, separately-timed read of shared state (§3 below).
+
+## Round 3: convergence check
+
+A third independent reviewer verified all three round-2 fixes against the
+actual code (confirmed `_build_records`'s `on_page -> bool` early-stop is
+real at `similarity.py:242-243`; confirmed the `_load_partial` write-back
+race is closed because the gen+status re-check and the write happen inside
+one uninterrupted `with _jobs_lock:` block; confirmed the completion-path gen
+guard doesn't break the normal case) and found only two LOW, non-blocking
+documentation issues, both fixed inline: `_next_gen()` pinned to a concrete
+module-level `itertools.count()`, and §4's rationale corrected to attribute
+supersession-prevention to `_start_background`'s existing "already building"
+guard rather than to `_on_page`'s early-stop (which is real but not the
+mechanism actually load-bearing here). No new CRITICAL/HIGH findings. Design
+considered converged.
+
+## Approach (v3)
+
+No new files, no new persisted formats, no mutation of shared state.
+Everything reuses the existing from-scratch `sim_score.py` functions and the
+existing `_load()`-shaped `entry = {"index": ..., "anchor_index": ...}`
+structure that `similar_functions()` already consumes (`similarity.py:458-472`,
+`:533-545`).
+
+### 1. Expose the background job's growing record list, with a generation tag
+
+`_build_records()` (`similarity.py:231-248`) already threads an `on_page`
+callback that receives the **same, in-place-mutated** `records` list on every
+page (`records.extend(funcs); on_page(records, total)`). `_start_background`
+(`similarity.py:356+`, where `_jobs[iid] = {...}` is assigned fresh for every
+new build — including retries after an error) gains one new field, and its
+`_on_page` closure (`:371+`) stashes the list reference (not a copy) plus a
+page counter, once per page, under the existing `_jobs_lock`:
+```python
+_gen_counter = itertools.count()   # module-level, next()'d only while holding _jobs_lock
+
+def _start_background(...):
+    with _jobs_lock:
+        gen = next(_gen_counter)
+        _jobs[iid] = {"status": "building", "progress": 0.0, "gen": gen, "pages_seen": 0, ...}
+    ...
+    def _on_page(recs, total):
+        with _jobs_lock:
+            job = _jobs.get(iid)
+            if job is None or job.get("gen") != gen:
+                return False   # a newer build superseded this one; stop
+            job["progress"] = ...              # existing
+            job.setdefault("live_records", recs)   # same list object every call; no-op after first page
+            job["pages_seen"] = job.get("pages_seen", 0) + 1
+        ...
+```
+`gen` (captured once per `_run()` invocation) is the fix for the v2→v3
+finding-1 race: every later read/write that touches `_jobs[iid]` compares
+against this captured `gen` before trusting or mutating shared state, so a
+slow background write from a superseded or already-finished build can never
+clobber a newer build's state or resurrect cleared state (§2, §4 below).
+
+Because CPython list mutation (`.extend`) is safe to read concurrently from
+another thread (no "changed size during iteration" error, unlike dict/set —
+a reader just sees whatever length existed when it started iterating), no
+further locking is needed to *read* `live_records` itself. This matches
+reviewer feedback: the actual safety argument is "GIL + list, not dict,
+semantics," not "pages only add" (true for the list, but previously stated
+imprecisely against the dict-based merge functions that no longer exist).
+
+### 2. Debounced partial-index assembly in `similar_functions`
+
+New small helper in `tools/similarity.py`, sitting next to `_load`:
+```python
+_PARTIAL_TTL_S = 2.0
+
+def _load_partial(iid: str) -> dict | None:
+    """Ephemeral, debounced index+anchor_index entry from a build in progress.
+
+    Reuses the exact from-scratch functions `_assemble_index`/`_load` already
+    use for the final index, over whatever the background thread has
+    accumulated so far. Returns None if no build is running for `iid`.
+    """
+    with _jobs_lock:
+        job = _jobs.get(iid)
+        if not job or job.get("status") != "building":
+            return None
+        gen = job["gen"]
+        recs = job.get("live_records")
+        cached = job.get("_partial_cache")
+    if not recs:
+        return None
+    now = time.time()
+    if cached and cached["gen"] == gen and now - cached["at"] < _PARTIAL_TTL_S:
+        return cached["entry"]
+    key, fp = _instance_key(iid)               # re-fingerprints; see §5
+    if not key:
+        return None
+    info = (_registry.get_instance(iid) or {}) if _registry else {}
+    idx = _assemble_index(list(recs), key, info.get("binary_name", ""), fp)
+    funcs = list(idx["functions"].values())
+    entry = {"index": idx, "anchor_index": sim_score.build_anchor_index(funcs)}
+    with _jobs_lock:
+        j = _jobs.get(iid)
+        # Only cache back if this is STILL the same build, still in progress.
+        # A build that finished/errored/was superseded while we were off the
+        # lock computing `entry` must not have its (now-stale, and for a
+        # finished build, un-freed) result written back — this is the v2→v3
+        # fix for the completion race (finding 1). The caller still gets the
+        # freshly-computed `entry` for THIS call either way; only the cache
+        # write is conditional.
+        if j is not None and j.get("gen") == gen and j.get("status") == "building":
+            j["_partial_cache"] = {"at": now, "gen": gen, "entry": entry}
+    return entry
+```
+`_assemble_index` already runs `_valid_records` (drops `func_features` error
+stubs before df/zstats/lsh see them — fixes a gap the v1 merge-function
+draft would have hit), so no separate filtering is needed here.
+
+### 3. Wire into `similar_functions`
+
+At `similarity.py:533` (`entry = _load(gkey, rp)` → `not_indexed` on
+`None`), fall back to the partial loader and tag the result. Coverage is
+read from the **same `entry`** that scoring goes on to use — never a second,
+separately-timed lookup into `_jobs` — so it can never disagree with
+`results` or race a completing/popped job (v2→v3 finding 3):
+```python
+entry = _load(gkey, rp)
+partial = False
+if entry is None:
+    entry = _load_partial(giid)
+    partial = entry is not None
+if entry is None:
+    not_indexed.append(giid)
+    continue
+...
+if partial:
+    partial_coverage[giid] = entry["index"]["function_count"]  # same entry used below for scoring
+```
+After the loop, if `partial_coverage` is non-empty, add to `out`:
+```python
+out["partial"] = True
+out["coverage"] = {giid: {"done": n, "total": None} for giid, n in partial_coverage.items()}
+```
+(`total` stays `None` — `func_features`'s paging cursor doesn't report an
+upfront total function count cheaply; `index_status(instance_id)` already
+reports `progress` as a 0..1 fraction computed the same way the build itself
+tracks it, so coverage's absolute numerator is enough context and this
+avoids a second, possibly-inconsistent, source of "total.")
+
+A query whose own function address hasn't been reached by the background
+loop yet still resolves normally — `q` is always fetched fresh via a direct
+`func_features` call (`similarity.py:503`, unrelated to the gallery/index
+build). It simply won't itself be *findable as a candidate in someone else's
+search* until its page is processed — expected, not an error case.
+
+### 4. Memory: clear partial state on completion
+
+In `_run()`'s success path (`similarity.py:386-389`, where `status` flips to
+`"ready"`), also drop the heavy partial-only state under the same lock —
+guarded by the same `gen` check as everywhere else. In practice a `_run()`
+never reaches this point with a stale `gen` at all: `_start_background`'s
+existing "already building" short-circuit (`similarity.py:358-362`) refuses
+to start a second build for the same `iid` while one is in progress, so
+nothing can supersede a running `_run()`'s `gen` mid-flight — the guard here
+is a belt-and-suspenders correctness check (matching the same pattern used
+everywhere else `_jobs[iid]` is touched), not a load-bearing recovery from a
+reachable race. If that upstream guard is ever relaxed in the future (e.g.
+to support concurrent rebuilds), this check is what keeps completion
+handling correct without relying on `_on_page`'s early-stop path, which
+`_build_records` does honor (`similarity.py:242-243`, `on_page -> bool`)
+but which is not the mechanism actually preventing supersession today:
+```python
+with _jobs_lock:
+    job = _jobs.get(iid)
+    if job is not None and job.get("gen") == gen:
+        job.pop("live_records", None)
+        job.pop("_partial_cache", None)
+        job.update(status="ready", ...)   # existing
+```
+`similar_functions` always tries `_load(gkey, rp)` (the real, persisted,
+`_loaded`-cached index) first and only calls `_load_partial` when that
+returns `None` — once the real index exists, `_load_partial` is never
+reached again for that key, so the pop above is the only cleanup needed (no
+risk of a stale partial cache being served after completion).
+
+On the **error** path (`similarity.py:406-409`), `live_records` and
+`_partial_cache` are deliberately left in place — the partial data is "as
+good as it'll get" until `index_functions` is invoked again, and
+`similar_functions` should keep serving it (labeled `partial: true`).
+`index_status`'s existing `job_status: "error"` field already tells the
+caller the build has stalled.
+
+### 5. Binary-change guard (bounded, not eliminated — explicit trade-off)
+
+`_instance_key(iid)` calls the IDA-side `binary_fingerprint` tool — a routed
+round-trip (`similarity.py:212-224`). Checking it on every page (~262 for a
+130K-function binary) would add that many extra round-trips contending with
+`func_features` for the same single-threaded IDA main thread — an
+unacceptable, unvalidated cost regression against the very goal of this
+change. Instead, the `_on_page` closure (§1) — which already runs after
+`_build_records` has appended that page's records
+(`records.extend(funcs); on_page(records, total)`, `similarity.py:240-243`
+— confirmed there is no earlier hook available) — re-checks the fingerprint
+every `_FP_CHECK_EVERY_N_PAGES` pages (default 20, so at most ~13 extra
+round-trips for a 262-page build) using the `pages_seen` counter from §1:
+```python
+def _on_page(recs, total):
+    with _jobs_lock:
+        job = _jobs.get(iid)
+        if job is None or job.get("gen") != gen:
+            return False
+        job["progress"] = ...
+        job.setdefault("live_records", recs)
+        job["pages_seen"] = n = job.get("pages_seen", 0) + 1
+    if n % _FP_CHECK_EVERY_N_PAGES == 0:
+        cur_key, _ = _instance_key(iid)
+        if cur_key != key:
+            with _jobs_lock:
+                j = _jobs.get(iid)
+                if j is not None and j.get("gen") == gen:
+                    j.update(status="error",
+                              error=f"binary changed mid-build (was {key[:12]}…, now "
+                                    f"{cur_key[:12] if cur_key else '?'}…)")
+            return False
+    return True
+```
+**Explicit, documented trade-off** (not silently swept under "cheap," per
+round-2 feedback): this closes most of the exposure window a mid-build
+binary swap opens, but not all of it — up to `_FP_CHECK_EVERY_N_PAGES - 1`
+pages' worth of already-swapped-binary functions can land in `live_records`
+(and be served as `partial: true` results, and end up in the final index if
+the swap is never caught within the whole build) before detection fires.
+This is strictly better than today (zero checks, unbounded exposure, only
+ever surfaces via the router's *filename*-based guard on the *next* tool
+call against the wrong binary) without adding a cost the goal can't afford.
+A tighter guarantee (check every page, or make `_build_records` itself
+fingerprint-aware) is left as a follow-up if this bounded window proves
+insufficient in practice — this design does not claim to fully close it.
+
+## Non-goals
+
+- Skipping already-covered functions on the **IDA side** — out of scope;
+  there is no resume to save work for anymore (§v1→v2 point 2).
+- ~~Persisted resume across a server restart~~ — **dropped**. A restart
+  mid-build loses progress and requires re-invoking `index_functions`,
+  identical to today's behavior. No regression; explicitly deferred, per
+  reviewer 3 and this feature's own `01-v1-production-design.md` §7
+  precedent.
+- Auto-resuming/auto-starting a background build from a bare
+  `similar_functions()` call with no `index_functions()` ever invoked —
+  unchanged from v1's reasoning (never silently start unbounded IDA-side
+  work as a side effect of what looks like a read).
+- Multi-process / multi-server-instance coordination — dropped from explicit
+  discussion (reviewer 3: not asked for, existing final-index write path
+  doesn't handle it either, mentioning it only invited unnecessary scope
+  questions). Two *different `instance_id`s* (e.g. two IDA GUI windows) each
+  running `index_functions()` on the *same* binary each get their own
+  independent `_jobs[iid]` and `live_records` — no shared mutable state
+  between them until each writes its own final index to the same
+  content-hash key at the end, which is pre-existing, unchanged behavior.
+
+## Testing
+
+- `test_similarity.py` (extended):
+  - Background build (fake IDA/router stub yielding controlled pages) +
+    a `similar_functions` call mid-build asserts `partial: true`,
+    `coverage[iid].done` equal to `entry["index"]["function_count"]` (i.e.
+    read from the same object that produced `results`, not a second lookup),
+    and results drawn only from already-seen addrs.
+  - Debounce: two `similar_functions` calls within `_PARTIAL_TTL_S` of each
+    other while no new pages have landed reuse the cached entry (assert via
+    a call-counter on a monkeypatched `_assemble_index`/`build_anchor_index`
+    or by timing).
+  - Query function not yet reached by the build: `similar_functions` still
+    returns (query resolves via the direct fetch), just with a smaller/empty
+    candidate set from the partial gallery — no exception.
+  - On completion, `partial` is absent (or `False`) and results match a
+    normal from-scratch index; `_jobs[iid]` no longer holds `live_records`/
+    `_partial_cache` (assert via `similarity._jobs`).
+  - **Completion race (v2→v3 finding 1)**: start a build, call
+    `_load_partial` and, via a monkeypatch/hook, pause it after it releases
+    `_jobs_lock` the first time (having read `recs`/`gen`) but before it
+    re-acquires the lock to write the cache; let the real build finish in
+    that window (pops `live_records`/`_partial_cache`, flips `status`);
+    resume `_load_partial`; assert it does NOT re-insert `_partial_cache`
+    into the now-`"ready"` job (i.e. `_jobs[iid]` still has no
+    `live_records`/`_partial_cache` after `_load_partial` returns).
+  - **Retry/generation (v2→v3 finding 1, retry variant)**: start a build,
+    force it to error, call `index_functions()` again for the same `iid`
+    (new `_jobs[iid]`, new `gen`); assert a `_load_partial` call whose
+    in-flight computation started against the OLD `gen` does not write its
+    stale result into the new job's `_partial_cache`.
+  - On a build error mid-way, `similar_functions` still returns the last
+    partial results (`partial: true`) rather than `not_indexed`.
+  - **Binary-change guard, bounded window (v2→v3 finding 2)**: monkeypatch
+    `_instance_key` to flip to a different key partway through a fake
+    multi-page build; assert the job transitions to `status: "error"` within
+    `_FP_CHECK_EVERY_N_PAGES` pages of the flip (not immediately — assert
+    the bound, not zero-tolerance), and that no further pages are appended
+    after detection.
+- Full existing test suite must stay green — the final-index code path
+  (`_assemble_index`, `write_index`) is completely untouched.

--- a/src/ida_multi_mcp/tools/similarity.py
+++ b/src/ida_multi_mcp/tools/similarity.py
@@ -46,6 +46,7 @@ _gen_counter = itertools.count()
 # bounds (does not eliminate) the window during which a mid-build binary swap
 # can produce results attributed to the wrong binary.
 _FP_CHECK_EVERY_N_PAGES = int(os.environ.get("IDA_MCP_SIM_FP_CHECK_EVERY_N_PAGES", "20"))
+_PARTIAL_TTL_S = float(os.environ.get("IDA_MCP_SIM_PARTIAL_TTL_S", "2.0"))
 
 # Neural recall (opt-in): set IDA_MCP_SIM_NEURAL=1 and point JTRANS_MODEL /
 # JTRANS_TOKENIZER at a jTrans-finetune checkpoint. This adds a jTrans embedding
@@ -520,6 +521,48 @@ def _load(key: str, rp: str | None) -> dict | None:
     entry = {"index": idx, "anchor_index": sim_score.build_anchor_index(funcs)}
     with _loaded_lock:
         _loaded[key] = entry
+    return entry
+
+
+def _load_partial(iid: str) -> dict | None:
+    """Ephemeral, debounced index+anchor_index entry from a build in progress
+    (or one that errored, serving its last-known-good state).
+
+    Reuses the exact from-scratch functions `_assemble_index`/`build_anchor_index`
+    already used for the final index, over whatever the background thread has
+    accumulated so far (`_jobs[iid]["live_records"]`). Returns None if no build
+    is running/errored for `iid`, or none of its pages have landed yet.
+    """
+    with _jobs_lock:
+        job = _jobs.get(iid)
+        if not job or job.get("status") not in ("building", "error"):
+            return None
+        gen = job.get("gen")
+        recs = job.get("live_records")
+        cached = job.get("_partial_cache")
+    if not recs:
+        return None
+    now = time.time()
+    if cached and cached.get("gen") == gen and now - cached["at"] < _PARTIAL_TTL_S:
+        return cached["entry"]
+    key, fp = _instance_key(iid)
+    if not key:
+        return None
+    info = (_registry.get_instance(iid) or {}) if _registry else {}
+    idx = _assemble_index(list(recs), key, info.get("binary_name", ""), fp)
+    funcs = list(idx["functions"].values())
+    entry = {"index": idx, "anchor_index": sim_score.build_anchor_index(funcs)}
+    with _jobs_lock:
+        j = _jobs.get(iid)
+        # Only cache back if this is STILL the same build (gen match) and
+        # still in a state we're allowed to serve. A build that finished or
+        # was superseded by a NEWER generation while we were off the lock
+        # computing `entry` must not have its (now-stale, and for a finished
+        # build, un-freed) result written back. The caller still gets the
+        # freshly-computed `entry` for THIS call either way; only the cache
+        # write is conditional.
+        if j is not None and j.get("gen") == gen and j.get("status") in ("building", "error"):
+            j["_partial_cache"] = {"at": now, "gen": gen, "entry": entry}
     return entry
 
 

--- a/src/ida_multi_mcp/tools/similarity.py
+++ b/src/ida_multi_mcp/tools/similarity.py
@@ -618,6 +618,7 @@ def similar_functions(arguments: dict) -> dict:
 
     results: list[dict] = []
     not_indexed: list[str] = []
+    partial_coverage: dict[str, int] = {}
     gallery_size = 0
     for giid in gallery_iids:
         gkey, _ = _instance_key(giid)
@@ -625,9 +626,17 @@ def similar_functions(arguments: dict) -> dict:
             not_indexed.append(giid)
             continue
         entry = _load(gkey, rp)
+        partial = False
+        if entry is None:
+            entry = _load_partial(giid)
+            partial = entry is not None
         if entry is None:
             not_indexed.append(giid)
             continue
+        if partial:
+            # Same `entry` used for scoring below -- never a second, separately
+            # -timed lookup into `_jobs`.
+            partial_coverage[giid] = entry["index"]["function_count"]
         idx = entry["index"]
         funcs = idx.get("functions", {})
         gallery_size += len(funcs)
@@ -680,6 +689,9 @@ def similar_functions(arguments: dict) -> dict:
         "gallery_size": gallery_size,
         "results": results[:top_k],
     }
+    if partial_coverage:
+        out["partial"] = True
+        out["coverage"] = {giid: {"done": n, "total": None} for giid, n in partial_coverage.items()}
     if not_indexed:
         out["not_indexed"] = not_indexed
         out["hint"] = "Run index_functions on the listed instances first."

--- a/src/ida_multi_mcp/tools/similarity.py
+++ b/src/ida_multi_mcp/tools/similarity.py
@@ -383,7 +383,7 @@ def _start_background(iid: str, key: str, fp: dict, binary_name: str,
         gen = next(_gen_counter)
         _jobs[iid] = {"status": "ready" if features_ready else "building",
                       "progress": 1.0 if features_ready else 0.0,
-                      "cancel": False, "error": None, "key": key,
+                      "cancel": False, "error": None, "key": key, "fp": fp,
                       "gen": gen, "pages_seen": 0}
 
     def _on_page(recs: list, total: int) -> bool:
@@ -399,7 +399,11 @@ def _start_background(iid: str, key: str, fp: dict, binary_name: str,
                 return False
         if n % _FP_CHECK_EVERY_N_PAGES == 0:
             cur_key, _ = _instance_key(iid)
-            if cur_key != key:
+            # cur_key is None on a transient routing/IDA failure (_instance_key
+            # returns (None, None) whenever _call_ida fails), not just on a
+            # real binary swap -- treat that as inconclusive and skip this
+            # check rather than aborting the build on a flaky round-trip.
+            if cur_key is not None and cur_key != key:
                 with _jobs_lock:
                     j = _jobs.get(iid)
                     if j is not None and j.get("gen") == gen:
@@ -417,7 +421,8 @@ def _start_background(iid: str, key: str, fp: dict, binary_name: str,
                 with _jobs_lock:
                     job = _jobs.get(iid)
                     superseded_or_errored = (
-                        job is None or job.get("gen") != gen or job.get("status") == "error"
+                        job is None or job.get("gen") != gen
+                        or job.get("status") == "error" or job.get("cancel")
                     )
                 if superseded_or_errored:
                     # _on_page stopped the loop (supersession, cancel, or a
@@ -538,16 +543,20 @@ def _load_partial(iid: str) -> dict | None:
         if not job or job.get("status") not in ("building", "error"):
             return None
         gen = job.get("gen")
+        key = job.get("key")
+        fp = job.get("fp") or {}
         recs = job.get("live_records")
         cached = job.get("_partial_cache")
-    if not recs:
+    if not recs or not key:
         return None
     now = time.time()
     if cached and cached.get("gen") == gen and now - cached["at"] < _PARTIAL_TTL_S:
         return cached["entry"]
-    key, fp = _instance_key(iid)
-    if not key:
-        return None
+    # Use the build's own recorded key/fp (fixed at _start_background time),
+    # not a live re-fingerprint: the live fingerprint may have already moved
+    # on (e.g. after a detected binary-change error), and tagging these
+    # STALE records with a fresh key would misattribute them. Live-swap
+    # detection is _on_page's job (periodic recheck), not this loader's.
     info = (_registry.get_instance(iid) or {}) if _registry else {}
     idx = _assemble_index(list(recs), key, info.get("binary_name", ""), fp)
     funcs = list(idx["functions"].values())
@@ -630,6 +639,13 @@ def similar_functions(arguments: dict) -> dict:
         if entry is None:
             entry = _load_partial(giid)
             partial = entry is not None
+            if entry is None:
+                # The build may have finished (and been persisted) in the
+                # window between the _load() miss above and this point --
+                # _load_partial returns None once status leaves
+                # "building"/"error". Re-check the real index once more
+                # before reporting a false not_indexed.
+                entry = _load(gkey, rp)
         if entry is None:
             not_indexed.append(giid)
             continue

--- a/src/ida_multi_mcp/tools/similarity.py
+++ b/src/ida_multi_mcp/tools/similarity.py
@@ -10,6 +10,7 @@ Wiring mirrors tools/management.py (module-level registry/router injection).
 from __future__ import annotations
 
 import hashlib
+import itertools
 import json
 import os
 import threading
@@ -31,6 +32,20 @@ _loaded: dict[str, dict] = {}
 _loaded_lock = threading.Lock()
 
 PAGE = int(os.environ.get("IDA_MCP_SIM_PAGE", "500"))
+
+# Monotonic build-generation counter: next()'d only while holding _jobs_lock,
+# in _start_background. Lets in-flight work (e.g. _load_partial) tell whether
+# the job it read from is still the one it started with, so a slow write-back
+# from a superseded/finished build can never clobber newer state.
+_gen_counter = itertools.count()
+
+# How often (in pages) a background build re-verifies the instance's binary
+# fingerprint still matches the one it started with. Every page would add a
+# routed IDA round-trip per page (~262 for a 130K-function binary) contending
+# with func_features calls on the same single-threaded IDA main thread; this
+# bounds (does not eliminate) the window during which a mid-build binary swap
+# can produce results attributed to the wrong binary.
+_FP_CHECK_EVERY_N_PAGES = int(os.environ.get("IDA_MCP_SIM_FP_CHECK_EVERY_N_PAGES", "20"))
 
 # Neural recall (opt-in): set IDA_MCP_SIM_NEURAL=1 and point JTRANS_MODEL /
 # JTRANS_TOKENIZER at a jTrans-finetune checkpoint. This adds a jTrans embedding
@@ -364,29 +379,65 @@ def _start_background(iid: str, key: str, fp: dict, binary_name: str,
             return {"index_id": key, "status": "ready", "embed_status": "embedding",
                     "embed_done": existing.get("embed_done", 0),
                     "embed_total": existing.get("embed_total", 0), "note": "already embedding"}
+        gen = next(_gen_counter)
         _jobs[iid] = {"status": "ready" if features_ready else "building",
                       "progress": 1.0 if features_ready else 0.0,
-                      "cancel": False, "error": None, "key": key}
+                      "cancel": False, "error": None, "key": key,
+                      "gen": gen, "pages_seen": 0}
+
+    def _on_page(recs: list, total: int) -> bool:
+        with _jobs_lock:
+            job = _jobs.get(iid)
+            if job is None or job.get("gen") != gen:
+                return False   # a newer build superseded this one; stop
+            if total:
+                job["progress"] = min(len(recs) / total, 0.999)
+            job.setdefault("live_records", recs)   # same list object every call; no-op after page 1
+            job["pages_seen"] = n = job.get("pages_seen", 0) + 1
+            if job.get("cancel"):
+                return False
+        if n % _FP_CHECK_EVERY_N_PAGES == 0:
+            cur_key, _ = _instance_key(iid)
+            if cur_key != key:
+                with _jobs_lock:
+                    j = _jobs.get(iid)
+                    if j is not None and j.get("gen") == gen:
+                        j.update(status="error",
+                                 error=f"binary changed mid-build (was {key[:12]}…, now "
+                                       f"{cur_key[:12] if cur_key else '?'}…)")
+                return False
+        return True
 
     def _run() -> None:
         try:
             if not features_ready:
-                def _on_page(recs: list, total: int) -> bool:
-                    with _jobs_lock:
-                        job = _jobs.get(iid, {})
-                        if total:
-                            job["progress"] = min(len(recs) / total, 0.999)
-                        return not job.get("cancel", False)
                 index_store.clear_vectors(key, rp)   # fresh build -> fresh vectors
                 records = _build_records(iid, _on_page)
+                with _jobs_lock:
+                    job = _jobs.get(iid)
+                    superseded_or_errored = (
+                        job is None or job.get("gen") != gen or job.get("status") == "error"
+                    )
+                if superseded_or_errored:
+                    # _on_page stopped the loop (supersession, cancel, or a
+                    # detected binary-change mismatch) -- the collected
+                    # `records` are not trustworthy as a final index and must
+                    # not be persisted. Whatever partial results were already
+                    # served stay served (error path keeps live_records); we
+                    # just skip turning them into a bogus final write.
+                    return
                 index = _assemble_index(records, key, binary_name, fp)
                 index_store.write_index(index, rp)
                 _invalidate_cache(key)
                 valid_addrs = [r["addr"] for r in _valid_records(records)]
                 with _jobs_lock:
-                    _jobs[iid].update(status="ready", progress=1.0,
-                                      function_count=index["function_count"],
-                                      skipped_count=index["skipped_count"])
+                    job = _jobs.get(iid)
+                    if job is not None and job.get("gen") == gen:
+                        job.pop("live_records", None)
+                        job.pop("_partial_cache", None)
+                        job.update(status="ready", progress=1.0,
+                                  function_count=index["function_count"],
+                                  skipped_count=index["skipped_count"])
             else:  # features already on disk -> resume embedding only
                 idx = index_store.read_index(key, rp) or {}
                 valid_addrs = list(idx.get("functions", {}).keys())

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -9,13 +9,15 @@ import json
 import os
 import sys
 import tempfile
+import threading
+import time
 import unittest
 from pathlib import Path
 
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
 sys.path.insert(0, str(SRC_ROOT))
 
-from ida_multi_mcp.tools import sim_score, similarity  # noqa: E402
+from ida_multi_mcp.tools import index_store, sim_score, similarity  # noqa: E402
 
 
 # --- synthetic feature corpus -------------------------------------------------
@@ -295,6 +297,143 @@ class SimilarityErrorRecordTest(unittest.TestCase):
         })
         self.assertIn("error", out)
         self.assertNotIn("KeyError", out["error"])
+
+
+def _wait_until(predicate, timeout=5.0, interval=0.01):
+    """Poll `predicate()` until truthy or `timeout` elapses; raise on timeout.
+
+    The background build genuinely runs on a separate thread (that is the
+    behavior under test), so tests synchronize on job-state, not sleeps.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+    raise AssertionError(f"condition not met within {timeout}s")
+
+
+class PausableRouter:
+    """Serves func_features / binary_fingerprint like MockRouter, but each
+    '*' (paginated) func_features call blocks on a counting semaphore until
+    the test calls release_pages(n) — lets tests pause a background build
+    mid-page and inspect/exercise partial state deterministically. Optional
+    swap_after_pages flips the fingerprint after that many pages have been
+    served, simulating a mid-build binary change.
+    """
+
+    def __init__(self, corpus):
+        self._corpus = corpus
+        self._budget = threading.Semaphore(0)
+        self.pages_served = 0
+        self.swap_after_pages = None
+        self._swapped = False
+
+    def release_pages(self, n):
+        for _ in range(n):
+            self._budget.release()
+
+    def route_request(self, method, params):
+        name = params.get("name")
+        args = params.get("arguments", {})
+        iid = args.get("instance_id")
+        feats = self._corpus.get(iid)
+        if feats is None:
+            return {"error": f"no instance {iid}"}
+        if name == "binary_fingerprint":
+            sha = f"sha-{iid}-swapped" if self._swapped else f"sha-{iid}"
+            payload = {"sha256": sha, "md5": None,
+                       "function_count": len(feats), "arch": "x86_64"}
+        elif name == "func_features":
+            addrs = args.get("addrs", "*")
+            if addrs == "*":
+                self._budget.acquire()
+                self.pages_served += 1
+                if (self.swap_after_pages is not None
+                        and self.pages_served > self.swap_after_pages):
+                    self._swapped = True
+                offset = int(args.get("offset", 0))
+                count = int(args.get("count", 500))
+                page = feats[offset:offset + count]
+                nxt = offset + len(page)
+                cursor = {"done": True} if nxt >= len(feats) else {"next": nxt}
+                payload = {"functions": page, "total": len(feats), "cursor": cursor}
+            else:
+                match = [f for f in feats if f["addr"] == str(addrs) or f["name"] == str(addrs)]
+                payload = {"functions": match[:1], "total": len(match),
+                           "cursor": {"done": True}}
+        else:
+            return {"error": f"unknown tool {name}"}
+        return {"content": [{"type": "text", "text": json.dumps(payload)}],
+                "structuredContent": payload}
+
+
+class PartialIndexTest(unittest.TestCase):
+    """Background-build instrumentation, partial-serving, and their race/edge
+    cases. Uses PausableRouter to deterministically pause a build mid-page —
+    real threading is exercised (this is the behavior under test), so tests
+    synchronize on `_jobs` state via `_wait_until`, never on sleeps alone.
+    """
+
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self._registry_path = os.path.join(self._td.name, "instances.json")
+        self._corpus = {"aaaa": _corpus()["aaaa"]}   # 6 functions
+        self._router = PausableRouter(self._corpus)
+        similarity.set_registry(MockRegistry(self._registry_path, self._corpus))
+        similarity.set_router(self._router)
+        similarity._jobs.clear()
+        similarity._loaded.clear()
+        self._orig_page = similarity.PAGE
+        similarity.PAGE = 2   # 6 functions / 2-per-page = 3 pages, so tests can pause mid-build
+
+    def tearDown(self):
+        similarity.PAGE = self._orig_page
+        similarity._jobs.clear()
+        similarity._loaded.clear()
+        self._td.cleanup()
+
+    def test_background_build_exposes_gen_and_live_records(self):
+        res = similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self.assertEqual(res["status"], "building")
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+
+        job = similarity._jobs["aaaa"]
+        self.assertIsInstance(job["gen"], int)
+        self.assertEqual(len(job["live_records"]), 2)   # exactly page 1's functions
+        self.assertEqual(job["status"], "building")
+
+        self._router.release_pages(2)   # let the remaining 2 pages through
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+        self.assertEqual(similarity._jobs["aaaa"]["pages_seen"], 3)
+
+    def test_completion_clears_live_records_and_partial_cache(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(3)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+        job = similarity._jobs["aaaa"]
+        self.assertNotIn("live_records", job)
+        self.assertNotIn("_partial_cache", job)
+
+    def test_binary_change_mid_build_stops_and_does_not_persist(self):
+        orig_key, _ = similarity._instance_key("aaaa")   # fingerprint BEFORE any swap
+        orig_n = similarity._FP_CHECK_EVERY_N_PAGES
+        similarity._FP_CHECK_EVERY_N_PAGES = 1   # check every page for a deterministic test
+        self._router.swap_after_pages = 1        # fingerprint flips once page 2 is requested
+        try:
+            similarity.index_functions({"instance_id": "aaaa", "background": True})
+            self._router.release_pages(3)
+            _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "error")
+        finally:
+            similarity._FP_CHECK_EVERY_N_PAGES = orig_n
+
+        job = similarity._jobs["aaaa"]
+        self.assertIn("binary changed", job["error"])
+        self.assertLessEqual(job["pages_seen"], 2)   # detected within the checked bound
+        rp = similarity._registry_path()
+        self.assertFalse(index_store.has_index(orig_key, rp),
+                          "an error/superseded build must not persist a final index")
 
 
 if __name__ == "__main__":

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -328,6 +328,7 @@ class PausableRouter:
         self.pages_served = 0
         self.swap_after_pages = None
         self._swapped = False
+        self.fail_fingerprint_times = 0
 
     def release_pages(self, n):
         for _ in range(n):
@@ -341,6 +342,9 @@ class PausableRouter:
         if feats is None:
             return {"error": f"no instance {iid}"}
         if name == "binary_fingerprint":
+            if self.fail_fingerprint_times > 0:
+                self.fail_fingerprint_times -= 1
+                return {"error": "transient routing failure"}
             sha = f"sha-{iid}-swapped" if self._swapped else f"sha-{iid}"
             payload = {"sha256": sha, "md5": None,
                        "function_count": len(feats), "arch": "x86_64"}
@@ -527,7 +531,7 @@ class PartialIndexTest(unittest.TestCase):
         # the gen-mismatch guard itself, rather than staging a full realistic
         # error-then-retry sequence (which would be racy/slow to set up).
         similarity._jobs["aaaa"] = {
-            "status": "building", "gen": 1,
+            "status": "building", "gen": 1, "key": "sha-aaaa",
             "live_records": _corpus()["aaaa"][:2],
         }
 
@@ -607,6 +611,83 @@ class PartialIndexTest(unittest.TestCase):
         out = similarity.similar_functions({"instance_id": "aaaa", "func": "0x1001", "top_k": 5})
         self.assertTrue(out.get("partial"))
         self.assertNotIn("not_indexed", out)
+        self.assertIn("0x1002", [r["addr"] for r in out["results"]])
+
+    # --- code-review follow-up fixes --------------------------------------
+
+    def test_transient_fingerprint_failure_does_not_abort_build(self):
+        orig_n = similarity._FP_CHECK_EVERY_N_PAGES
+        similarity._FP_CHECK_EVERY_N_PAGES = 1   # check every page for a deterministic test
+        try:
+            # index_functions() below makes its own synchronous fingerprint
+            # call first (to resolve the index key) -- only fail the NEXT
+            # one, which is the periodic mid-build recheck on page 1.
+            similarity.index_functions({"instance_id": "aaaa", "background": True})
+            self._router.fail_fingerprint_times = 1
+            self._router.release_pages(3)
+            _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+        finally:
+            similarity._FP_CHECK_EVERY_N_PAGES = orig_n
+
+        self.assertEqual(similarity._jobs["aaaa"]["status"], "ready")
+        self.assertEqual(similarity._jobs["aaaa"]["pages_seen"], 3)
+
+    def test_cancel_prevents_final_write(self):
+        orig_key, _ = similarity._instance_key("aaaa")
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+        with similarity._jobs_lock:
+            similarity._jobs["aaaa"]["cancel"] = True
+
+        self._router.release_pages(2)   # let the background thread observe cancel on page 2
+        _wait_until(lambda: self._router.pages_served == 2)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 2)
+        time.sleep(0.05)   # let _run()'s post-loop guard check finish (no other observable hook)
+
+        rp = similarity._registry_path()
+        self.assertFalse(index_store.has_index(orig_key, rp),
+                          "a cancelled build must not persist a final index")
+        self.assertEqual(self._router.pages_served, 2, "page 3 must not be fetched after cancel")
+
+    def test_load_partial_uses_the_jobs_recorded_key_not_a_live_refetch(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+        orig_key = similarity._jobs["aaaa"]["key"]
+
+        self._router._swapped = True   # live fingerprint would now differ
+        entry = similarity._load_partial("aaaa")
+        self.assertEqual(entry["index"]["binary_sha256"], orig_key,
+                          "_load_partial must tag the partial index with the build's own "
+                          "recorded key, not whatever the live fingerprint currently reads")
+
+        self._router._swapped = False
+        self._router.release_pages(2)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+
+    def test_similar_functions_not_indexed_race_falls_back_to_completed_index(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+
+        real_load_partial = similarity._load_partial
+
+        def load_partial_after_completion(iid):
+            # Simulate the build finishing in the window between _load()
+            # returning None and _load_partial() being consulted.
+            self._router.release_pages(2)
+            _wait_until(lambda: similarity._jobs.get(iid, {}).get("status") == "ready")
+            return real_load_partial(iid)
+
+        similarity._load_partial = load_partial_after_completion
+        try:
+            out = similarity.similar_functions({"instance_id": "aaaa", "func": "0x1001", "top_k": 5})
+        finally:
+            similarity._load_partial = real_load_partial
+
+        self.assertNotIn("not_indexed", out)
+        self.assertFalse(out.get("partial", False))
         self.assertIn("0x1002", [r["addr"] for r in out["results"]])
 
 

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -522,6 +522,43 @@ class PartialIndexTest(unittest.TestCase):
         self.assertNotIn("_partial_cache", job,
                           "a stale write-back must not resurrect cleared partial state")
 
+    def test_load_partial_write_back_respects_generation_bump(self):
+        # Directly inject a "building" job (grey-box) so this test isolates
+        # the gen-mismatch guard itself, rather than staging a full realistic
+        # error-then-retry sequence (which would be racy/slow to set up).
+        similarity._jobs["aaaa"] = {
+            "status": "building", "gen": 1,
+            "live_records": _corpus()["aaaa"][:2],
+        }
+
+        entered = threading.Event()
+        resume = threading.Event()
+        real_assemble = similarity._assemble_index
+
+        def blocking_assemble(*args, **kwargs):
+            entered.set()
+            resume.wait(timeout=5)
+            return real_assemble(*args, **kwargs)
+
+        similarity._assemble_index = blocking_assemble
+        try:
+            t = threading.Thread(target=similarity._load_partial, args=("aaaa",))
+            t.start()
+            self.assertTrue(entered.wait(timeout=5))
+
+            # Simulate a retried build superseding this one (a fresh
+            # _start_background call always bumps gen).
+            with similarity._jobs_lock:
+                similarity._jobs["aaaa"]["gen"] = 2
+
+            resume.set()
+            t.join(timeout=5)
+        finally:
+            similarity._assemble_index = real_assemble
+
+        self.assertIsNone(similarity._jobs["aaaa"].get("_partial_cache"),
+                           "a write-back for a superseded generation must be dropped")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -435,6 +435,54 @@ class PartialIndexTest(unittest.TestCase):
         self.assertFalse(index_store.has_index(orig_key, rp),
                           "an error/superseded build must not persist a final index")
 
+    def test_load_partial_returns_none_with_no_build(self):
+        self.assertIsNone(similarity._load_partial("aaaa"))
+
+    def test_load_partial_reflects_pages_seen_so_far(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+
+        entry = similarity._load_partial("aaaa")
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry["index"]["function_count"], 2)
+        self.assertIn("anchor_index", entry)
+
+        self._router.release_pages(2)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+
+    def test_load_partial_returns_none_once_build_completes(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(3)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+        self.assertIsNone(similarity._load_partial("aaaa"))
+
+    def test_load_partial_debounces_within_ttl(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+
+        first = similarity._load_partial("aaaa")
+        second = similarity._load_partial("aaaa")
+        self.assertIs(first, second, "within the TTL, the cached entry object must be reused")
+
+        self._router.release_pages(2)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+
+    def test_load_partial_still_serves_after_build_errors(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+        # Force the job into "error" directly (grey-box) rather than staging a
+        # real IDA-call failure -- isolates the status-gate behavior under test.
+        with similarity._jobs_lock:
+            similarity._jobs["aaaa"]["status"] = "error"
+            similarity._jobs["aaaa"]["error"] = "synthetic failure for this test"
+
+        entry = similarity._load_partial("aaaa")
+        self.assertIsNotNone(entry, "an errored build's last-known partial data must stay servable")
+        self.assertEqual(entry["index"]["function_count"], 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -483,6 +483,45 @@ class PartialIndexTest(unittest.TestCase):
         self.assertIsNotNone(entry, "an errored build's last-known partial data must stay servable")
         self.assertEqual(entry["index"]["function_count"], 2)
 
+    def test_load_partial_write_back_does_not_resurrect_cleared_state(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+
+        entered = threading.Event()
+        resume = threading.Event()
+        real_assemble = similarity._assemble_index
+        call_count = {"n": 0}
+
+        def blocking_assemble(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                entered.set()
+                resume.wait(timeout=5)
+            return real_assemble(*args, **kwargs)
+
+        similarity._assemble_index = blocking_assemble
+        try:
+            t = threading.Thread(target=similarity._load_partial, args=("aaaa",))
+            t.start()
+            self.assertTrue(entered.wait(timeout=5), "_load_partial did not reach _assemble_index")
+
+            # While _load_partial is blocked mid-computation, let the REAL
+            # background build finish (its own _assemble_index call is #2,
+            # which passes straight through).
+            self._router.release_pages(2)
+            _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+
+            resume.set()   # let _load_partial's blocked call proceed and try to write back
+            t.join(timeout=5)
+        finally:
+            similarity._assemble_index = real_assemble
+
+        job = similarity._jobs["aaaa"]
+        self.assertNotIn("live_records", job)
+        self.assertNotIn("_partial_cache", job,
+                          "a stale write-back must not resurrect cleared partial state")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -559,6 +559,56 @@ class PartialIndexTest(unittest.TestCase):
         self.assertIsNone(similarity._jobs["aaaa"].get("_partial_cache"),
                            "a write-back for a superseded generation must be dropped")
 
+    def test_similar_functions_serves_partial_results_mid_build(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)   # page 1 = addrs 0x1001, 0x1002 (the encrypt twins)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+
+        out = similarity.similar_functions({"instance_id": "aaaa", "func": "0x1001", "top_k": 5})
+        self.assertTrue(out.get("partial"))
+        self.assertEqual(out["coverage"]["aaaa"]["done"], 2)
+        self.assertIsNone(out["coverage"]["aaaa"]["total"])
+        addrs = [r["addr"] for r in out["results"]]
+        self.assertIn("0x1002", addrs)          # its twin landed in page 1
+        for a in addrs:
+            self.assertIn(a, ("0x1001", "0x1002"))   # nothing from later pages
+
+        self._router.release_pages(2)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+
+        out2 = similarity.similar_functions({"instance_id": "aaaa", "func": "0x1001", "top_k": 5})
+        self.assertFalse(out2.get("partial", False))
+        self.assertNotIn("coverage", out2)
+
+    def test_similar_functions_query_not_yet_covered_does_not_crash(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)   # page 1 only has 0x1001/0x1002
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+
+        # 0x1005 ("misc_z") is in page 3, not yet processed by the background
+        # loop -- but func_features resolves single-address queries directly
+        # (unrelated to the paginated '*' gate), so this must not crash.
+        out = similarity.similar_functions({"instance_id": "aaaa", "func": "0x1005", "top_k": 5})
+        self.assertNotIn("error", out)
+        self.assertTrue(out.get("partial"))
+        self.assertEqual(out["query"]["addr"], "0x1005")
+
+        self._router.release_pages(2)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("status") == "ready")
+
+    def test_similar_functions_serves_partial_after_build_error(self):
+        similarity.index_functions({"instance_id": "aaaa", "background": True})
+        self._router.release_pages(1)
+        _wait_until(lambda: similarity._jobs.get("aaaa", {}).get("pages_seen") == 1)
+        with similarity._jobs_lock:
+            similarity._jobs["aaaa"]["status"] = "error"
+            similarity._jobs["aaaa"]["error"] = "synthetic failure for this test"
+
+        out = similarity.similar_functions({"instance_id": "aaaa", "func": "0x1001", "top_k": 5})
+        self.assertTrue(out.get("partial"))
+        self.assertNotIn("not_indexed", out)
+        self.assertIn("0x1002", [r["addr"] for r in out["results"]])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`index_functions()` builds the per-binary function-similarity index in a background thread, but until it finishes, `similar_functions()` returned `not_indexed` unconditionally — useless on large binaries (observed: 130K+ functions, multi-minute builds).

This lets `similar_functions()` serve results against whatever the build has processed so far, tagged `partial: true` + per-instance `coverage`, without any new persisted formats or new dependencies.

- `_start_background`/`_on_page`/`_run` now tag each build with a monotonic generation, expose its growing records list on the job, clear that state on completion, and bound (not eliminate) exposure to a mid-build binary swap via a periodic fingerprint recheck.
- New `_load_partial()` reuses the existing from-scratch `_assemble_index`/`build_anchor_index` functions (no new merge/incremental-aggregation code) over the in-progress records, debounced 2s.
- `similar_functions()` falls back to it when no persisted index exists yet.

## Process

Design went through 3 rounds of independent adversarial review before implementation (an initial incremental-merge + resume-sidecar design was found over-engineered and replaced with this simpler debounced-recompute approach — see `docs/superpowers/specs/2026-07-08-incremental-similarity-indexing-design.md` for the full history). Implementation followed a 6-task TDD plan (`docs/superpowers/plans/2026-07-08-incremental-similarity-indexing-plan.md`). Post-implementation, 2 independent reviewers found 4 real issues (1 HIGH: transient fingerprint-fetch failures were treated as binary swaps; 2 MEDIUM: `cancel` bypassing the final-write guard, and a `_load()`/`_load_partial()` TOCTOU that could report a fully-indexed instance as `not_indexed`; 1 LOW: re-fetching a live fingerprint instead of the build's recorded one) — all fixed and re-verified by a follow-up independent review (confirmed "sound and ready to ship").

## Test plan

- [x] `python3 -m pytest tests/` — 356 passed, 4 skipped (pre-existing, unrelated)
- [x] New `PartialIndexTest` class (17 tests) covers: generation/live-records exposure, memory cleanup on completion, bounded binary-change detection, debounced partial loading (including serving an errored build's last-known state), two independent write-back race regressions (completion race, generation-bump race), `similar_functions()` wiring (`partial`/`coverage`, query-not-yet-covered, serves-after-error), and the 4 code-review-driven fixes (transient fingerprint failure, cancel guard, TOCTOU retry, recorded-key reuse)
- [x] Manually verified the completion-race regression test actually fails without its guard (temporarily weakened it, confirmed failure, restored) before committing it as coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)