### PR TITLE
fix: reentrant @idasync deadlock, broken enum_upsert, and stale upstream claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,27 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    name: lint (undefined names)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install ruff
+        run: python -m pip install --upgrade pip && pip install ruff
+
+      # IDA modules cannot be imported in CI, so undefined names inside the
+      # bundled ida_mcp package are invisible to pytest. A missing `import idc`
+      # silently turned every enum_upsert call into an error result until a
+      # static check caught it. F821/F811 only — style rules stay advisory.
+      - name: Check for undefined and redefined names
+        run: ruff check src/ tests/ --select F821,F811
+
   test:
     name: test (${{ matrix.os }}, py${{ matrix.python }})
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ Thumbs.db
 
 # Function-similarity benchmark run outputs (regenerable)
 bench/similarity/results/
+
+# Serena tool local state
+.serena/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Multi-instance IDA Pro MCP server for simultaneous reverse engineering of multip
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)
-![IDA Pro](https://img.shields.io/badge/IDA%20Pro-8.3%2B-orange.svg)
+![IDA Pro](https://img.shields.io/badge/IDA%20Pro-8.5%2B-orange.svg)
 ![MCP](https://img.shields.io/badge/MCP-compatible-brightgreen.svg)
 
 ## ✨ What's New
@@ -58,14 +58,16 @@ MCP Client (Claude, Cursor, etc.)
 - **Cross-binary analysis** — Target specific instances via `instance_id` parameter
 - **Function-similarity search** — `similar_functions` / `compare_functions` rank BCSD matches (instruction-shingle MinHash + API/string/constant anchors + CFG/shape) within a binary or across instances. Optional on-demand **neural recall** (jTrans embeddings) recovers anchor-less cross-compiler twins that lexical/structural signals miss — enable with `pip install ida-multi-mcp[neural]` + `IDA_MCP_SIM_NEURAL=1` (model auto-downloads to `~/.ida-mcp/models/`)
 - **Smart instance tracking** — 4-character IDs (k7m2, px3a, etc.) with automatic binary-change detection
-- **IDA 8.3–9.3 compatible** — Built-in version compatibility shims (`compat.py`)
+- **IDA 8.5–9.3 compatible** — Version compatibility shims (`compat.py`) for entry-point and `inf_*` API moves
 - **File-based registry** — Tracks all active instances (GUI and headless)
 - **Graceful fallback** — Handles binary changes, stale instances, and crashes
 
 ## Requirements
 
 - Python 3.11 or later
-- IDA Pro 8.3+ (9.0 recommended)
+- IDA Pro 8.5+ (9.1 or later recommended)
+
+> **IDA 9.0 SP0 (build 240925) is not supported.** That build shipped without `func_t.get_name`, `func_t.get_prototype`, and `tinfo_t.get_udm`, which several tools call directly. Use IDA 9.0 SP1 (build 241217) or later.
 
 ## Manual Installation
 
@@ -146,10 +148,10 @@ The canonical installation guide an AI agent should follow is at
 
 ### Supported MCP Clients
 
-Works with any MCP-compatible client. `ida-multi-mcp --install` auto-configures all detected clients (Claude Code, Claude Desktop, Cursor, Windsurf, VS Code, Zed, and 20+ more).
+Works with any MCP-compatible client. `ida-multi-mcp --install` auto-configures all detected clients (Claude Code, Claude Desktop, Cursor, Windsurf, VS Code, Zed, and 20 more).
 
 <details>
-<summary>Full tested client list (19)</summary>
+<summary>Full auto-configured client list (26)</summary>
 
 | Client | Type |
 |--------|------|
@@ -159,11 +161,14 @@ Works with any MCP-compatible client. `ida-multi-mcp --install` auto-configures 
 | VS Code (Copilot) | IDE |
 | Windsurf | IDE |
 | Zed | IDE |
+| Antigravity IDE | IDE |
 | Augment Code | IDE |
 | Cline | Extension |
 | Kilo Code | Extension |
 | Kiro | IDE |
 | LM Studio | Desktop |
+| BoltAI | Desktop |
+| Perplexity | Desktop |
 | Opencode | CLI |
 | Qodo Gen | Extension |
 | Roo Code | Extension |
@@ -172,6 +177,10 @@ Works with any MCP-compatible client. `ida-multi-mcp --install` auto-configures 
 | Amazon Q Developer CLI | CLI |
 | Copilot CLI | CLI |
 | Gemini CLI | CLI |
+| Qwen Coder | CLI |
+| Codex | CLI |
+| Crush | CLI |
+| Factory Droid | CLI |
 
 </details>
 
@@ -559,7 +568,7 @@ Do not use unquoted `\\?\...` project table keys, and do not use double-quoted W
 | Dynamic tool discovery | Future-proof, automatic updates, no hardcoded tool list |
 | Dual binary-change detection | Robust fallback if IDA hooks fail |
 | Subprocess-per-binary (idalib) | True parallelism, crash isolation, no in-process DB switching |
-| compat.py shims | Single source for IDA 8.3–9.3 API differences |
+| compat.py shims | Single source for IDA 8.5–9.3 API differences |
 
 ## Performance
 
@@ -610,11 +619,13 @@ Contributions welcome! Please ensure:
 
 This project was inspired by and builds upon [ida-pro-mcp](https://github.com/mrexodia/ida-pro-mcp) by [Duncan Ogilvie (mrexodia)](https://github.com/mrexodia). The IDA tool implementations (80+ tools) originated from ida-pro-mcp and have been absorbed into ida-multi-mcp as a bundled package, adding multi-instance orchestration and headless idalib support on top.
 
+Upstream has since grown its own multi-session story: `idalib-mcp` is now a supervisor that keeps each open database in a persistent worker process, requires an explicit `database` argument per call, and can adopt an already-running worker or GUI for the same path. The two projects have converged on explicit session routing but differ in approach — ida-multi-mcp discovers GUI instances through a shared file registry that each IDA plugin auto-registers with on startup, so no per-database endpoint configuration is needed on the client side.
+
 The installation approach (AI-agent-friendly installation guides) was influenced by [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) by [Yeongyu Yun (code-yeongyu)](https://github.com/code-yeongyu).
 
 ## Related Projects
 
-- **[ida-pro-mcp](https://github.com/mrexodia/ida-pro-mcp)** — The original single-instance IDA MCP plugin (tools originated from here) (MIT License)
+- **[ida-pro-mcp](https://github.com/mrexodia/ida-pro-mcp)** — The upstream IDA MCP plugin this project forked its tool implementations from; now also ships a multi-session `idalib-mcp` supervisor (MIT License)
 - **Claude Code** — MCP client with native support
 - **Cursor** — Alternative MCP-enabled editor
 

--- a/docs/function-similarity-usage.md
+++ b/docs/function-similarity-usage.md
@@ -1,0 +1,146 @@
+# Function Similarity — Usage Examples
+
+All examples below are **real tool calls and outputs** against two stripped benchmark binaries opened in IDA:
+
+| Instance | Binary | Notes |
+|---|---|---|
+| `koeu` | `simbench_v2_clang_stripped.exe` | clang build, **symbols stripped** |
+| `83oy` | `simbench_v3_stripped.exe` | a different build, **symbols stripped** |
+
+Both are stripped (functions are `sub_*`), i.e. the realistic reverse-engineering condition. Every match below is **name-independent**.
+
+Each example shows the natural-language prompt you'd give your LLM, the underlying tool call, and the real result.
+
+---
+
+## 0. Build the index (once per binary)
+
+> Index the functions in koeu and 83oy
+
+```jsonc
+// index_functions(instance_id="koeu")
+{ "index_id": "694060…", "function_count": 114, "status": "ready", "progress": 1 }
+
+// index_status(instance_id="koeu")
+{ "indexed": true, "function_count": 114, "stale": false, "progress": 1,
+  "path": "C:\\Users\\…\\.ida-mcp\\index\\694060….json" }
+```
+
+The index is **content-hash keyed** and persisted under `~/.ida-mcp/index/`, so it is reused across sessions (GUI or headless) until the binary changes.
+
+---
+
+## 1. Find a function's twin in another binary (the headline use case)
+
+> Find the function in 83oy most similar to sub_140002110 in koeu
+
+```jsonc
+// similar_functions(instance_id="koeu", func="0x140002110",
+//                    scope="instances", instances=["83oy"], top_k=3)
+{
+  "query": { "instance_id": "koeu", "addr": "0x140002110", "name": "sub_140002110" },
+  "gallery_size": 116,
+  "results": [
+    { "instance_id": "83oy", "addr": "0x140001DB0", "score": 1.0, "confidence": "high",
+      "signals": { "ngram": 1, "api": 0, "str": 1, "const": 1, "cfg": 1, "shape": 1 } },
+    { "instance_id": "83oy", "addr": "0x140001450", "score": 0.18, "confidence": "low",
+      "signals": { "ngram": 0, "api": 0, "str": 0, "const": 0.04, "cfg": 0.004, "shape": 0.58 } },
+    { "instance_id": "83oy", "addr": "0x140002BF0", "score": 0.11, "confidence": "low", "signals": { … } }
+  ]
+}
+```
+
+**Reading it:** the #1 hit scores **1.0 / high** with every signal maxed — the same function, recovered across two stripped binaries with no symbols. The large gap to #2 (**0.18 / low**) makes the match unambiguous. `api: 0` just means this function calls no imported APIs, so that one signal doesn't contribute.
+
+---
+
+## 2. A match where imported-API anchors contribute
+
+Functions that call Windows/CRT APIs gain an extra stripping-resistant signal.
+
+> Find the twin of sub_140001FA0 (koeu) in 83oy
+
+```jsonc
+// similar_functions(instance_id="koeu", func="0x140001fa0",
+//                    scope="instances", instances=["83oy"], top_k=3)
+{
+  "query": { "addr": "0x140001FA0", "name": "sub_140001FA0" },
+  "gallery_size": 116,
+  "results": [
+    { "instance_id": "83oy", "addr": "0x140001C40", "score": 1.0, "confidence": "high",
+      "signals": { "ngram": 1, "api": 1, "str": 1, "const": 1, "cfg": 1, "shape": 1 } },
+    { "addr": "0x140002EA0", "score": 0.28, "confidence": "low",
+      "signals": { "ngram": 0, "api": 0, "str": 0, "const": 0.14, "cfg": 0.16, "shape": 0.79 } },
+    { "name": "___w64_mingwthr_add_key_dtor", "score": 0.25, "confidence": "low", "signals": { … } }
+  ]
+}
+```
+
+Here **`api: 1`** — the twin shares the same imported-API call set (a strong fingerprint that survives stripping). Note the #3 candidate is a CRT function IDA recognized by name (`___w64_mingwthr_add_key_dtor`); it scores only **0.25 / low** and is correctly rejected.
+
+---
+
+## 3. Search within one binary (`scope="binary"`)
+
+Use `scope="binary"` to find clones/siblings inside a single binary.
+
+> Find functions in koeu similar to sub_140002110
+
+```jsonc
+// similar_functions(instance_id="koeu", func="0x140002110", scope="binary", top_k=3)
+{
+  "query": { "addr": "0x140002110", "name": "sub_140002110" },
+  "gallery_size": 114,
+  "results": [
+    { "instance_id": "koeu", "addr": "0x140002840", "score": 0.11, "confidence": "low",
+      "signals": { "ngram": 0, "api": 0, "str": 0, "const": 0.07, "cfg": 0.004, "shape": 0.33 } }
+  ]
+}
+```
+
+The best in-binary match is only **0.11 / low** — this function is **unique within its own binary** (no near-duplicate). Yet Example 1 found its exact twin in *another* binary. That contrast is exactly why cross-instance search is valuable.
+
+---
+
+## 4. Compare two specific functions (pairwise)
+
+When you already suspect two functions correspond, `compare_functions` scores them directly.
+
+> Compare sub_140002110 (koeu) with sub_140001DB0 (83oy)
+
+```jsonc
+// compare_functions(a={instance_id:"koeu", func:"0x140002110"},
+//                    b={instance_id:"83oy", func:"0x140001DB0"})
+{ "score": 1.0, "confidence": "high",
+  "signals": { "ngram": 1, "api": 0, "str": 1, "const": 1, "cfg": 1, "shape": 1 } }
+```
+
+> Now compare it with sub_140001450 (83oy) instead
+
+```jsonc
+// compare_functions(a={…"0x140002110"}, b={…"0x140001450"})
+{ "score": 0.18, "confidence": "low",
+  "signals": { "ngram": 0, "api": 0, "str": 0, "const": 0.05, "cfg": 0.004, "shape": 0.58 } }
+```
+
+A confident **1.0 / high** for the true pair versus **0.18 / low** for an unrelated one — a direct "are these the same function?" check.
+
+---
+
+## Reading the output
+
+| Field | Meaning |
+|---|---|
+| `score` | 0–1 blended similarity (weighted over the signals below) |
+| `signals.ngram` | instruction-shingle MinHash (opcode-level similarity) |
+| `signals.api` | shared imported-API set, IDF-weighted (`0` if the function calls no imports) |
+| `signals.str` / `signals.const` | shared string / constant literals |
+| `signals.cfg` | control-flow feature similarity (blocks, edges, complexity, loops) |
+| `signals.shape` | CFG out-degree shape |
+| `confidence` | `high` (≥0.75 and ≥2 strong signals) · `medium` (≥0.5) · `low` |
+| `gallery_size` | number of candidate functions searched (production scale) |
+
+**Practical notes**
+- v1 is strongest for same-/similar-toolchain matches (the `1.0` hits above). The `confidence` label and per-signal breakdown surface uncertainty honestly rather than overclaiming.
+- If the query binary has no index yet, run `index_functions` first (or the tool returns a hint to do so — it never silently full-scans).
+- For harder cross-compiler cases where lexical/structural signals fade, enable the optional neural recall: `pip install ida-multi-mcp[neural]` + `IDA_MCP_SIM_NEURAL=1` (jTrans embeddings, model auto-downloads to `~/.ida-mcp/models/`).

--- a/docs/ida-pro-mcp/comparison.md
+++ b/docs/ida-pro-mcp/comparison.md
@@ -1,97 +1,165 @@
 # ida-pro-mcp (upstream) vs ida-multi-mcp — Comparison
 
-Last updated: 2026-04-16 (upstream commit `d80ed7f`)
+Last updated: 2026-07-25 (upstream commit `9236fc6`, reviewed range `d80ed7f..9236fc6` = 88 non-merge commits)
 
-This document tracks what upstream features/fixes ida-multi-mcp has NOT yet adopted.
+This document tracks what upstream fixes ida-multi-mcp has NOT yet adopted, and where the
+two projects have diverged architecturally.
 
-## Current Coverage
+## How to refresh this document
 
-After PRs #2–#8, ida-multi-mcp has ported or implemented equivalents of most upstream tools. The remaining gaps are **bugfixes, optimizations, and minor features** rather than major missing tool categories.
+The upstream clone lives at `_ref/ida-pro-mcp` (git-excluded via `.git/info/exclude`).
 
----
+```bash
+git -C _ref/ida-pro-mcp fetch origin
+git -C _ref/ida-pro-mcp log --no-merges --oneline <last-reviewed>..origin/main -- src/ida_pro_mcp/ida_mcp/
+```
 
-## HIGH Priority — Correctness & Token Cost
-
-### 1. BSS/Virtual Memory Read Bug
-
-**Upstream fix**: commit `2fee279` — `read_bytes_bss_safe()` and `read_int_bss_safe()` helpers in `utils.py`.
-
-**Problem**: `ida_bytes.get_bytes()` returns `0xFF` for unloaded BSS/virtual memory regions. Upstream now returns `0x00` for these addresses, which is the correct semantic (BSS is zero-initialized).
-
-**Current state**: ida-multi-mcp uses raw `ida_bytes.get_bytes()` in `api_memory.py` and `api_types.py`, so reading BSS globals returns incorrect `0xFF` byte fills.
-
-**Impact**: Any memory read of uninitialized globals or BSS data is wrong. Affects `get_bytes`, `get_int`, `get_global_value`, `read_struct`.
-
-### 2. Token Optimization — Whitespace Compaction
-
-**Upstream fix**: PR #341 — `compact_whitespace()` function in `utils.py`.
-
-**What it does**: Collapses multiple spaces/tabs in decompiler and disassembly output while preserving string literals. Reduces response payload size.
-
-**Current state**: ida-multi-mcp sends raw Hex-Rays/disasm output with original whitespace, inflating token cost.
-
-**Impact**: `decompile` and `disasm` responses are larger than necessary. On a 736K-function binary, this can add up.
-
-### 3. Token Optimization — Compact JSON Serialization
-
-**Upstream fix**: PR #341 — `separators=(",", ":")` in zeromcp JSON serialization.
-
-**What it does**: Removes spaces after `:` and `,` in all JSON-RPC responses. ~15-20% reduction in wire bytes.
-
-**Current state**: ida-multi-mcp uses default `json.dumps()` with spaces (`", ": "`).
-
-**Impact**: Every tool response is larger than necessary. Combined with whitespace compaction, upstream achieves significant token savings.
+Only `src/ida_pro_mcp/ida_mcp/**` is shared code. Upstream's `server.py`, `installer.py`,
+`idalib_server.py`, `idalib_supervisor.py`, and `worker_lifecycle.py` have no counterpart
+here — ida-multi-mcp has its own router, registry, and subprocess manager.
 
 ---
 
-## MEDIUM Priority — Usability & Performance
+## Upstream is no longer single-instance
 
-### 4. parse_address Symbol Name Resolution
+The 2026-04 → 2026-07 range brought a supervisor architecture upstream (`c028108`,
+`8545e80`, `22aae5f`). `idalib-mcp` now keeps each open database in a persistent worker
+process, requires an explicit `database` argument on every tool call, and adopts an
+already-running worker or GUI for the same path instead of opening a second one.
 
-**Upstream fix**: PR #349 — `parse_address()` now calls `idaapi.get_name_ea()` as fallback.
-
-**What it does**: Allows passing symbol names (e.g., `"main"`, `"CreateFileW"`) directly to any tool that takes an address parameter. If hex parsing fails, tries name lookup.
-
-**Current state**: ida-multi-mcp's `parse_address()` only accepts hex/decimal strings. Passing a function name like `"main"` fails with an error.
-
-**Impact**: Users must look up addresses before calling tools. Upstream allows natural name-based workflows.
-
-### 5. Lazy Cache Initialization
-
-**Upstream fix**: commit `c25459b` — removed `init_caches()` from plugin load path.
-
-**What it does**: Strings cache is built lazily on first access instead of at plugin startup. Reduces IDA startup time.
-
-**Current state**: ida-multi-mcp calls `init_caches()` eagerly on plugin load (`__init__.py` exports it, plugin calls it on Ctrl+M).
-
-**Impact**: Plugin startup is slower, especially on large binaries. Not a correctness issue.
-
-### 6. idalib Detection via `is_idaq()`
-
-**Upstream fix**: commit `b8be030` — uses `ida_kernwin.is_idaq()` instead of `sys.modules` check.
-
-**What it does**: Cleaner headless mode detection. `is_idaq()` returns `False` when running under idalib (no GUI).
-
-**Current state**: ida-multi-mcp uses `ida_major` version checks and separate `idalib_worker.py` architecture (subprocess model), so this is less relevant.
-
-**Impact**: LOW — architectural difference makes this a minor code quality item.
+Both projects have converged on explicit session routing. The remaining difference is
+discovery: ida-multi-mcp's IDA plugin auto-registers each GUI instance into a shared file
+registry (`~/.ida-mcp/instances.json`), so the client needs no per-database endpoint
+configuration; upstream routes through a supervisor process that owns the workers.
 
 ---
 
-## Already Adopted (No Action Needed)
+## HIGH Priority — Not Yet Adopted
 
-| Upstream Change | Status |
+### 1. `sync.py`: reentrant `@idasync` deadlocks the IDA main thread
+
+**Upstream fix**: `85efdf8` (closes upstream #406).
+
+`_sync_wrapper.runned()` uses a blocking `call_stack.get()` in both the pre-check and the
+`finally`. If a `@idasync` function synchronously invokes another `@idasync` function, the
+inner call drains the LifoQueue; the outer call's `finally` then parks forever on
+`Queue.get()` against an empty queue. IDA's main thread freezes and every subsequent tool
+call piles up in `execute_sync` and never returns.
+
+**Current state**: `src/ida_multi_mcp/ida_mcp/sync.py:65` and `:75` still use blocking
+`get()`. Upstream's fix is a two-line change to `get_nowait()` with `queue.Empty` handling.
+
+### 2. `sync.py`: no native cancellation, so slow SDK calls blow past the tool timeout
+
+**Upstream fix**: `55533c4` (addresses upstream #235).
+
+The Python-level `setprofile` timeout cannot preempt pure-C SDK calls. `ida_search.find_*`,
+`ida_bytes.find_bytes`/`bin_search`, `ida_hexrays.decompile*`, `ida_strlist.build_strlist`,
+and `ida_auto.auto_wait` all run to natural completion regardless of the deadline, holding
+the IDA main thread while every queued tool call times out client-side.
+
+Those same SDK calls poll `user_cancelled()`. `ida_kernwin.set_cancelled()` is THREAD_SAFE,
+so upstream schedules a `threading.Timer(timeout, set_cancelled)`, gives the tool a 5s grace
+window to format a partial response, then unconditionally `clr_cancelled()` in the `finally`
+(the flag is sticky — without the clear, every later `user_cancelled()` returns True forever).
+
+**Current state**: not implemented. This is the direct remedy for full-scan tools timing out
+on large binaries; it is the highest-value item in this list.
+
+### 3. `sync.py`: `idc.batch()` is called from the requesting thread, not the IDA main thread
+
+**Upstream fix**: part of `f0cd877`.
+
+`sync_wrapper()` calls `old_batch = idc.batch(1)` *before* `execute_sync`, i.e. on the HTTP
+worker thread, and restores it in a `finally` that also runs off-thread. Upstream moved both
+into `runned()` so they execute on the IDA main thread, and added `get_pre_call_batch()` so
+tools restore the caller's real prior state instead of a hard-coded default.
+
+**Current state**: `src/ida_multi_mcp/ida_mcp/sync.py:97` and `:126` still call `idc.batch()`
+off the main thread.
+
+### 4. IDA 8.5+ APIs used without version guards
+
+**Upstream fix**: `f212140`, `7cca988`, `dd4e730`, plus `compat.py`'s `tinfo_get_udm()`,
+`inf_get_*()`, `get_ordinal_limit()`, `get_func_name()`, `get_func_prototype()`.
+
+Our `compat.py` is 65 lines and covers only entry-point APIs and `inf_is_64bit`. These call
+sites bypass it and will raise on older or early builds:
+
+| Call | Introduced | Sites |
+|---|---|---|
+| `ida_ida.inf_get_min_ea` / `inf_get_max_ea` | 8.5 | `api_analysis.py:613,627,628,795,796` |
+| `ida_ida.inf_get_omin_ea` / `inf_get_omax_ea` | 8.5 | `utils.py:434,435` |
+| `ida_typeinf.get_ordinal_limit` | 8.4 (`get_ordinal_qty` before) | `api_resources.py:177`, `api_types.py:216` |
+| `tinfo_t.get_udm` | 8.5, **absent in 9.0 SP0** | `api_modify.py:376`, `api_stack.py:121`, `api_types.py:355` |
+| `func_t.get_name` | 8.5, **absent in 9.0 SP0** | `api_resources.py:130` (unguarded; `utils.py:625` has a try/except) |
+
+Upstream additionally *rejects* IDA 9.0 SP0 (build 240925) at import time with an explicit
+error listing the missing methods, rather than failing deep inside a tool.
+
+**Current state**: README now documents an 8.5+ floor and the 9.0 SP0 exclusion. Adding the
+`compat.py` wrappers would restore the original 8.3+ claim.
+
+---
+
+## MEDIUM Priority — Not Yet Adopted
+
+### 5. `idb_save` uses save-as semantics in the GUI
+
+**Upstream fix**: `6673de9` (closes upstream #446).
+
+Upstream's bug was packing with `DBFL_KILL|DBFL_COMP`, deleting the loose `.id0/.id1/.id2/
+.nam/.til` files the GUI is actively using. We pass `flags=0`, so we do **not** have the
+corruption bug — but we always pass an explicit `save_path` (`api_core.py:661`), which is a
+save-as rather than IDA's native in-place save. Upstream branches on `ida_kernwin.is_idaq()`
+and uses `save_database(None, 0)` in the GUI. Worth mirroring; we already detect `is_idaq`.
+
+### 6. Bounded HTTP session registry
+
+**Upstream fix**: `1c97442`.
+
+Upstream's `_http_sessions` was an unbounded `set[str]`; it is now a TTL + max-count LRU dict
+(24h / 4096). Our zeromcp copies do not track HTTP sessions at all, so this is currently
+moot — but it is the design to copy if session tracking is ever added.
+
+### 7. Richer tool error reporting
+
+**Upstream fix**: `c395db9` (fixes upstream #52) — `rename`, `xrefs`, `decompile`, `set_type`
+return actionable messages instead of bare failures. Applies to our `api_analysis.py`,
+`api_composite.py`, `api_modify.py`, `api_types.py`, `utils.py`.
+
+---
+
+## Deliberately Not Adopted (architectural divergence)
+
+| Upstream change | Why it does not apply |
 |---|---|
-| Tool parameter consistency (PR #362): `int_convert`, `list_globals`, `set_comments`, `dbg_step_into/over` naming | Already uses these names |
-| HTTP Host/Origin validation (PR #352) | Already implemented in `http.py` |
-| `@unsafe` flag gating in idalib (PR #335) | Implemented via `is_idalib_available()` + worker `--unsafe` flag |
-| `survey_binary` | Ported (PR #2) |
-| `api_composite` (4 tools) | Ported (PR #3) |
-| `append_comments`, `define_func/code`, `undefine` | Ported (PR #4) |
-| `func_query`, `xref_query`, `insn_query`, `analyze_batch` | Implemented (PR #7) |
-| `imports_query`, `idb_save`, `enum_upsert` | Implemented (PR #7) |
-| `server_health`, `server_warmup` | Implemented (PR #7) |
-| IDA 8.3–9.3 compat shims | `compat.py` with try/import fallback |
+| `c028108`, `8545e80`, `22aae5f`, `9fd8d89`, `420cfdb`, `2c4c65b`, `8a0820c`, `e9ccaba` — supervisor architecture | ida-multi-mcp's router + file registry + subprocess-per-binary model already covers this ground differently |
+| `e12fbb5` — stale strings cache when switching binaries | Our `idalib_worker.py` is one binary per process; there is no in-process database switch to invalidate |
+| `492a569` — SIGTERM/SIGINT handler deadlock in `idalib_server` | Our worker's handler calls `sys.exit(0)` rather than `MCP_SERVER.stop()`, so it does not block on `HTTPServer.shutdown()` |
+| `54b0566`, `e802b32` — `rpc.py` truncation metadata | `_install_tools_call_patch()` is disabled here (`rpc.py:155`); the router owns truncation |
+| `0916ebf`, `77c3090`, `ca35773`, `bf59293` — sigmaker | Feature we have not ported |
+| `c93166b`, `6828fd9`, `397e09c`, `0b2ac19` — trace subsystem | Feature we have not ported |
+| `913421a`, `e02eaec`, `aae0afc`, `c6f491d`, `e88bb69`, `37b8a84`, `6dc91a0` — debugger refactor | Our `api_debug.py` diverged; revisit only if debugger tools are actively used |
+| `40e585c`, `5368021`, `1be78d0`, `120ae7a` — Kimi/Codex installer targets | Our installer covers 26 clients including Codex, on a different code path |
+
+---
+
+## Already Adopted
+
+| Upstream change | Adopted in |
+|---|---|
+| BSS-safe reads (`read_bytes_bss_safe` / `read_int_bss_safe`, `2fee279`) | PR #10 |
+| Whitespace compaction (`compact_whitespace`) | PR #11 |
+| Compact JSON serialization (`separators=(",", ":")`) | PR #11 |
+| `parse_address` symbol resolution (`idaapi.get_name_ea` fallback) | PR #12 |
+| Lazy caches for functions and globals | PR #14 |
+| Headless detection via `is_idaq()` | PR #15 |
+| Tool parameter consistency (PR #362 upstream) | Names already match |
+| HTTP Host/Origin validation | `http.py`; CORS fallback hardened in PR #17 |
+| `@unsafe` gating in idalib | `is_idalib_available()` + worker `--unsafe` |
+| `survey_binary`, `api_composite`, `append_comments`, `define_func/code`, `undefine` | PRs #2–#4 |
+| `func_query`, `xref_query`, `insn_query`, `analyze_batch`, `imports_query`, `idb_save` | PR #7 |
 
 ---
 
@@ -102,6 +170,7 @@ After PRs #2–#8, ida-multi-mcp has ported or implemented equivalents of most u
 | Multi-instance router | Single MCP endpoint proxying to N IDA instances |
 | `instance_id` routing | Explicit per-call instance targeting |
 | Auto-select single instance | Omit `instance_id` when only 1 instance registered |
+| Function similarity (BCSD) | `index_functions` / `similar_functions` / `compare_functions`, MinHash + anchors + CFG, optional jTrans neural recall |
 | `compare_binaries` | Router-level diff of two instances |
 | `classify_functions` | Batch function classification (thunk/wrapper/leaf/dispatcher/complex) |
 | `func_profile` | Per-function metrics with sort/pagination |
@@ -115,11 +184,11 @@ After PRs #2–#8, ida-multi-mcp has ported or implemented equivalents of most u
 
 ## Adoption Roadmap
 
-| # | Item | Priority | Effort |
-|---|---|---|---|
-| 1 | BSS read fix (`read_bytes_bss_safe`) | HIGH | S |
-| 2 | Whitespace compaction (`compact_whitespace`) | HIGH | S |
-| 3 | Compact JSON serialization | HIGH | S |
-| 4 | `parse_address` symbol resolution | MED | S |
-| 5 | Lazy cache initialization | MED | S |
-| 6 | `is_idaq()` detection | LOW | S |
+| # | Item | Upstream commit | Priority | Effort |
+|---|---|---|---|---|
+| 1 | `set_cancelled()` at tool deadline | `55533c4` | HIGH | M |
+| 2 | `get_nowait()` in `call_stack` cleanup | `85efdf8` | HIGH | S |
+| 3 | Move `idc.batch()` onto the IDA main thread | `f0cd877` | HIGH | S |
+| 4 | `compat.py` guards for 8.4/8.5/9.0-SP0 APIs | `f212140`, `7cca988` | HIGH | M |
+| 5 | `idb_save` native in-place save in GUI | `6673de9` | MED | S |
+| 6 | Richer error reporting on rename/xrefs/decompile/set_type | `c395db9` | MED | M |

--- a/src/ida_multi_mcp/ida_mcp/api_types.py
+++ b/src/ida_multi_mcp/ida_mcp/api_types.py
@@ -7,6 +7,7 @@ import ida_bytes
 import ida_frame
 import ida_ida
 import idaapi
+import idc
 
 from .rpc import tool
 from .sync import idasync, ida_major

--- a/src/ida_multi_mcp/ida_mcp/sync.py
+++ b/src/ida_multi_mcp/ida_mcp/sync.py
@@ -62,17 +62,39 @@ def _sync_wrapper(ff):
 
     def runned():
         if not call_stack.empty():
-            last_func_name = call_stack.get()
-            error_str = f"Call stack is not empty while calling the function {ff.__name__} from {last_func_name}"
-            raise IDASyncError(error_str)
+            # Non-blocking: a reentrant @idasync call from within another
+            # tool's ff() on this same main thread may have drained the queue
+            # between empty() and get().
+            try:
+                last_func_name = call_stack.get_nowait()
+            except queue.Empty:
+                last_func_name = "<empty>"
+            # Report through res_container instead of raising: execute_sync
+            # swallows the exception, and the res_container.get() below would
+            # then block the requesting thread forever on an empty queue.
+            res_container.put(IDASyncError(
+                f"Call stack is not empty while calling the function "
+                f"{ff.__name__} from {last_func_name}"
+            ))
+            return
 
         call_stack.put((ff.__name__))
+        # Batch mode must be toggled on the IDA main thread. Doing it in
+        # sync_wrapper() ran idc.batch() on the requesting HTTP worker thread.
+        old_batch = idc.batch(1)
         try:
             res_container.put(ff())
         except Exception as x:
             res_container.put(x)
         finally:
-            call_stack.get()
+            idc.batch(old_batch)
+            # Non-blocking: a reentrant @idasync invoked synchronously inside
+            # ff() may have already popped our entry. A blocking get() here
+            # would freeze the IDA main thread and hang every later call.
+            try:
+                call_stack.get_nowait()
+            except queue.Empty:
+                pass
 
     idaapi.execute_sync(runned, idaapi.MFF_WRITE)
     res = res_container.get()
@@ -90,40 +112,40 @@ def _normalize_timeout(value: object) -> float | None:
 
 
 def sync_wrapper(ff, timeout_override: float | None = None):
-    """Wrapper to enable batch mode during IDA synchronization."""
+    """Wrapper to enable timeout and cancellation during IDA synchronization.
+
+    Batch mode is handled inside _sync_wrapper so that idc.batch() runs on the
+    IDA main thread rather than on the calling HTTP worker thread.
+    """
     # Capture cancel event from thread-local before execute_sync
     cancel_event = get_current_cancel_event()
 
-    old_batch = idc.batch(1)
-    try:
-        timeout = timeout_override
-        if timeout is None:
-            timeout = _get_tool_timeout_seconds()
-        if timeout > 0 or cancel_event is not None:
-            def timed_ff():
-                # Calculate deadline when execution starts on IDA main thread,
-                # not when the request was queued (avoids stale deadlines)
-                deadline = time.monotonic() + timeout if timeout > 0 else None
+    timeout = timeout_override
+    if timeout is None:
+        timeout = _get_tool_timeout_seconds()
+    if timeout > 0 or cancel_event is not None:
+        def timed_ff():
+            # Calculate deadline when execution starts on IDA main thread,
+            # not when the request was queued (avoids stale deadlines)
+            deadline = time.monotonic() + timeout if timeout > 0 else None
 
-                def profilefunc(frame, event, arg):
-                    # Check cancellation first (higher priority)
-                    if cancel_event is not None and cancel_event.is_set():
-                        raise CancelledError("Request was cancelled")
-                    if deadline is not None and time.monotonic() >= deadline:
-                        raise IDASyncError(f"Tool timed out after {timeout:.2f}s")
+            def profilefunc(frame, event, arg):
+                # Check cancellation first (higher priority)
+                if cancel_event is not None and cancel_event.is_set():
+                    raise CancelledError("Request was cancelled")
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise IDASyncError(f"Tool timed out after {timeout:.2f}s")
 
-                old_profile = sys.getprofile()
-                sys.setprofile(profilefunc)
-                try:
-                    return ff()
-                finally:
-                    sys.setprofile(old_profile)
+            old_profile = sys.getprofile()
+            sys.setprofile(profilefunc)
+            try:
+                return ff()
+            finally:
+                sys.setprofile(old_profile)
 
-            timed_ff.__name__ = ff.__name__
-            return _sync_wrapper(timed_ff)
-        return _sync_wrapper(ff)
-    finally:
-        idc.batch(old_batch)
+        timed_ff.__name__ = ff.__name__
+        return _sync_wrapper(timed_ff)
+    return _sync_wrapper(ff)
 
 
 def idasync(f):

--- a/tests/test_sync_reentrancy.py
+++ b/tests/test_sync_reentrancy.py
@@ -1,0 +1,226 @@
+"""Tests for ida_mcp/sync.py reentrancy and batch-mode handling (IDA stubbed).
+
+sync.py imports idaapi / ida_kernwin / idc at module scope, so every IDA module
+is replaced with a stub before importing it. idaapi.execute_sync is stubbed to
+call the callback inline, which is exactly the situation the real one creates:
+the callback runs on the IDA main thread while the requesting thread waits.
+
+Regression coverage for two bugs:
+  1. A reentrant @idasync call drained the LifoQueue, so the outer call's
+     finally blocked forever on Queue.get() and froze the IDA main thread.
+  2. idc.batch() was toggled on the requesting worker thread rather than on
+     the IDA main thread inside execute_sync.
+"""
+
+import sys
+import threading
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+_PKG = "ida_multi_mcp.ida_mcp"
+
+# Sentinel for "this sys.modules key did not exist before we stubbed it".
+_ABSENT = object()
+
+
+# Importing ida_mcp.sync executes the package __init__, which eagerly imports
+# every api_* module. Stub the whole IDA surface plus those submodules so only
+# sync.py itself really runs.
+_IDA_MODULES = [
+    "idaapi", "idautils", "idc", "ida_auto", "ida_bytes", "ida_dbg", "ida_dirtree",
+    "ida_entry", "ida_frame", "ida_funcs", "ida_gdl", "ida_hexrays", "ida_ida",
+    "ida_idaapi", "ida_idp", "ida_kernwin", "ida_lines", "ida_loader", "ida_moves",
+    "ida_nalt", "ida_name", "ida_netnode", "ida_offset", "ida_pro", "ida_range",
+    "ida_search", "ida_segment", "ida_strlist", "ida_struct", "ida_typeinf", "ida_ua",
+    "ida_xref",
+]
+
+_SIBLING_MODULES = [
+    "http", "framework", "utils", "compat",
+    "api_core", "api_analysis", "api_memory", "api_types", "api_modify",
+    "api_stack", "api_debug", "api_python", "api_resources", "api_survey",
+    "api_composite", "api_similarity",
+]
+
+
+def _install_stubs(saved):
+    """Stub every module sync.py touches, then import it fresh.
+
+    Every sys.modules key written here is recorded in `saved` so the fixture
+    can put the real (or absent) modules back; otherwise these stubs leak into
+    whatever test runs next.
+    """
+
+    def _stub(name, value):
+        if name not in saved:
+            saved[name] = sys.modules.get(name, _ABSENT)
+        sys.modules[name] = value
+
+    for name in _IDA_MODULES:
+        _stub(name, MagicMock())
+    for name in _SIBLING_MODULES:
+        _stub(f"{_PKG}.{name}", MagicMock())
+
+    sys.modules["idaapi"].get_kernel_version.return_value = "9.3"
+    sys.modules["idaapi"].MFF_WRITE = 0x2
+
+    # execute_sync runs the callback inline, mirroring the real main-thread
+    # dispatch. Exceptions escaping the callback are swallowed by IDA.
+    def _execute_sync(callback, _flags):
+        try:
+            callback()
+        except Exception:
+            pass
+        return 1
+
+    sys.modules["idaapi"].execute_sync.side_effect = _execute_sync
+
+    # batch() returns the previous batch value, like the real idc.batch().
+    batch_state = {"value": 0}
+
+    def _batch(new_value):
+        previous = batch_state["value"]
+        batch_state["value"] = new_value
+        return previous
+
+    sys.modules["idc"].batch.side_effect = _batch
+
+    # sync.py imports McpToolError from .rpc and cancel helpers from zeromcp;
+    # stub both so no HTTP/MCP machinery is pulled in.
+    rpc_stub = types.ModuleType(f"{_PKG}.rpc")
+    rpc_stub.McpToolError = type("McpToolError", (Exception,), {})
+    # Names the package __init__ pulls out of .rpc
+    rpc_stub.MCP_SERVER = MagicMock()
+    rpc_stub.MCP_UNSAFE = set()
+    rpc_stub.MCP_EXTENSIONS = {}
+    rpc_stub.tool = lambda f: f
+    rpc_stub.unsafe = lambda f: f
+    rpc_stub.ext = lambda _group: (lambda f: f)
+    rpc_stub.resource = lambda _uri: (lambda f: f)
+    rpc_stub.get_cached_output = lambda _id: None
+    rpc_stub.set_download_base_url = lambda _url: None
+    rpc_stub.get_download_base_url = lambda: ""
+    _stub(f"{_PKG}.rpc", rpc_stub)
+
+    jsonrpc_stub = types.ModuleType(f"{_PKG}.zeromcp.jsonrpc")
+    jsonrpc_stub.get_current_cancel_event = lambda: None
+    jsonrpc_stub.RequestCancelledError = type("RequestCancelledError", (Exception,), {})
+    _stub(f"{_PKG}.zeromcp", MagicMock())
+    _stub(f"{_PKG}.zeromcp.jsonrpc", jsonrpc_stub)
+
+    saved.setdefault(f"{_PKG}.sync", sys.modules.get(f"{_PKG}.sync", _ABSENT))
+    sys.modules.pop(f"{_PKG}.sync", None)
+    import importlib
+
+    return importlib.import_module(f"{_PKG}.sync"), batch_state
+
+
+def _call_without_hanging(fn, timeout=5.0):
+    """Run fn on a worker thread and fail (rather than hang) if it blocks.
+
+    The regression this guards is an unbounded Queue.get(), so a plain call
+    would wedge the whole test session instead of reporting a failure.
+    """
+    box = {}
+
+    def run():
+        try:
+            box["value"] = fn()
+        except BaseException as exc:  # noqa: BLE001 - re-raised on the main thread
+            box["error"] = exc
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    thread.join(timeout)
+    if thread.is_alive():
+        pytest.fail(f"call blocked for more than {timeout}s (deadlock regression)")
+    if "error" in box:
+        raise box["error"]
+    return box["value"]
+
+
+@pytest.fixture
+def sync_mod():
+    saved: dict[str, object] = {}
+    module, batch_state = _install_stubs(saved)
+    module._test_batch_state = batch_state
+    # Timeout machinery installs a profile hook; disable it so the tests
+    # exercise the queue/batch logic directly.
+    module._DEFAULT_TOOL_TIMEOUT_SEC = 0.0
+    try:
+        yield module
+    finally:
+        while not module.call_stack.empty():
+            module.call_stack.get_nowait()
+        for name, previous in saved.items():
+            if previous is _ABSENT:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+
+def test_reentrant_idasync_does_not_hang_outer_call(sync_mod):
+    """A nested @idasync must not leave the outer call blocked on the queue.
+
+    Reentrancy is rejected by design (the guard raises IDASyncError). The bug
+    was what happened next: the rejected inner call had already drained the
+    LifoQueue, so the outer call's finally then blocked forever on a blocking
+    Queue.get() and froze the IDA main thread for every later request.
+    """
+
+    @sync_mod.idasync
+    def inner():
+        return "inner-done"
+
+    @sync_mod.idasync
+    def outer():
+        try:
+            inner()
+        except sync_mod.IDASyncError:
+            pass  # guard rejected the reentrant call; the outer tool carries on
+        return "outer-done"
+
+    result = _call_without_hanging(outer)
+    assert result == "outer-done"
+    assert sync_mod.call_stack.empty()
+
+
+def test_reentrant_call_reports_error_instead_of_blocking(sync_mod):
+    """The non-empty-call-stack guard must surface, not deadlock the caller."""
+    sync_mod.call_stack.put("someone_else")
+
+    @sync_mod.idasync
+    def tool():
+        return "unreachable"
+
+    with pytest.raises(sync_mod.IDASyncError, match="Call stack is not empty"):
+        tool()
+
+
+def test_batch_is_toggled_on_the_ida_main_thread(sync_mod):
+    """idc.batch() must run inside execute_sync, not before it."""
+    observed = {}
+
+    @sync_mod.idasync
+    def tool():
+        # Inside the tool body — i.e. on the IDA main thread — batch is on.
+        observed["during"] = sync_mod._test_batch_state["value"]
+        return "ok"
+
+    assert tool() == "ok"
+    assert observed["during"] == 1, "batch mode was not enabled on the main thread"
+    assert sync_mod._test_batch_state["value"] == 0, "batch mode was not restored"
+
+
+def test_batch_is_restored_when_the_tool_raises(sync_mod):
+    @sync_mod.idasync
+    def failing_tool():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        failing_tool()
+
+    assert sync_mod._test_batch_state["value"] == 0
+    assert sync_mod.call_stack.empty()


### PR DESCRIPTION
Full-project audit pass. Three independent fixes plus a refreshed upstream comparison.

## Bugs fixed

### `sync.py` — reentrant `@idasync` deadlocks the IDA main thread

`_sync_wrapper.runned()` used a blocking `call_stack.get()` in both the pre-check and the `finally`. When a `@idasync` function synchronously invokes another one, the inner call's guard pops the outer frame's entry off the LifoQueue; the outer call then parks forever on `Queue.get()` against an empty queue. IDA's main thread freezes and every later tool call piles up in `execute_sync` and never returns. Same bug upstream fixed in `85efdf8`.

Two more in the same path:

- The non-empty-call-stack guard raised `IDASyncError` from inside the `execute_sync` callback, where IDA swallows it, leaving the requesting thread blocked forever on `res_container.get()`. Now reported through `res_container`.
- `idc.batch()` was toggled in `sync_wrapper()`, i.e. on the requesting HTTP worker thread rather than the IDA main thread. Moved into `runned()` (upstream `f0cd877`).

`tests/test_sync_reentrancy.py` covers all three. The reentrancy test runs on a worker thread with a join timeout so a regression fails instead of wedging the suite — verified it reproduces the 5s block against the pre-fix code.

### `enum_upsert` has never worked

`api_types.py` referenced `idc` at 14 call sites but never imported it. Every call raised `NameError`, which the surrounding `except Exception` turned into a per-enum error result — silent failure, no test coverage.

Checked IDA 9.3's `idc.py` directly: all ten enum APIs used here still exist with matching signatures, so the import was the only thing missing.

Added a CI lint job for `F821`/`F811`. IDA modules can't be imported in CI, so undefined names inside the bundled `ida_mcp` package are invisible to pytest — a static check is what catches this class. Scoped to those two rules; style rules stay advisory.

## README corrections

| Was | Actually |
|---|---|
| ida-pro-mcp is "the original **single-instance** IDA MCP plugin" | Upstream now ships an `idalib-mcp` supervisor: persistent per-database workers, an explicit `database` argument per call, and adoption of an already-running worker **or GUI** for the same path |
| "IDA **8.3**–9.3 compatible" | Not true. `ida_ida.inf_get_*` (8.5+), `tinfo_t.get_udm` (8.5+), `func_t.get_name` (8.5+), `get_ordinal_limit` (8.4+) are all called without guards. Real floor is **8.5**; IDA 9.0 SP0 (build 240925) is unsupported |
| "Full tested client list (**19**)" | The installer configures **26**. Codex and Factory Droid were omitted despite having dedicated tests |

## `docs/ida-pro-mcp/comparison.md` refresh

The doc was pinned to upstream `d80ed7f` (April) and every gap it listed had since been closed by PRs #10–#15.

Rewritten against upstream `9236fc6` after reviewing all **88 non-merge commits** in `d80ed7f..9236fc6` — 54 of which touch shared `ida_mcp/**` code. Now includes a refresh procedure, the outstanding cherry-pick list ranked by priority, and an explicit record of which upstream changes do *not* apply here and why.

Top remaining candidate is upstream `55533c4` (`ida_kernwin.set_cancelled()` at the tool deadline). The Python `setprofile` timeout cannot preempt pure-C SDK calls, which is why full-scan tools blow past the 15s timeout on large binaries and queue every subsequent call behind them.

## Also

- `docs/function-similarity-usage.md` — worked examples against two stripped benchmark binaries
- gitignore `.serena/`

## Verification

```
python -m pytest -q                                        # 368 passed, 4 skipped
python -m ruff check src/ tests/ --select F821,F811         # All checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)