### PR TITLE
fix: real batched jTrans embedding + MPS device support

### DIFF
--- a/docs/superpowers/plans/2026-07-08-neural-embedding-scalability-plan.md
+++ b/docs/superpowers/plans/2026-07-08-neural-embedding-scalability-plan.md
@@ -1,0 +1,498 @@
+# Neural Embedding Scalability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Note for this run**: tasks are executed sequentially in the main session (not fresh subagents per task) — Task 3 depends on Task 2's file existing and mirrors its patterns; sequential execution matches how this codebase's sibling feature (partial-index serving) was implemented in this same session.
+
+**Goal:** Fix the two real performance problems in the optional neural (jTrans) embedding backend — a `embed_batch()` that isn't actually batched, and CUDA-only device selection that leaves Apple Silicon on CPU — without changing what gets embedded or how results are scored.
+
+**Architecture:** Rewrite `JTransBackend.embed_batch()` to do one padded-tensor tokenizer call + one forward pass per invocation instead of a per-item Python loop; extract device selection into a standalone, unit-testable `_select_device()` function that adds an MPS branch; add a defensive empty-input guard around the two `_embed_incremental()` call sites in `similarity.py` (placed precisely so it doesn't break status bookkeeping for a zero-valid-function build).
+
+**Tech Stack:** Python 3.11+. `torch`/`transformers` are an optional `[neural]` extra — code in `neural_backend.py` imports them lazily inside functions, never at module level. Tests: `unittest`, matching `tests/test_similarity_neural.py`'s existing style; new tests requiring real tensor construction are gated `@unittest.skipUnless(neural_backend.is_available(), ...)`.
+
+## Global Constraints
+
+- `torch`/`transformers` stay optional — no module-level `import torch` anywhere in `src/ida_multi_mcp/`; every existing and new use is inside a function body — spec §Approach, `neural_backend.py`'s existing pattern.
+- No change to what gets embedded (still every valid function — the "anchor-gated selective embedding" idea was evaluated and dropped; see spec §v1→v2) and no change to `sim_score.py`'s scoring/blending — spec §Non-goals.
+- No new persisted formats or schema changes to the vectors sidecar (`index_store.py`'s `append_vectors`/`read_vectors`) — untouched, spec §Non-goals.
+- No "tiny real `BertConfig`" model-instantiation test tier — this repo's existing tests never instantiate a real `transformers` model; new tests either need zero torch (pure logic) or use a hand-mocked `_load()` returning fake-but-real small tensors, never a real HF model load — spec §Non-goals, §Testing.
+- Full existing test suite (`pytest tests/`) must stay green throughout — spec §Testing.
+- Design spec of record: `docs/superpowers/specs/2026-07-08-neural-embedding-scalability-design.md` (§Approach (v3) is authoritative for exact code shape; this plan mirrors it 1:1).
+
+---
+
+## File Structure
+
+- **Modify**: `src/ida_multi_mcp/tools/neural_backend.py` — `_load()`'s device selection extracted to `_select_device()`; `JTransBackend.embed_batch()` rewritten for real batching.
+- **Modify**: `src/ida_multi_mcp/tools/similarity.py` — two call sites (`index_functions()`'s sync branch, `_start_background`'s `_run()`) gain an empty-`valid_addrs` guard around the `_embed_incremental()` call only.
+- **Create**: `tests/test_neural_backend.py` — new file, `_select_device()` unit tests + batching-equivalence test (both torch-gated).
+- **Modify**: `tests/test_similarity_neural.py` — two new regression tests (sync-branch skip-on-empty, background-branch bookkeeping-stays-correct-on-empty).
+
+---
+
+## Task 1: Extract `_select_device()` and add MPS support
+
+**Files:**
+- Modify: `src/ida_multi_mcp/tools/neural_backend.py:78-97` (`_load`)
+- Create: `tests/test_neural_backend.py`
+
+**Interfaces:**
+- Produces: `_select_device() -> str` — module-level function in `neural_backend.py`, returns `"cuda"`, `"mps"`, or `"cpu"` in that priority order, based on `torch.cuda.is_available()` / `torch.backends.mps.is_available()`. `_load()` calls it instead of its inline ternary; no change to `_load()`'s signature or its `@functools.lru_cache` decorator.
+- Consumes: nothing from other tasks (first task).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_neural_backend.py`:
+```python
+"""Unit tests for tools/neural_backend.py's device selection and batched
+embedding. torch/transformers are an optional [neural] extra; every test
+here is gated on their availability and skips cleanly when absent.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from ida_multi_mcp.tools import neural_backend  # noqa: E402
+
+_SKIP_REASON = "torch/transformers not installed (optional [neural] extra)"
+
+
+@unittest.skipUnless(neural_backend.is_available(), _SKIP_REASON)
+class SelectDeviceTest(unittest.TestCase):
+    def setUp(self):
+        import torch
+        self._orig_cuda = torch.cuda.is_available
+        self._orig_mps = torch.backends.mps.is_available
+
+    def tearDown(self):
+        import torch
+        torch.cuda.is_available = self._orig_cuda
+        torch.backends.mps.is_available = self._orig_mps
+
+    def test_prefers_cuda_when_available(self):
+        import torch
+        torch.cuda.is_available = lambda: True
+        torch.backends.mps.is_available = lambda: True
+        self.assertEqual(neural_backend._select_device(), "cuda")
+
+    def test_prefers_mps_over_cpu_when_cuda_unavailable(self):
+        import torch
+        torch.cuda.is_available = lambda: False
+        torch.backends.mps.is_available = lambda: True
+        self.assertEqual(neural_backend._select_device(), "mps")
+
+    def test_falls_back_to_cpu(self):
+        import torch
+        torch.cuda.is_available = lambda: False
+        torch.backends.mps.is_available = lambda: False
+        self.assertEqual(neural_backend._select_device(), "cpu")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/merozemory/projects/MeroZemory/ida-multi-mcp
+python3 -m pytest tests/test_neural_backend.py -v
+```
+Expected: if `torch`/`transformers` are NOT installed in your environment, all three tests report `SKIPPED` (not a failure — this confirms the skip gate itself works; proceed to Step 3 regardless, since the code must be correct whether or not this particular environment can execute it). If they ARE installed, all three FAIL with `AttributeError: module 'ida_multi_mcp.tools.neural_backend' has no attribute '_select_device'`.
+
+- [ ] **Step 3: Implement**
+
+In `src/ida_multi_mcp/tools/neural_backend.py`, add `_select_device` immediately before `_load` (before line 78's `@functools.lru_cache(maxsize=2)`):
+```python
+def _select_device() -> str:
+    import torch
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+@functools.lru_cache(maxsize=2)
+def _load(model_id: str, tokenizer_id: str):
+    import torch
+    from transformers import AutoTokenizer, BertModel
+
+    class BinBertModel(BertModel):
+        """jTrans's model: BERT with position embeddings tied to word embeddings,
+        so a JUMP_ADDR_k token resonates with the target instruction's position
+        (its jump-aware mechanism). Exactly jTrans eval_save.py:105."""
+
+        def __init__(self, config, add_pooling_layer=False):
+            super().__init__(config, add_pooling_layer=add_pooling_layer)
+            self.embeddings.position_embeddings = self.embeddings.word_embeddings
+
+    tok = AutoTokenizer.from_pretrained(tokenizer_id)
+    model = BinBertModel.from_pretrained(
+        model_id, add_pooling_layer=False, ignore_mismatched_sizes=True)
+    dev = _select_device()
+    model.to(dev).eval()
+    return tok, model, dev
+```
+This changes exactly one line inside `_load` (`dev = "cuda" if torch.cuda.is_available() else "cpu"` → `dev = _select_device()`) and adds the new function above it; everything else in `_load` is unchanged.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+python3 -m pytest tests/test_neural_backend.py -v
+```
+Expected: PASS (or SKIPPED, consistently with Step 2's result — if your environment doesn't have `torch` installed, install it temporarily to verify locally: `pip install torch transformers`, rerun, then it's fine to leave it uninstalled again — the test suite must pass either way).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ida_multi_mcp/tools/neural_backend.py tests/test_neural_backend.py
+git commit -m "feat: add MPS device support to the neural embedding backend
+
+Extracts device selection out of _load() into a standalone _select_device()
+function (cuda > mps > cpu priority) so Apple Silicon Macs use Metal
+acceleration instead of falling back to CPU-only inference. Also makes
+device selection unit-testable without instantiating a model."
+```
+
+---
+
+## Task 2: Real batched inference in `JTransBackend.embed_batch`
+
+**Files:**
+- Modify: `src/ida_multi_mcp/tools/neural_backend.py:111-123` (`JTransBackend.embed_batch`)
+- Test: `tests/test_neural_backend.py` (extend)
+
+**Interfaces:**
+- Produces: `JTransBackend.embed_batch(token_lists: list[list[str]]) -> list[list[float]]` — same signature and return shape as today (unit-normalized `[CLS]` vectors, one per input, in input order), but implemented as one batched tokenizer call + one forward pass instead of a per-item loop. Returns `[]` immediately for an empty `token_lists`, without importing `torch`.
+- Consumes: `_select_device()` (Task 1, indirectly via `_load()` — `embed_batch` itself doesn't call it directly, `_load()` does).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_neural_backend.py`, after `SelectDeviceTest`:
+```python
+class EmbedBatchTest(unittest.TestCase):
+    def test_empty_list_returns_empty_without_torch(self):
+        # Must not require torch/transformers to be installed: verifies the
+        # guard runs before `import torch`.
+        backend = neural_backend.JTransBackend("unused-model-id", "unused-tok-id")
+        self.assertEqual(backend.embed_batch([]), [])
+
+
+@unittest.skipUnless(neural_backend.is_available(), _SKIP_REASON)
+class EmbedBatchBatchingTest(unittest.TestCase):
+    """Verifies embed_batch's real tensor batching logic (padding, attention
+    mask, [CLS] indexing, output ordering) via a hand-mocked _load() --
+    fake-but-real small torch tensors, no real transformers model needed.
+    """
+
+    def setUp(self):
+        import torch
+
+        class _FakeTokenizer:
+            def __call__(self, texts, return_tensors, truncation, max_length, padding):
+                # One token per character (deterministic, easy to reason about);
+                # pad to the longest text in the batch (mirrors a real tokenizer).
+                lengths = [max(len(t), 1) for t in texts]
+                width = max(lengths)
+                input_ids = torch.zeros((len(texts), width), dtype=torch.long)
+                attention_mask = torch.zeros((len(texts), width), dtype=torch.long)
+                for i, n in enumerate(lengths):
+                    attention_mask[i, :n] = 1
+                return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+        class _FakeOutput:
+            def __init__(self, last_hidden_state):
+                self.last_hidden_state = last_hidden_state
+
+        class _FakeModel:
+            def __call__(self, input_ids, attention_mask):
+                batch, width = input_ids.shape
+                # 4-dim hidden state; row i's [CLS] (position 0) is a one-hot
+                # encoding of i, so a transposed/misindexed batch is detectable
+                # by decoding argmax back to the row index.
+                hidden = torch.zeros((batch, width, 4))
+                for i in range(batch):
+                    hidden[i, 0, i % 4] = 1.0
+                return _FakeOutput(hidden)
+
+        self._tok, self._model, self._dev = _FakeTokenizer(), _FakeModel(), "cpu"
+        self._orig_load = neural_backend._load
+        neural_backend._load = lambda model_id, tokenizer_id: (
+            self._tok, self._model, self._dev)
+
+    def tearDown(self):
+        neural_backend._load = self._orig_load
+
+    def test_batched_output_preserves_order_and_count(self):
+        backend = neural_backend.JTransBackend("fake-model", "fake-tok")
+        token_lists = [["a", "b", "c"], ["d"], ["e", "f"]]
+        vecs = backend.embed_batch(token_lists)
+        self.assertEqual(len(vecs), 3)
+        for i, v in enumerate(vecs):
+            self.assertEqual(len(v), 4)
+            decoded = max(range(4), key=lambda j: v[j])
+            self.assertEqual(decoded, i % 4,
+                              f"row {i}'s decoded index doesn't match -- "
+                              "batch dimension may be transposed or misindexed")
+
+    def test_empty_token_list_entry_within_a_nonempty_batch(self):
+        backend = neural_backend.JTransBackend("fake-model", "fake-tok")
+        vecs = backend.embed_batch([["a", "b"], [], ["c"]])
+        self.assertEqual(len(vecs), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+python3 -m pytest tests/test_neural_backend.py -v
+```
+Expected: `test_empty_list_returns_empty_without_torch` PASSES already (the empty-input behavior happens to already hold for the OLD per-item-loop implementation too — `for toks in []` is a no-op, returning `[]` — this test is here to lock in that behavior across the rewrite, not to prove a bug). `EmbedBatchBatchingTest`'s two tests FAIL (or SKIP if torch isn't installed) — the fake `_load` returns a 4-dim hidden state and the OLD implementation does `last_hidden_state[0, 0]` (indexing into the wrong axis for a batched multi-row tensor) rather than `[:, 0]`, so decoded values won't line up correctly, or the old per-item loop calls `model(**enc)` per single item so the fake `_FakeModel.__call__`'s multi-row batch logic wouldn't even receive a real batch — confirms the equivalence test actually exercises different code than today's implementation.
+
+- [ ] **Step 3: Implement**
+
+In `src/ida_multi_mcp/tools/neural_backend.py`, replace `embed_batch` (current lines 111-123):
+```python
+    def embed_batch(self, token_lists: list[list[str]]) -> list[list[float]]:
+        """token_lists -> unit-normalized [CLS] vectors (list[list[float]])."""
+        if not token_lists:
+            return []
+        import torch
+        tok, model, dev = _load(self.model_id, self.tokenizer_id)
+        texts = [" ".join(toks) if toks else "" for toks in token_lists]
+        with torch.no_grad():
+            enc = tok(texts, return_tensors="pt", truncation=True,
+                      max_length=self.max_len, padding=True)
+            enc = {k: v.to(dev) for k, v in enc.items()}
+            cls = model(**enc).last_hidden_state[:, 0]          # [CLS] per row
+            vecs = torch.nn.functional.normalize(cls, dim=1).cpu().tolist()
+        return vecs
+```
+(`unk_rate`, immediately below `embed_batch` in the same class, is unchanged — it's diagnostic-only, not in the hot path.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+python3 -m pytest tests/test_neural_backend.py -v
+```
+Expected: all PASS (or SKIP consistently, if torch isn't installed in this environment — the empty-list test still PASSES either way since it doesn't need torch).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ida_multi_mcp/tools/neural_backend.py tests/test_neural_backend.py
+git commit -m "feat: make JTransBackend.embed_batch actually batched
+
+Was a per-item Python loop (one tokenizer call + one forward pass per
+function) despite the name. Now does one padded-tensor tokenizer call +
+one forward pass per invocation, with attention-mask-aware [CLS]
+extraction per row. _embed_incremental already chunks work into
+EMBED_BATCH-sized groups before calling this -- that batching survives
+unchanged; this fixes what happens to each chunk once it gets here."
+```
+
+---
+
+## Task 3: Defensive empty-input guard around `_embed_incremental`
+
+**Files:**
+- Modify: `src/ida_multi_mcp/tools/similarity.py:337-353` (`index_functions()`'s sync branch), `:396-404` (`_start_background`'s `_run()`, phase-2 block)
+- Test: `tests/test_similarity_neural.py` (extend)
+
+**Interfaces:**
+- Consumes: nothing from Tasks 1-2 directly (this task only touches `similarity.py`, not `neural_backend.py`) — independent of them, but grouped in this plan because it's part of the same design spec.
+- Produces: no new functions. Behavior change only: `_embed_incremental()` is no longer called at all when `valid_addrs` is empty, at either of its two call sites. At the `_run()` site specifically, the surrounding `embed_status`/`embed_total`/`embed_done` bookkeeping still runs unconditionally (this is the precise placement round-2 design review required — guarding the whole block, not just the call, was found to leave `embed_status` stuck at a stale/unset value for a zero-valid-function build).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_similarity_neural.py`, after the existing `NeuralRecallTest` class's last test method (`test_partial_vectors_usable_then_resume`) and before `class NeuralBackendPathsTest`:
+```python
+    def test_sync_branch_skips_embedding_for_zero_valid_functions(self):
+        # Reuse this test class's corpus/mocks but swap in a router that
+        # reports zero valid functions (every func_features record is an
+        # error stub) -- mirrors the real shape func_features returns for
+        # an unextractable function (see test_similarity.py's _ErrRouter).
+        class _EmptyValidRouter:
+            def route_request(self, method, params):
+                import json
+                name = params.get("name")
+                if name == "binary_fingerprint":
+                    payload = {"sha256": "sha-empty", "md5": None,
+                              "function_count": 1, "arch": "x86_64"}
+                elif name == "func_features":
+                    payload = {"functions": [{"addr": "0x1", "error": "no func"}],
+                              "total": 1, "cursor": {"done": True}}
+                else:
+                    return {"error": f"unknown tool {name}"}
+                return {"content": [{"type": "text", "text": json.dumps(payload)}],
+                        "structuredContent": payload}
+
+        similarity.set_router(_EmptyValidRouter())
+        called = {"n": 0}
+
+        def _raise_if_called(*a, **k):
+            called["n"] += 1
+            raise AssertionError("get_backend() must not be called for zero valid functions")
+
+        orig_get_backend = neural_backend.get_backend
+        neural_backend.get_backend = _raise_if_called
+        try:
+            res = similarity.index_functions({"instance_id": "nn", "background": False})
+        finally:
+            neural_backend.get_backend = orig_get_backend
+
+        self.assertEqual(res["function_count"], 0)
+        self.assertEqual(called["n"], 0)
+
+    def test_background_branch_reports_done_for_zero_valid_functions(self):
+        import time
+
+        class _EmptyValidRouter:
+            def route_request(self, method, params):
+                import json
+                name = params.get("name")
+                if name == "binary_fingerprint":
+                    payload = {"sha256": "sha-empty-bg", "md5": None,
+                              "function_count": 1, "arch": "x86_64"}
+                elif name == "func_features":
+                    payload = {"functions": [{"addr": "0x1", "error": "no func"}],
+                              "total": 1, "cursor": {"done": True}}
+                else:
+                    return {"error": f"unknown tool {name}"}
+                return {"content": [{"type": "text", "text": json.dumps(payload)}],
+                        "structuredContent": payload}
+
+        similarity.set_router(_EmptyValidRouter())
+        similarity.index_functions({"instance_id": "nn", "background": True})
+
+        deadline = time.time() + 5.0
+        st = {}
+        while time.time() < deadline:
+            st = similarity.index_status({"instance_id": "nn"})
+            if st.get("embed_status") == "done":
+                break
+            time.sleep(0.01)
+        else:
+            self.fail("embed_status never reached 'done' within 5s "
+                      f"(last status: {st})")
+
+        self.assertEqual(st["embed_total"], 0)
+```
+
+Add `from ida_multi_mcp.tools import neural_backend` is already imported at the top of this file (line 19) — no new import needed for these two tests.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+python3 -m pytest tests/test_similarity_neural.py -v -k "zero_valid"
+```
+Expected: `test_sync_branch_skips_embedding_for_zero_valid_functions` FAILS with the `AssertionError("get_backend() must not be called...")` raised from inside `_raise_if_called` (today's code calls `_embed_incremental` unconditionally, which calls `get_backend()` even for zero valid functions). `test_background_branch_reports_done_for_zero_valid_functions` currently PASSES already (bookkeeping already runs unconditionally today, before this task's change) — that's expected and fine: it's here as a **regression guard** for Task 3's own upcoming edit, to prove the fix doesn't reintroduce the round-2-identified stuck-`"pending"` bug. Keep it in the suite; it should stay green through Step 4.
+
+- [ ] **Step 3: Implement**
+
+In `src/ida_multi_mcp/tools/similarity.py`, in `index_functions()`'s sync branch, change:
+```python
+    neural = False
+    if _neural_enabled():
+        _embed_incremental(iid, key, rp, valid_addrs)
+        neural = bool(index_store.read_vectors(key, rp))
+```
+to:
+```python
+    neural = False
+    if _neural_enabled() and valid_addrs:
+        _embed_incremental(iid, key, rp, valid_addrs)
+        neural = bool(index_store.read_vectors(key, rp))
+```
+
+In `_start_background`'s `_run()`, change:
+```python
+            # Phase 2: neural vectors accrue in the background (non-blocking).
+            if _neural_enabled():
+                with _jobs_lock:
+                    _jobs[iid].update(embed_status="embedding",
+                                      embed_total=len(valid_addrs), embed_done=0)
+                _embed_incremental(iid, key, rp, valid_addrs)
+                with _jobs_lock:
+                    if not _jobs[iid].get("cancel"):
+                        _jobs[iid].update(embed_status="done")
+```
+to (only the added `if valid_addrs:` line and its indentation of the existing call — the bookkeeping lines before and after are unchanged and stay unconditional):
+```python
+            # Phase 2: neural vectors accrue in the background (non-blocking).
+            if _neural_enabled():
+                with _jobs_lock:
+                    _jobs[iid].update(embed_status="embedding",
+                                      embed_total=len(valid_addrs), embed_done=0)
+                if valid_addrs:
+                    _embed_incremental(iid, key, rp, valid_addrs)
+                with _jobs_lock:
+                    if not _jobs[iid].get("cancel"):
+                        _jobs[iid].update(embed_status="done")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+python3 -m pytest tests/test_similarity_neural.py -v
+python3 -m pytest tests/ -v
+```
+Expected: both new tests PASS; every pre-existing test in `test_similarity_neural.py` (and the whole suite) still PASSES — `test_index_stores_vectors`, `test_neural_recall_surfaces_anchorless_twin`, `test_disabled_neural_misses_twin`, `test_index_status_reports_full_embed_progress`, and `test_partial_vectors_usable_then_resume` all use corpora with valid (non-error) functions, so `valid_addrs` is always non-empty for them — the new `and valid_addrs` / `if valid_addrs:` guards are no-ops on those paths.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ida_multi_mcp/tools/similarity.py tests/test_similarity_neural.py
+git commit -m "fix: skip neural embedding entirely for zero valid functions
+
+_embed_incremental() unconditionally called neural_backend.get_backend()
+(which can trigger a ~1.2GB model download) and paged the whole binary's
+func_tokens, even when there was nothing to embed. Guarded at both call
+sites. The background-thread call site's guard applies ONLY to the
+_embed_incremental() call, not the embed_status/embed_total/embed_done
+bookkeeping around it -- guarding the whole block would leave a
+zero-valid-function build's embed_status stuck unset instead of
+resolving to \"done\"."
+```
+
+---
+
+## Task 4: Full regression run
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the complete test suite**
+
+```bash
+cd /Users/merozemory/projects/MeroZemory/ida-multi-mcp
+python3 -m pytest tests/ -v
+```
+Expected: every test PASSES or SKIPS cleanly (torch-gated tests skip if `[neural]` isn't installed in this environment) — no FAILs, no ERRORs.
+
+- [ ] **Step 2: If `torch`/`transformers` are available in this environment, additionally smoke-test the real batched path once**
+
+This is a one-time manual check (per the design spec's Non-goals — no permanent real-model test infrastructure), not an automated test:
+```bash
+python3 -c "
+from ida_multi_mcp.tools import neural_backend
+if neural_backend.is_available():
+    backend = neural_backend.get_backend()
+    vecs = backend.embed_batch([['mov.rr', 'add.ri', 'ret.'], ['push.r', 'pop.r']])
+    print('embedded', len(vecs), 'vectors, dim', len(vecs[0]) if vecs else 0)
+else:
+    print('torch/transformers not installed -- skipping manual smoke test')
+"
+```
+Expected: either the skip message, or `embedded 2 vectors, dim 768` (jTrans's embedding dimension) — confirms the real tokenizer/model path works end-to-end with the batched rewrite, not just the mocked test. Note the result in the PR description (downloads the ~1.2GB jTrans checkpoint on first run if not already cached at `~/.ida-mcp/models/`).
+
+- [ ] **Step 3: Commit (only if Step 1 or 2 required a fixup; otherwise this task produces no diff)**
+
+```bash
+git add -A
+git commit -m "test: fix regression found during full-suite verification"
+```

--- a/docs/superpowers/specs/2026-07-08-neural-embedding-scalability-design.md
+++ b/docs/superpowers/specs/2026-07-08-neural-embedding-scalability-design.md
@@ -1,0 +1,312 @@
+# Neural Embedding Scalability — Design v3 (two rounds of adversarial review)
+
+## Problem
+
+The optional neural-recall extra (`IDA_MCP_SIM_NEURAL=1`, jTrans embeddings)
+has two real performance problems on large binaries (observed: a
+130,717-function binary):
+
+1. **`JTransBackend.embed_batch()` (`tools/neural_backend.py:111-123`) is not
+   actually batched** despite its name — it loops per-function, doing one
+   tokenizer call + one `model()` forward pass each. `_embed_incremental`
+   (`tools/similarity.py:67-120`) already chunks work into `EMBED_BATCH`
+   (default 64) groups before calling it, so the batching machinery exists
+   one level up but is thrown away inside `embed_batch` itself.
+2. **Device selection only checks CUDA** (`tools/neural_backend.py:95`:
+   `dev = "cuda" if torch.cuda.is_available() else "cpu"`), so Apple Silicon
+   Macs never use MPS (Metal) acceleration and fall back to CPU-only
+   inference unconditionally — the concrete complaint that started this
+   investigation.
+
+## v1 → v2: what changed after adversarial review
+
+v1 additionally proposed restricting embedding to "anchor-less" functions by
+default (skip embedding any function that has at least one import/string/
+constant anchor), on the premise that neural recall's whole purpose is
+rescuing anchor-less functions per
+`docs/plans/function-similarity/04-neural-semantic-track.md` §1. Three
+independent reviewers found this premise doesn't survive contact with the
+actual scoring code:
+
+1. **CRITICAL — real recall regressions, not just missed optimization.**
+   Neural recall in `similar_functions()` does cosine top-K over the
+   **gallery** side's vectors (`gvectors = idx.get("vectors", {})`,
+   `similarity.py:552-557`) — it is symmetric, not query-centric. The design
+   only guaranteed the *query* gets a vector; it assumed an anchor-less
+   query's true cross-compiler twin would *also* be anchor-less. That's not
+   guaranteed: two twins can each have anchors that simply don't overlap
+   (inlined vs. imported `memcpy`, differently-pooled strings), or only one
+   side has any anchor at all. `anchor_candidates()`'s rare-anchor
+   requirement (`sim_score.py:397-410`) already fails to surface such pairs
+   lexically; restricting gallery-side embedding to anchor-less functions
+   means neural recall *also* fails to surface them, because the twin never
+   gets a vector. **Today's embed-everything behavior catches cases this
+   design would have silently stopped catching** — a regression dressed up
+   as an optimization.
+2. **HIGH — ranking silently shifts for candidates that keep their vector.**
+   The neural blend (`final = (1-λ)·grouped + λ·ncos`, `λ=0.7` default) only
+   applies `if gvectors.get(addr)`. Anchor-rich candidates that lose their
+   vector under the restricted scope silently revert to 100% grouped
+   scoring, changing rankings for pairs that have nothing to do with the
+   "anchor-less rescue" goal. The v1 design's "doesn't change how scoring
+   works" non-goal claim was false.
+3. **HIGH — the proposed "fix embedding completeness tracking" sub-change
+   compared vector *counts* against a target count, not set membership.**
+   `index_store.read_vectors()` returns every address ever appended to the
+   sidecar, including ones outside whatever the *current* scope setting
+   targets (e.g., left over from a prior `scope=all` run, or a cancelled
+   job). Comparing `len(done) >= len(target)` instead of `target_set ⊆
+   done_set` can report "embedding complete" while the specific functions
+   that matter were never embedded — silently, with no error, exactly the
+   shape of bug that's hardest to notice in production.
+4. **Independent finding — even the selection predicate was wrong on its
+   own terms.** `anchor_candidates()` only blocks on *rare* anchors
+   (`df <= rare_df`); common anchors don't help candidate-gen find a
+   function. The v1 predicate ("has zero anchors of any kind") would still
+   exclude a function whose only anchors are common ones — exactly a
+   function that's just as invisible to lexical/anchor matching as a truly
+   anchor-less one, and exactly the kind neural recall exists to rescue.
+   Getting this right would require wiring the `df`/`rare_df` machinery
+   into the embedding-selection path — real additional complexity, not the
+   one-line predicate v1 proposed.
+5. **Independent argument — the performance case for restricting scope at
+   all is weak once batching + MPS ship.** 130,717 functions /
+   `EMBED_BATCH=64` ≈ 2,043 forward passes. A padded BERT-base batch of 64
+   short sequences on GPU or MPS runs in roughly 100–400ms once tokenizer/
+   kernel-launch-per-call overhead is gone — call it 5–15 minutes total,
+   "minutes not days" for any CUDA or Apple Silicon machine. The scenario
+   that's still slow is CPU-only hardware (no CUDA, no MPS) — a hardware-
+   tier limitation, not evidence the *embedding target* was wrong.
+
+**v2 drops the anchor-gated scope entirely.** Ship the two changes that are
+unambiguously correct and address the concrete complaint (Apple Silicon /
+GPU users watching a CPU-only, unbatched embedding phase crawl). If
+CPU-only-hardware throughput still proves insufficient in practice after
+these ship, a properly `df`/`rare_df`-gated scope-narrowing (fixing finding
+4) is a well-scoped follow-up — not bundled into this change, and not
+shipped with the correctness gaps findings 1–3 identified.
+
+## v2 → v3: round-2 review findings and fixes
+
+Two independent reviewers verified v2 against the real code. Both confirmed
+fixes 1–2 (batching, MPS) are sound as specified. One found two real gaps:
+
+1. **The §3 guard's placement at the `_run()` call site was
+   under-specified and, applied literally, breaks status reporting for the
+   zero-valid-functions edge case.** The real block at `similarity.py:397-404`
+   (not `:397-401` — corrected) is `if _neural_enabled():` wrapping FOUR
+   statements: pre-call bookkeeping (`embed_status="embedding",
+   embed_total=len(valid_addrs), embed_done=0`), the `_embed_incremental`
+   call, and post-call bookkeeping (`embed_status="done"`). Wrapping the
+   whole header in `and valid_addrs` (as v2's snippet ambiguously suggested)
+   skips the bookkeeping too, leaving `_jobs[iid]` without `embed_status`
+   for a zero-valid-function build — `index_status()` then falls into its
+   `"pending"` branch permanently (`fc=0` makes `fc and nvec>=fc` false)
+   instead of correctly reporting `"done"` (nothing to embed). **Fix**: the
+   `and valid_addrs` guard applies ONLY to the `_embed_incremental(...)`
+   call itself, not the surrounding bookkeeping — see §3 below for the
+   corrected snippet.
+2. **The proposed `embed_batch([])` test is vacuous** — the empty-list guard
+   returns before `import torch`/`_load()`, so the test would pass even
+   under a badly broken batching implementation, and no *other* test
+   (existing or proposed) exercises the real tokenizer/padding/CLS-indexing
+   code path at all (`test_similarity_neural.py` replaces
+   `neural_backend.get_backend()` wholesale with a mock, never touching
+   `JTransBackend.embed_batch`'s real body). **Fix**: add a test that
+   monkeypatches `neural_backend._load` (not `get_backend`) with a fake
+   `(tok, model, dev)` triple whose fake `model()` call encodes each row's
+   identity into its output, then calls the REAL `embed_batch()` with
+   several differently-sized token lists and asserts output order/count
+   matches input — catches a transposed or misindexed batch without
+   needing `transformers`/real weights (still gated on `torch` being
+   importable, since it constructs real tensors). Also noted: every
+   existing test in this file uses `index_functions(...,
+   background=False)`, so a regression test for finding 1 (which is
+   specifically in the `_run()` **background** path) must explicitly use
+   `background=True`, or it won't exercise the code it's meant to guard.
+
+## Approach (v3)
+
+### 1. Real batching in `JTransBackend.embed_batch`
+
+Replace the per-item loop with a single padded-batch tokenizer call + one
+forward pass per `embed_batch` invocation (still externally chunked to
+`EMBED_BATCH` items by `_embed_incremental`, unchanged). Guards against an
+empty input list, which the old per-item loop tolerated for free
+(`for toks in []` is a no-op) but a batched `tok([], ...)` call is not
+guaranteed to (tokenizer padding logic computing `max()` over an empty
+batch is a known crash shape in some versions) — not reachable today (both
+current callers already guard against calling with `[]`), but the batched
+rewrite must not introduce a new crash mode a future caller could hit:
+```python
+def embed_batch(self, token_lists: list[list[str]]) -> list[list[float]]:
+    """token_lists -> unit-normalized [CLS] vectors (list[list[float]])."""
+    if not token_lists:
+        return []
+    import torch
+    tok, model, dev = _load(self.model_id, self.tokenizer_id)
+    texts = [" ".join(toks) if toks else "" for toks in token_lists]
+    with torch.no_grad():
+        enc = tok(texts, return_tensors="pt", truncation=True,
+                   max_length=self.max_len, padding=True)
+        enc = {k: v.to(dev) for k, v in enc.items()}
+        cls = model(**enc).last_hidden_state[:, 0]          # [CLS] per row
+        vecs = torch.nn.functional.normalize(cls, dim=1).cpu().tolist()
+    return vecs
+```
+Verified safe against the actual bundled tokenizer config
+(`tools/jtrans_tokenizer/`): declares `tokenizer_class: BertTokenizer` with
+no `padding_side` override, so HF's default `padding_side="right"` holds —
+`[CLS]` stays at index 0 for every row regardless of padding. `tok(...,
+padding=True)` returns `attention_mask`, and `model(**enc)` consumes it, so
+padded positions are masked out of the CLS token's contextualization — no
+silent quality regression for short sequences batched with longer ones.
+`unk_rate` (diagnostic-only, not in the hot path) is left as-is.
+
+### 2. MPS device support
+
+Extract device selection into its own function so it's unit-testable
+without instantiating a model:
+```python
+def _select_device() -> str:
+    import torch
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+```
+`_load()` calls `dev = _select_device()` instead of the inline ternary.
+`torch.backends.mps` has existed since torch 1.12; `pyproject.toml` already
+pins `torch>=2.0` for the `[neural]` extra, so no version guard needed.
+
+### 3. Defensive empty-input guard in `_embed_incremental` (independent small fix)
+
+Not scope-related — this closes a real gap reviewer feedback found
+independent of the (now-dropped) scope change: `_embed_incremental` with an
+empty `valid_addrs` today still unconditionally calls
+`neural_backend.get_backend()` (`similarity.py:81`), which can trigger
+`ensure_model()` — a ~1.2GB on-demand download — and pages through the
+*entire* binary's `func_tokens` via the network/IDA round-trip, just to
+filter everything out, for a binary with zero valid functions to embed
+(a real, if rare, degenerate case — e.g. an index build where every function
+was skipped as an extraction error). Guard at the call sites instead of
+inside `_embed_incremental` itself (keeps the function's contract simple).
+`valid_addrs` is unchanged from today (still every valid function; no scope
+filtering in v3).
+
+**Sync branch** (`similarity.py:347-350`) — the whole `if _neural_enabled():`
+body is just the call + a status read, so it's safe to guard as a unit:
+```python
+if _neural_enabled() and valid_addrs:
+    _embed_incremental(iid, key, rp, valid_addrs)
+    neural = bool(index_store.read_vectors(key, rp))
+```
+
+**`_run()`'s phase-2 block** (`similarity.py:397-404`) — this `if
+_neural_enabled():` body does bookkeeping *and* the call; per round-2
+review, the `valid_addrs` guard must apply ONLY to the call, not the
+bookkeeping either side of it, so `embed_status` still correctly resolves
+to `"done"` (with `embed_total=0`) instead of getting stuck `"pending"` for
+a zero-valid-function build:
+```python
+if _neural_enabled():
+    with _jobs_lock:
+        _jobs[iid].update(embed_status="embedding",
+                          embed_total=len(valid_addrs), embed_done=0)
+    if valid_addrs:
+        _embed_incremental(iid, key, rp, valid_addrs)
+    with _jobs_lock:
+        if not _jobs[iid].get("cancel"):
+            _jobs[iid].update(embed_status="done")
+```
+(Only the `if valid_addrs:` line is new; the rest of this block is existing
+code shown for placement context.)
+
+## Non-goals
+
+- Anchor-gated / scope-restricted embedding — dropped, see §v1→v2. A
+  future, correctly `df`/`rare_df`-gated version is a separate follow-up if
+  CPU-only throughput proves insufficient after batching+MPS ship, not part
+  of this change.
+- Any change to `sim_score.py`'s scoring/blending logic, the
+  `IDA_MCP_SIM_NEURAL_LAMBDA`/`IDA_MCP_SIM_NEURAL_K` tuning knobs, or the
+  vectors-sidecar format/resumability (`index_store.py`'s
+  `append_vectors`/`read_vectors`) — all unchanged, all already working as
+  designed per `04-neural-semantic-track.md` §9b.
+- A "tiny synthetic `BertConfig`" real-model test tier — considered and
+  dropped; no test in this repo instantiates a real `transformers` model
+  (grep-verified), and this codebase's established pattern is testing
+  entirely at a mock-backend boundary (`tests/test_similarity_neural.py`'s
+  `_MockBackend`). Introducing real-model test infrastructure for this one
+  change would be new machinery inconsistent with that pattern. The batched
+  rewrite is instead smoke-tested manually against the real jTrans
+  checkpoint once during review (documented in the PR description), and
+  covered automatically only at the `_select_device()` pure-function
+  boundary (no model needed).
+
+## Testing
+
+- `tests/test_neural_backend.py` (new — pure-Python, no torch required to
+  collect the file; individual tests skip if torch isn't importable):
+  - `_select_device()`: monkeypatch `torch.cuda.is_available`/
+    `torch.backends.mps.is_available` through all three priority
+    combinations (cuda>mps>cpu), assert the right string returned.
+    `@unittest.skipUnless(neural_backend.is_available(), "torch/transformers not installed")`.
+  - `embed_batch([])` returns `[]` without ever reaching the `import torch`
+    line (the `if not token_lists: return []` guard runs first). Gated with
+    the same `skipUnless` as the other tests for consistency, even though
+    `JTransBackend(...)` construction itself requires nothing torch-specific
+    — keeps this test file's skip behavior uniform rather than having one
+    test collect in environments where its siblings don't.
+  - **Batching-equivalence (round-2 fix — the previous plan's only
+    non-empty-input coverage was vacuous)**: monkeypatch `neural_backend._load`
+    to return a fake `(tok, model, dev)` triple — `tok` a callable that
+    records the input list and returns a minimal dict of real small tensors
+    (`input_ids`, `attention_mask`) shaped from token-list lengths; `model`
+    a callable returning an object whose `.last_hidden_state` is a real
+    tensor where row `i`'s `[CLS]` position encodes `i` (e.g. a one-hot or
+    index-scaled vector) so misordering/mis-indexing is detectable. Call the
+    REAL (unmocked) `embed_batch()` with 3 token lists of different lengths
+    (including one empty list mixed into a non-empty batch) and assert the
+    output count matches input count and each output vector decodes back to
+    its own row's index — catches a transposed batch dimension or wrong
+    `[CLS]` index without needing `transformers`/real weights (still
+    requires `torch` to construct the fake tensors, so still gated).
+- `tests/test_similarity_neural.py` (extended, existing `_MockBackend`/mock
+  router — no torch needed, unchanged from today for anything not listed):
+  - New: `index_functions()` on a corpus where `_valid_records` returns an
+    empty list (all records are `{"addr","error"}` stubs), called with
+    `background=False` (the sync branch), does not call `get_backend()`
+    (assert via monkeypatching `neural_backend.get_backend` to raise if
+    called) — regression test for §3's sync-branch guard.
+  - **New (round-2 fix — every existing test in this file uses
+    `background=False`, which would never exercise the bug that motivated
+    this fix)**: `index_functions(..., background=True)` on the same
+    zero-valid-functions corpus, polled via `index_status()` **specifically
+    until `embed_status == "done"`** (bounded timeout, e.g. ~5s) — NOT until
+    `job_status != "building"`, which is a distinct field the background
+    thread sets *before* reaching the phase-2 embed bookkeeping
+    (`similarity.py:387`/`:394` set `status="ready"` strictly before
+    `:397-404`'s `embed_status` bookkeeping runs); polling the wrong field
+    would read `embed_status` while it's still unset and flake on `None`
+    (round-3 review finding). Once the poll condition is met, additionally
+    assert `embed_total == 0` — regression test for §3's `_run()`-branch
+    guard placement specifically (the round-2 bug: guarding the bookkeeping
+    instead of only the call).
+  - No existing test changes needed — `NEURAL_SCOPE`/selective embedding
+    was dropped, so `test_index_status_reports_full_embed_progress` and
+    `test_partial_vectors_usable_then_resume`'s `embed_total == 3`
+    assertions stay valid unchanged.
+- Full existing suite must stay green — `similar_functions()`'s scoring
+  path, `_embedding_incomplete()`, and `index_status()` are all untouched
+  in v3.
+- **Pre-existing, out-of-scope note**: `index_status()`'s embed-status
+  fallback formula (`"done" if fc and nvec>=fc else "partial" if nvec else
+  "pending"`, `similarity.py:447-448`) would report `"pending"` forever for
+  a zero-valid-functions build queried *without* ever having gone through
+  `_start_background`'s bookkeeping (e.g. only ever called with
+  `background=False`, which never writes `_jobs[iid]["embed_status"]` at
+  all). This is unrelated to and unchanged by this design — `_jobs` state
+  for the sync branch has never been populated, before or after this
+  change — noted for completeness, not fixed here.

--- a/src/ida_multi_mcp/tools/neural_backend.py
+++ b/src/ida_multi_mcp/tools/neural_backend.py
@@ -118,7 +118,10 @@ class JTransBackend:
         self.max_len = max_len
 
     def embed_batch(self, token_lists: list[list[str]]) -> list[list[float]]:
-        """token_lists -> unit-normalized [CLS] vectors (list[list[float]])."""
+        """token_lists -> unit-normalized [CLS] vectors (list[list[float]]).
+
+        One padded-batch tokenizer call + one forward pass per invocation
+        (not per item)."""
         if not token_lists:
             return []
         import torch

--- a/src/ida_multi_mcp/tools/neural_backend.py
+++ b/src/ida_multi_mcp/tools/neural_backend.py
@@ -75,6 +75,15 @@ def resolve_paths(download: bool = True) -> tuple[str, str]:
     return str(model_dir), tok
 
 
+def _select_device() -> str:
+    import torch
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
 @functools.lru_cache(maxsize=2)
 def _load(model_id: str, tokenizer_id: str):
     import torch
@@ -92,7 +101,7 @@ def _load(model_id: str, tokenizer_id: str):
     tok = AutoTokenizer.from_pretrained(tokenizer_id)
     model = BinBertModel.from_pretrained(
         model_id, add_pooling_layer=False, ignore_mismatched_sizes=True)
-    dev = "cuda" if torch.cuda.is_available() else "cpu"
+    dev = _select_device()
     model.to(dev).eval()
     return tok, model, dev
 

--- a/src/ida_multi_mcp/tools/neural_backend.py
+++ b/src/ida_multi_mcp/tools/neural_backend.py
@@ -119,16 +119,17 @@ class JTransBackend:
 
     def embed_batch(self, token_lists: list[list[str]]) -> list[list[float]]:
         """token_lists -> unit-normalized [CLS] vectors (list[list[float]])."""
+        if not token_lists:
+            return []
         import torch
         tok, model, dev = _load(self.model_id, self.tokenizer_id)
-        vecs: list[list[float]] = []
+        texts = [" ".join(toks) if toks else "" for toks in token_lists]
         with torch.no_grad():
-            for toks in token_lists:
-                enc = tok(" ".join(toks) if toks else "", return_tensors="pt",
-                          truncation=True, max_length=self.max_len)
-                enc = {k: v.to(dev) for k, v in enc.items()}
-                v = model(**enc).last_hidden_state[0, 0]              # [CLS]
-                vecs.append(torch.nn.functional.normalize(v, dim=0).cpu().tolist())
+            enc = tok(texts, return_tensors="pt", truncation=True,
+                      max_length=self.max_len, padding=True)
+            enc = {k: v.to(dev) for k, v in enc.items()}
+            cls = model(**enc).last_hidden_state[:, 0]          # [CLS] per row
+            vecs = torch.nn.functional.normalize(cls, dim=1).cpu().tolist()
         return vecs
 
     def unk_rate(self, token_lists: list[list[str]]) -> float:

--- a/src/ida_multi_mcp/tools/similarity.py
+++ b/src/ida_multi_mcp/tools/similarity.py
@@ -345,7 +345,7 @@ def index_functions(arguments: dict) -> dict:
         valid_addrs = list(idx.get("functions", {}).keys())
         fc, sk = idx.get("function_count", len(valid_addrs)), 0
     neural = False
-    if _neural_enabled():
+    if _neural_enabled() and valid_addrs:
         _embed_incremental(iid, key, rp, valid_addrs)
         neural = bool(index_store.read_vectors(key, rp))
     return {"index_id": key, "function_count": fc, "skipped_count": sk,
@@ -398,7 +398,8 @@ def _start_background(iid: str, key: str, fp: dict, binary_name: str,
                 with _jobs_lock:
                     _jobs[iid].update(embed_status="embedding",
                                       embed_total=len(valid_addrs), embed_done=0)
-                _embed_incremental(iid, key, rp, valid_addrs)
+                if valid_addrs:
+                    _embed_incremental(iid, key, rp, valid_addrs)
                 with _jobs_lock:
                     if not _jobs[iid].get("cancel"):
                         _jobs[iid].update(embed_status="done")

--- a/tests/test_neural_backend.py
+++ b/tests/test_neural_backend.py
@@ -45,5 +45,76 @@ class SelectDeviceTest(unittest.TestCase):
         self.assertEqual(neural_backend._select_device(), "cpu")
 
 
+class EmbedBatchTest(unittest.TestCase):
+    def test_empty_list_returns_empty_without_torch(self):
+        # Must not require torch/transformers to be installed: verifies the
+        # guard runs before `import torch`.
+        backend = neural_backend.JTransBackend("unused-model-id", "unused-tok-id")
+        self.assertEqual(backend.embed_batch([]), [])
+
+
+@unittest.skipUnless(neural_backend.is_available(), _SKIP_REASON)
+class EmbedBatchBatchingTest(unittest.TestCase):
+    """Verifies embed_batch's real tensor batching logic (padding, attention
+    mask, [CLS] indexing, output ordering) via a hand-mocked _load() --
+    fake-but-real small torch tensors, no real transformers model needed.
+    """
+
+    def setUp(self):
+        import torch
+
+        class _FakeTokenizer:
+            def __call__(self, texts, return_tensors, truncation, max_length, padding):
+                # One token per character (deterministic, easy to reason about);
+                # pad to the longest text in the batch (mirrors a real tokenizer).
+                lengths = [max(len(t), 1) for t in texts]
+                width = max(lengths)
+                input_ids = torch.zeros((len(texts), width), dtype=torch.long)
+                attention_mask = torch.zeros((len(texts), width), dtype=torch.long)
+                for i, n in enumerate(lengths):
+                    attention_mask[i, :n] = 1
+                return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+        class _FakeOutput:
+            def __init__(self, last_hidden_state):
+                self.last_hidden_state = last_hidden_state
+
+        class _FakeModel:
+            def __call__(self, input_ids, attention_mask):
+                batch, width = input_ids.shape
+                # 4-dim hidden state; row i's [CLS] (position 0) is a one-hot
+                # encoding of i, so a transposed/misindexed batch is detectable
+                # by decoding argmax back to the row index.
+                hidden = torch.zeros((batch, width, 4))
+                for i in range(batch):
+                    hidden[i, 0, i % 4] = 1.0
+                return _FakeOutput(hidden)
+
+        self._tok, self._model, self._dev = _FakeTokenizer(), _FakeModel(), "cpu"
+        self._orig_load = neural_backend._load
+        neural_backend._load = lambda model_id, tokenizer_id: (
+            self._tok, self._model, self._dev)
+
+    def tearDown(self):
+        neural_backend._load = self._orig_load
+
+    def test_batched_output_preserves_order_and_count(self):
+        backend = neural_backend.JTransBackend("fake-model", "fake-tok")
+        token_lists = [["a", "b", "c"], ["d"], ["e", "f"]]
+        vecs = backend.embed_batch(token_lists)
+        self.assertEqual(len(vecs), 3)
+        for i, v in enumerate(vecs):
+            self.assertEqual(len(v), 4)
+            decoded = max(range(4), key=lambda j: v[j])
+            self.assertEqual(decoded, i % 4,
+                              f"row {i}'s decoded index doesn't match -- "
+                              "batch dimension may be transposed or misindexed")
+
+    def test_empty_token_list_entry_within_a_nonempty_batch(self):
+        backend = neural_backend.JTransBackend("fake-model", "fake-tok")
+        vecs = backend.embed_batch([["a", "b"], [], ["c"]])
+        self.assertEqual(len(vecs), 3)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_neural_backend.py
+++ b/tests/test_neural_backend.py
@@ -83,11 +83,15 @@ class EmbedBatchBatchingTest(unittest.TestCase):
             def __call__(self, input_ids, attention_mask):
                 batch, width = input_ids.shape
                 # 4-dim hidden state; row i's [CLS] (position 0) is a one-hot
-                # encoding of i, so a transposed/misindexed batch is detectable
-                # by decoding argmax back to the row index.
+                # encoding of (i + that row's real, masked sequence length).
+                # Folding attention_mask into the *class index* (not just
+                # magnitude, which L2-normalize would erase) means a batch
+                # transposition/misindexing AND a dropped/wrong attention_mask
+                # are both detectable by decoding argmax back to the row.
                 hidden = torch.zeros((batch, width, 4))
                 for i in range(batch):
-                    hidden[i, 0, i % 4] = 1.0
+                    real_len = int(attention_mask[i].sum().item())
+                    hidden[i, 0, (i + real_len) % 4] = 1.0
                 return _FakeOutput(hidden)
 
         self._tok, self._model, self._dev = _FakeTokenizer(), _FakeModel(), "cpu"
@@ -101,14 +105,21 @@ class EmbedBatchBatchingTest(unittest.TestCase):
     def test_batched_output_preserves_order_and_count(self):
         backend = neural_backend.JTransBackend("fake-model", "fake-tok")
         token_lists = [["a", "b", "c"], ["d"], ["e", "f"]]
+        # Mirrors embed_batch's own text construction, to independently
+        # compute each row's expected (real, masked) sequence length.
+        texts = [" ".join(toks) if toks else "" for toks in token_lists]
+        lengths = [max(len(t), 1) for t in texts]
+
         vecs = backend.embed_batch(token_lists)
         self.assertEqual(len(vecs), 3)
         for i, v in enumerate(vecs):
             self.assertEqual(len(v), 4)
             decoded = max(range(4), key=lambda j: v[j])
-            self.assertEqual(decoded, i % 4,
-                              f"row {i}'s decoded index doesn't match -- "
-                              "batch dimension may be transposed or misindexed")
+            expected = (i + lengths[i]) % 4
+            self.assertEqual(decoded, expected,
+                              f"row {i}'s decoded index doesn't match -- batch "
+                              "dimension may be transposed/misindexed, or "
+                              "attention_mask isn't reaching the model correctly")
 
     def test_empty_token_list_entry_within_a_nonempty_batch(self):
         backend = neural_backend.JTransBackend("fake-model", "fake-tok")

--- a/tests/test_neural_backend.py
+++ b/tests/test_neural_backend.py
@@ -1,0 +1,49 @@
+"""Unit tests for tools/neural_backend.py's device selection and batched
+embedding. torch/transformers are an optional [neural] extra; every test
+here is gated on their availability and skips cleanly when absent.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from ida_multi_mcp.tools import neural_backend  # noqa: E402
+
+_SKIP_REASON = "torch/transformers not installed (optional [neural] extra)"
+
+
+@unittest.skipUnless(neural_backend.is_available(), _SKIP_REASON)
+class SelectDeviceTest(unittest.TestCase):
+    def setUp(self):
+        import torch
+        self._orig_cuda = torch.cuda.is_available
+        self._orig_mps = torch.backends.mps.is_available
+
+    def tearDown(self):
+        import torch
+        torch.cuda.is_available = self._orig_cuda
+        torch.backends.mps.is_available = self._orig_mps
+
+    def test_prefers_cuda_when_available(self):
+        import torch
+        torch.cuda.is_available = lambda: True
+        torch.backends.mps.is_available = lambda: True
+        self.assertEqual(neural_backend._select_device(), "cuda")
+
+    def test_prefers_mps_over_cpu_when_cuda_unavailable(self):
+        import torch
+        torch.cuda.is_available = lambda: False
+        torch.backends.mps.is_available = lambda: True
+        self.assertEqual(neural_backend._select_device(), "mps")
+
+    def test_falls_back_to_cpu(self):
+        import torch
+        torch.cuda.is_available = lambda: False
+        torch.backends.mps.is_available = lambda: False
+        self.assertEqual(neural_backend._select_device(), "cpu")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_similarity_neural.py
+++ b/tests/test_similarity_neural.py
@@ -171,6 +171,75 @@ class NeuralRecallTest(unittest.TestCase):
         similarity.index_functions({"instance_id": "nn", "background": False})
         self.assertEqual(len(index_store.read_vectors("sha-nn", rp)), 3)
 
+    def test_sync_branch_skips_embedding_for_zero_valid_functions(self):
+        # Reuse this test class's corpus/mocks but swap in a router that
+        # reports zero valid functions (every func_features record is an
+        # error stub) -- mirrors the real shape func_features returns for
+        # an unextractable function (see test_similarity.py's _ErrRouter).
+        class _EmptyValidRouter:
+            def route_request(self, method, params):
+                name = params.get("name")
+                if name == "binary_fingerprint":
+                    payload = {"sha256": "sha-empty", "md5": None,
+                              "function_count": 1, "arch": "x86_64"}
+                elif name == "func_features":
+                    payload = {"functions": [{"addr": "0x1", "error": "no func"}],
+                              "total": 1, "cursor": {"done": True}}
+                else:
+                    return {"error": f"unknown tool {name}"}
+                return {"content": [{"type": "text", "text": json.dumps(payload)}],
+                        "structuredContent": payload}
+
+        similarity.set_router(_EmptyValidRouter())
+        called = {"n": 0}
+
+        def _raise_if_called(*a, **k):
+            called["n"] += 1
+            raise AssertionError("get_backend() must not be called for zero valid functions")
+
+        orig_get_backend = neural_backend.get_backend
+        neural_backend.get_backend = _raise_if_called
+        try:
+            res = similarity.index_functions({"instance_id": "nn", "background": False})
+        finally:
+            neural_backend.get_backend = orig_get_backend
+
+        self.assertEqual(res["function_count"], 0)
+        self.assertEqual(called["n"], 0)
+
+    def test_background_branch_reports_done_for_zero_valid_functions(self):
+        import time
+
+        class _EmptyValidRouter:
+            def route_request(self, method, params):
+                name = params.get("name")
+                if name == "binary_fingerprint":
+                    payload = {"sha256": "sha-empty-bg", "md5": None,
+                              "function_count": 1, "arch": "x86_64"}
+                elif name == "func_features":
+                    payload = {"functions": [{"addr": "0x1", "error": "no func"}],
+                              "total": 1, "cursor": {"done": True}}
+                else:
+                    return {"error": f"unknown tool {name}"}
+                return {"content": [{"type": "text", "text": json.dumps(payload)}],
+                        "structuredContent": payload}
+
+        similarity.set_router(_EmptyValidRouter())
+        similarity.index_functions({"instance_id": "nn", "background": True})
+
+        deadline = time.time() + 5.0
+        st = {}
+        while time.time() < deadline:
+            st = similarity.index_status({"instance_id": "nn"})
+            if st.get("embed_status") == "done":
+                break
+            time.sleep(0.01)
+        else:
+            self.fail("embed_status never reached 'done' within 5s "
+                      f"(last status: {st})")
+
+        self.assertEqual(st["embed_total"], 0)
+
 
 class NeuralBackendPathsTest(unittest.TestCase):
     def test_env_override_and_default_tokenizer(self):


### PR DESCRIPTION
## Summary

The optional neural (jTrans) embedding backend had two real performance problems:

- `JTransBackend.embed_batch()` wasn't actually batched — a per-item Python loop doing one tokenizer call + one forward pass per function despite the name (and despite `_embed_incremental` already chunking work into `EMBED_BATCH`-sized groups before calling it).
- Device selection only checked CUDA, so Apple Silicon Macs never used MPS (Metal) acceleration and fell back to CPU-only inference unconditionally — the concrete complaint that started this investigation (worry that embedding 130K+ functions on a Mac could take days).

This fixes both, plus a small related gap: `_embed_incremental()` unconditionally called `neural_backend.get_backend()` (which can trigger a ~1.2GB on-demand model download) even for a binary with zero valid functions to embed.

## Process

An initial design additionally proposed restricting embedding to "anchor-less" functions by default (skip functions that already have an import/string/constant anchor), on the premise that neural recall's whole purpose is rescuing anchor-less functions. **Three independent reviewers found this premise doesn't survive contact with the actual scoring code** — neural recall in `similar_functions()` is symmetric over the gallery side, and an anchor-less query's true cross-compiler twin isn't guaranteed to be anchor-less itself, so restricting gallery-side embedding this way would have silently caused real recall regressions. That idea was dropped entirely; see `docs/superpowers/specs/2026-07-08-neural-embedding-scalability-design.md` for the full history (2 rounds of adversarial review to convergence on the smaller, safe change actually shipped here).

Post-implementation, an independent code reviewer approved the diff (no CRITICAL/HIGH) with two minor follow-ups (a test-coverage gap around `attention_mask` handling, a docstring note) — both fixed and included.

## Test plan

- [x] `python3 -m pytest tests/` — 347 passed, 4 skipped (pre-existing, unrelated)
- [x] Ran with `torch`/`transformers` actually installed (not just skip-gated) — all torch-dependent tests execute for real, not just collect-and-skip
- [x] New `tests/test_neural_backend.py`: `_select_device()` priority (cuda>mps>cpu) via monkeypatched `torch.cuda.is_available`/`torch.backends.mps.is_available`; a batching-equivalence test against a hand-mocked `_load()` (fake-but-real small tensors, no real model download) that verifies output order/count AND that `attention_mask`'s real values reach the model correctly (not just its shape) — confirmed via mutation testing that this actually catches a transposed/misindexed batch
- [x] New tests in `tests/test_similarity_neural.py`: zero-valid-function builds skip embedding entirely on both the sync and background code paths, with the background-path regression specifically polling `embed_status == "done"` (not the `job_status` field, which flips to `"ready"` earlier and would make the test race — a bug an earlier design-review round caught before it shipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)