### PR TITLE
perf(router): dispatch stdio requests concurrently

### DIFF
--- a/src/ida_multi_mcp/router.py
+++ b/src/ida_multi_mcp/router.py
@@ -6,6 +6,7 @@ Routes MCP requests to the appropriate IDA instance with fallback verification.
 import json
 import http.client
 import os
+import threading
 import time
 from typing import Any
 
@@ -27,6 +28,7 @@ class InstanceRouter:
         """
         self.registry = registry
         self._binary_path_cache: dict[str, tuple[str | None, float]] = {}
+        self._cache_lock = threading.Lock()
         self._cache_timeout = 5.0  # seconds
 
     def route_request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
@@ -114,9 +116,14 @@ class InstanceRouter:
             normalized = os.path.basename(name.replace("\\", "/")).strip()
             return normalized.casefold() if normalized else None
 
-        # Check cache
-        if instance_id in self._binary_path_cache:
-            cached_name, cached_time = self._binary_path_cache[instance_id]
+        # Check cache. Held only around the dict access — the metadata query
+        # below is a blocking HTTP call and must not serialize other instances'
+        # requests now that dispatch runs concurrently. A racing miss just costs
+        # a duplicate query, which is harmless.
+        with self._cache_lock:
+            entry = self._binary_path_cache.get(instance_id)
+        if entry is not None:
+            cached_name, cached_time = entry
             if now - cached_time < self._cache_timeout:
                 # Benefit of doubt when the last query couldn't resolve a name.
                 if cached_name is None:
@@ -132,7 +139,8 @@ class InstanceRouter:
         current_name = _normalize_binary_name(metadata.get("module") if metadata else None)
 
         # Update cache
-        self._binary_path_cache[instance_id] = (current_name, now)
+        with self._cache_lock:
+            self._binary_path_cache[instance_id] = (current_name, now)
 
         # If we couldn't query, assume it's valid (benefit of doubt)
         if current_name is None:

--- a/src/ida_multi_mcp/server.py
+++ b/src/ida_multi_mcp/server.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 import json
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -112,9 +113,11 @@ class IdaMultiMcpServer:
         # idalib lifecycle manager
         self.idalib_manager = IdalibManager(self.registry, python_executable=idalib_python)
 
-        # Tool cache
+        # Tool cache. Rebound wholesale by _refresh_tools rather than mutated,
+        # so concurrent readers on stdio worker threads always see a complete map.
         self._tool_cache: dict[str, dict] = {}
         self._cache_valid = False
+        self._refresh_lock = threading.Lock()
 
         # Set up management tools
         management.set_registry(self.registry)
@@ -531,13 +534,23 @@ class IdaMultiMcpServer:
     def _refresh_tools(self) -> int:
         """Refresh tool cache from IDA instances.
 
+        Discovery does HTTP round-trips per instance and takes real time, so the
+        new cache is built into a local dict and swapped in at the end rather
+        than mutated in place. The lock keeps two concurrent refreshes (e.g. a
+        tools/list miss racing the one idalib_open triggers) from duplicating
+        that work.
+
         Returns:
             Number of tools discovered
         """
-        self._tool_cache = {}
+        with self._refresh_lock:
+            return self._build_tool_cache()
+
+    def _build_tool_cache(self) -> int:
+        cache = {}
 
         # Add management tools
-        self._tool_cache["list_instances"] = {
+        cache["list_instances"] = {
             "name": "list_instances",
             "description": "List all registered IDA Pro instances with their metadata.",
             "inputSchema": {
@@ -572,7 +585,7 @@ class IdaMultiMcpServer:
             }
         }
 
-        self._tool_cache["refresh_tools"] = {
+        cache["refresh_tools"] = {
             "name": "refresh_tools",
             "description": "Re-discover tools from IDA Pro instances.",
             "inputSchema": {
@@ -582,7 +595,7 @@ class IdaMultiMcpServer:
             }
         }
 
-        self._tool_cache["compare_binaries"] = {
+        cache["compare_binaries"] = {
             "name": "compare_binaries",
             "description": "Compare two IDA instances by diffing their binary metadata, entrypoints, and segments. Takes two instance_id values and returns what is common vs unique to each.",
             "inputSchema": {
@@ -595,7 +608,7 @@ class IdaMultiMcpServer:
             }
         }
 
-        self._tool_cache["list_cached_outputs"] = {
+        cache["list_cached_outputs"] = {
             "name": "list_cached_outputs",
             "description": "List all cached truncated outputs with cache_id, age, size, and tool name. Use this to find cache IDs for get_cached_output.",
             "inputSchema": {
@@ -605,7 +618,7 @@ class IdaMultiMcpServer:
             }
         }
 
-        self._tool_cache["get_cached_output"] = {
+        cache["get_cached_output"] = {
             "name": "get_cached_output",
             "description": "Retrieve cached output from a previous tool call that was truncated. Use this to get additional chunks of large responses.",
             "inputSchema": {
@@ -628,7 +641,7 @@ class IdaMultiMcpServer:
             }
         }
 
-        self._tool_cache["decompile_to_file"] = {
+        cache["decompile_to_file"] = {
             "name": "decompile_to_file",
             "description": "Decompile functions and save results directly to files on disk. "
                 "IMPORTANT: Each function requires a separate IDA decompile call. "
@@ -669,13 +682,13 @@ class IdaMultiMcpServer:
 
         # Register similarity tool schemas (always available; extraction is IDA-side)
         for schema in similarity.SIMILARITY_TOOL_SCHEMAS:
-            self._tool_cache[schema["name"]] = schema.copy()
+            cache[schema["name"]] = schema.copy()
 
         # Register idalib management tool schemas (only if IDA Pro with idalib is available)
         from .idalib_manager import is_idalib_available
         if is_idalib_available():
             for schema in idalib_tools.IDALIB_TOOL_SCHEMAS:
-                self._tool_cache[schema["name"]] = schema.copy()
+                cache[schema["name"]] = schema.copy()
 
         _SINGLE_THREAD_WARNING = (
             " WARNING: IDA executes on a single main thread. "
@@ -717,7 +730,7 @@ class IdaMultiMcpServer:
                     "Avoid count=0 (all) with glob filters on large binaries."
                 )
 
-            self._tool_cache[schema["name"]] = schema
+            cache[schema["name"]] = schema
 
         # Discover IDA tools from any available instance (rediscover if needed).
         instances = self.registry.list_instances()
@@ -775,11 +788,11 @@ class IdaMultiMcpServer:
                         "Avoid count=0 (all) with glob filters on large binaries."
                     )
 
-                self._tool_cache[tool_schema["name"]] = tool_schema
+                cache[tool_schema["name"]] = tool_schema
 
         # MCP spec expects outputSchema to be an object schema.
         # Some clients validate all advertised tools; keep schemas conservative.
-        for tool_schema in self._tool_cache.values():
+        for tool_schema in cache.values():
             os = tool_schema.get("outputSchema")
             if not os:
                 tool_schema["outputSchema"] = {"type": "object"}
@@ -791,8 +804,12 @@ class IdaMultiMcpServer:
                     "required": ["result"],
                 }
 
+        # Publish in one rebind. Readers (tools/list, _coerce_structured_for_schema)
+        # run on stdio worker threads, so they must never observe a partially
+        # populated cache: they either see the whole old dict or the whole new one.
+        self._tool_cache = cache
         self._cache_valid = True
-        return len(self._tool_cache)
+        return len(cache)
 
     def _discover_ida_tools(self, instance_info: dict) -> list[dict]:
         """Discover tools from an IDA instance.

--- a/src/ida_multi_mcp/vendor/zeromcp/mcp.py
+++ b/src/ida_multi_mcp/vendor/zeromcp/mcp.py
@@ -6,6 +6,7 @@
 # transport-specific — this copy logs to stderr (stdout is the stdio protocol
 # channel), whereas the HTTP copy logs to stdout. Keep shared, transport-neutral
 # fixes mirrored across both copies.
+import os
 import re
 import sys
 import time
@@ -14,6 +15,7 @@ import json
 import inspect
 import threading
 import traceback
+from concurrent.futures import ThreadPoolExecutor, wait as futures_wait
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer, HTTPServer
 from typing import Any, Callable, Union, Annotated, BinaryIO, NotRequired, get_origin, get_args, get_type_hints, is_typeddict
 from types import UnionType
@@ -430,36 +432,135 @@ class McpServer:
         print("[MCP] Server stopped", file=sys.stderr)
 
     _STDIO_MAX_LINE = 10 * 1024 * 1024  # 10MB max per line
+    # How long stdio shutdown waits for already-running calls to write a reply.
+    _STDIO_SHUTDOWN_GRACE_SEC = 5.0
 
-    def stdio(self, stdin: BinaryIO | None = None, stdout: BinaryIO | None = None):
+    def stdio(
+        self,
+        stdin: BinaryIO | None = None,
+        stdout: BinaryIO | None = None,
+        max_workers: int | None = None,
+    ):
+        """Serve MCP over stdio, dispatching requests concurrently.
+
+        Requests are handed to a bounded worker pool instead of being handled
+        inline. Dispatching inline made the router a global bottleneck: a tool
+        call to one IDA instance blocked every other instance's calls behind it
+        for as long as the router's HTTP timeout, even though the instances are
+        separate processes that can serve in parallel.
+
+        Two things stay on the reader thread:
+
+        - Notifications, so ``notifications/cancelled`` can reach an in-flight
+          request instead of queueing behind the very work it is cancelling.
+          Inline dispatch made cancellation unreachable in practice.
+        - ``initialize`` and ``ping``, which are cheap and ordering-sensitive.
+
+        JSON-RPC responses are correlated by id, so out-of-order replies are
+        valid. Only the stdout writes need serializing, which the write lock
+        does; the framing (one JSON object per line) stays intact because each
+        response is encoded and written as a single locked operation.
+        """
         stdin = stdin or sys.stdin.buffer
         stdout = stdout or sys.stdout.buffer
-        while True:
+
+        if max_workers is None:
+            max_workers = self._stdio_max_workers()
+
+        write_lock = threading.Lock()
+
+        def emit(response) -> None:
+            if response is None:
+                return
+            payload = json.dumps(response).encode("utf-8") + b"\n"
+            with write_lock:
+                stdout.write(payload)
+                stdout.flush()
+
+        def handle(request: bytes) -> None:
             try:
-                request = stdin.readline(self._STDIO_MAX_LINE + 1)
-                if not request: # EOF
+                emit(self.registry.dispatch(request))
+            except (BrokenPipeError, OSError):
+                pass  # client went away mid-write; the reader loop will notice EOF
+            except Exception as e:
+                # dispatch() maps exceptions itself, so reaching here means the
+                # failure was in emit/JSON encoding. Never let it kill a worker
+                # silently — the client would wait forever for this id.
+                print(f"[MCP] stdio worker error: {e!r}", file=sys.stderr)
+
+        def runs_inline(request: bytes) -> bool:
+            try:
+                obj = json.loads(request)
+            except Exception:
+                return True  # malformed: dispatch() owns the parse-error reply
+            if not isinstance(obj, dict):
+                return True
+            if "id" not in obj:
+                return True  # notification, including notifications/cancelled
+            return obj.get("method") in ("initialize", "ping")
+
+        executor = ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="mcp-stdio"
+        )
+        inflight: set = set()
+        inflight_lock = threading.Lock()
+
+        def submit(request: bytes) -> None:
+            future = executor.submit(handle, request)
+            with inflight_lock:
+                inflight.add(future)
+            future.add_done_callback(lambda f: inflight.discard(f))
+
+        try:
+            while True:
+                try:
+                    request = stdin.readline(self._STDIO_MAX_LINE + 1)
+                    if not request: # EOF
+                        break
+
+                    # Strip whitespace (trailing newline) before parsing
+                    request = request.strip()
+                    if not request:
+                        continue
+
+                    # Security: reject oversized lines. Reply with an error rather
+                    # than silently dropping, so the client does not hang waiting.
+                    if len(request) > self._STDIO_MAX_LINE:
+                        emit(self.registry._error(None, -32600, "Request too large"))
+                        continue
+
+                    if runs_inline(request):
+                        handle(request)
+                    else:
+                        submit(request)
+                except (BrokenPipeError, KeyboardInterrupt): # Client disconnected
                     break
+        finally:
+            # Drop work that has not started — nobody is waiting on it now — but
+            # give already-running calls a bounded window to write their reply.
+            # Waiting unbounded would hold shutdown for as long as a wedged IDA
+            # takes to answer.
+            with inflight_lock:
+                pending = [f for f in inflight if not f.done()]
+            executor.shutdown(wait=False, cancel_futures=True)
+            if pending:
+                futures_wait(pending, timeout=self._STDIO_SHUTDOWN_GRACE_SEC)
 
-                # Strip whitespace (trailing newline) before parsing
-                request = request.strip()
-                if not request:
-                    continue
-
-                # Security: reject oversized lines. Reply with an error rather
-                # than silently dropping, so the client does not hang waiting.
-                if len(request) > self._STDIO_MAX_LINE:
-                    response = self.registry._error(None, -32600, "Request too large")
-                    if response:
-                        stdout.write(json.dumps(response).encode("utf-8") + b"\n")
-                        stdout.flush()
-                    continue
-
-                response = self.registry.dispatch(request)
-                if response is not None:
-                    stdout.write(json.dumps(response).encode("utf-8") + b"\n")
-                    stdout.flush()
-            except (BrokenPipeError, KeyboardInterrupt): # Client disconnected
-                break
+    @staticmethod
+    def _stdio_max_workers() -> int:
+        """Concurrency cap for stdio dispatch (IDA_MCP_STDIO_WORKERS)."""
+        raw = os.environ.get("IDA_MCP_STDIO_WORKERS", "").strip()
+        if raw:
+            try:
+                value = int(raw)
+            except ValueError:
+                pass
+            else:
+                if value >= 1:
+                    return value
+        # Each in-flight call usually occupies one IDA instance, and IDA itself
+        # is single-threaded, so extra workers past a handful only add queueing.
+        return 8
 
     def cors_localhost(self, origin: str) -> bool:
         """Allow CORS requests from localhost on ANY port."""

--- a/tests/test_stdio_concurrency.py
+++ b/tests/test_stdio_concurrency.py
@@ -1,0 +1,239 @@
+"""Tests for concurrent stdio dispatch in vendor/zeromcp.
+
+The router proxies to N IDA instances that are separate processes and can serve
+in parallel. Dispatching inline on the reader thread made the router a global
+bottleneck: one slow tool call blocked every other instance's calls behind it.
+These tests pin the properties that fix depends on.
+"""
+
+import io
+import json
+import threading
+import time
+
+import pytest
+
+from ida_multi_mcp.vendor.zeromcp import McpServer
+
+
+class _BlockingStdin(io.RawIOBase):
+    """stdin whose readline() returns queued lines, then blocks until released.
+
+    A plain BytesIO would hit EOF immediately and shut the pool down before the
+    test could observe overlap.
+    """
+
+    def __init__(self, lines):
+        self._lines = list(lines)
+        self._eof = threading.Event()
+
+    def readline(self, _limit=-1):
+        if self._lines:
+            return self._lines.pop(0)
+        self._eof.wait(10)
+        return b""
+
+    def release(self):
+        self._eof.set()
+
+
+class _LockCheckingStdout(io.RawIOBase):
+    """stdout that records writes and flags any interleaving between them."""
+
+    def __init__(self):
+        self.chunks = []
+        self.interleaved = False
+        self._writer = None
+        self._guard = threading.Lock()
+
+    def write(self, data):
+        with self._guard:
+            if self._writer is not None:
+                self.interleaved = True
+            self._writer = threading.current_thread().name
+        time.sleep(0.001)  # widen the window for a real interleave to show up
+        with self._guard:
+            self.chunks.append(bytes(data))
+            self._writer = None
+        return len(data)
+
+    def flush(self):
+        pass
+
+    def payload(self):
+        return b"".join(self.chunks)
+
+
+def _request(req_id, method, params=None):
+    body = {"jsonrpc": "2.0", "id": req_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    return json.dumps(body).encode() + b"\n"
+
+
+def _responses(stdout):
+    lines = [l for l in stdout.payload().split(b"\n") if l.strip()]
+    return [json.loads(l) for l in lines]
+
+
+def _serve(server, stdin, stdout, **kwargs):
+    thread = threading.Thread(
+        target=server.stdio, args=(stdin, stdout), kwargs=kwargs, daemon=True
+    )
+    thread.start()
+    return thread
+
+
+def test_slow_request_does_not_block_a_later_one():
+    """The regression: a slow call must not hold up an unrelated one."""
+    server = McpServer("test")
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow() -> dict:
+        started.set()
+        release.wait(5)
+        return {"who": "slow"}
+
+    def fast() -> dict:
+        return {"who": "fast"}
+
+    server.registry.method(slow, "slow")
+    server.registry.method(fast, "fast")
+
+    stdin = _BlockingStdin([_request(1, "slow"), _request(2, "fast")])
+    stdout = _LockCheckingStdout()
+    thread = _serve(server, stdin, stdout, max_workers=4)
+
+    assert started.wait(5), "slow request never started"
+
+    # fast must complete while slow is still parked.
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        ids = [r.get("id") for r in _responses(stdout)]
+        if 2 in ids:
+            break
+        time.sleep(0.01)
+    else:
+        pytest.fail("fast request was blocked behind the slow one")
+
+    assert 1 not in [r.get("id") for r in _responses(stdout)], "slow finished early"
+
+    release.set()
+    stdin.release()
+    thread.join(5)
+
+    ids = sorted(r["id"] for r in _responses(stdout))
+    assert ids == [1, 2]
+
+
+def test_concurrent_writes_are_serialized_and_framing_holds():
+    """Many simultaneous responses must not interleave on stdout."""
+    server = McpServer("test")
+    gate = threading.Barrier(6, timeout=5)
+
+    def synchronized() -> dict:
+        # Release all workers at once so they race toward stdout together.
+        gate.wait()
+        return {"payload": "x" * 500}
+
+    server.registry.method(synchronized, "synchronized")
+
+    stdin = _BlockingStdin([_request(i, "synchronized") for i in range(6)])
+    stdout = _LockCheckingStdout()
+    thread = _serve(server, stdin, stdout, max_workers=6)
+
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and len(_responses(stdout)) < 6:
+        time.sleep(0.01)
+
+    stdin.release()
+    thread.join(5)
+
+    assert not stdout.interleaved, "stdout writes interleaved despite the lock"
+    responses = _responses(stdout)
+    assert sorted(r["id"] for r in responses) == list(range(6))
+    assert all(r["result"]["payload"] == "x" * 500 for r in responses)
+
+
+def test_notification_is_handled_inline_while_pool_is_saturated():
+    """notifications/cancelled must reach an in-flight request, not queue behind it."""
+    server = McpServer("test")
+    observed = []
+    release = threading.Event()
+    started = threading.Event()
+
+    def blocker() -> dict:
+        started.set()
+        release.wait(5)
+        return {}
+
+    def note() -> None:
+        observed.append("delivered")
+
+    server.registry.method(blocker, "blocker")
+    server.registry.method(note, "notifications/note")
+
+    notification = json.dumps(
+        {"jsonrpc": "2.0", "method": "notifications/note"}
+    ).encode() + b"\n"
+
+    # One worker, already occupied: a pooled notification could never run.
+    stdin = _BlockingStdin([_request(1, "blocker"), notification])
+    stdout = _LockCheckingStdout()
+    thread = _serve(server, stdin, stdout, max_workers=1)
+
+    assert started.wait(5), "blocker never started"
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not observed:
+        time.sleep(0.01)
+    assert observed == ["delivered"], "notification queued behind the busy pool"
+
+    release.set()
+    stdin.release()
+    thread.join(5)
+
+
+def test_malformed_line_still_gets_a_parse_error():
+    server = McpServer("test")
+    stdin = _BlockingStdin([b"{not json\n"])
+    stdout = _LockCheckingStdout()
+    thread = _serve(server, stdin, stdout, max_workers=2)
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not _responses(stdout):
+        time.sleep(0.01)
+
+    stdin.release()
+    thread.join(5)
+
+    responses = _responses(stdout)
+    assert responses and responses[0]["error"]["code"] == -32700
+
+
+def test_oversized_line_is_rejected():
+    server = McpServer("test")
+    huge = b"{" + b"a" * (server._STDIO_MAX_LINE + 10) + b"}\n"
+    stdin = _BlockingStdin([huge])
+    stdout = _LockCheckingStdout()
+    thread = _serve(server, stdin, stdout, max_workers=2)
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not _responses(stdout):
+        time.sleep(0.01)
+
+    stdin.release()
+    thread.join(5)
+
+    responses = _responses(stdout)
+    assert responses and responses[0]["error"]["code"] == -32600
+
+
+def test_worker_count_respects_env(monkeypatch):
+    monkeypatch.setenv("IDA_MCP_STDIO_WORKERS", "3")
+    assert McpServer._stdio_max_workers() == 3
+    monkeypatch.setenv("IDA_MCP_STDIO_WORKERS", "garbage")
+    assert McpServer._stdio_max_workers() == 8
+    monkeypatch.delenv("IDA_MCP_STDIO_WORKERS")
+    assert McpServer._stdio_max_workers() == 8


### PR DESCRIPTION
> **Draft — needs verification against live IDA instances before merge.**
> All automated tests pass, but nothing here has been exercised against real GUI/idalib instances yet.

## Problem

The router proxies to N IDA instances that are separate processes and can serve simultaneously. The stdio loop dispatched inline:

```python
response = self.registry.dispatch(request)   # blocking
stdout.write(...)
```

So a tool call to one instance held up every other instance's calls behind it for as long as the router's HTTP timeout. The headline use case — analysing a dropper, payload and C2 in parallel through one endpoint — was serial in practice.

## Change

Requests go to a bounded worker pool (`IDA_MCP_STDIO_WORKERS`, default 8). Only the stdout writes are serialized, under a lock, one encoded response per locked write so line framing holds. JSON-RPC correlates by id, so out-of-order replies are valid.

Two categories stay on the reader thread:

- **Notifications** — `notifications/cancelled` has to reach an in-flight request rather than queue behind the very work it cancels. Inline dispatch made cancellation unreachable in practice; a saturated pool would reintroduce that.
- **`initialize` / `ping`** — cheap and ordering-sensitive.

## Shared state this exposed

Threading the dispatch is the easy part; these were the substance.

- **`_refresh_tools`** assigned `self._tool_cache = {}` and then filled it across many HTTP round-trips. A concurrent reader could observe a half-built cache — a partial `tools/list`, or a missing `outputSchema` leading `_coerce_structured_for_schema` to mis-shape a response. Now builds a local dict and rebinds once, under a lock so two refreshes (a `tools/list` miss racing the one `idalib_open` triggers) cannot overlap.
- **`router._binary_path_cache`** reads/writes are now guarded. The lock is released across the metadata HTTP call so one instance's probe does not serialize others; a racing miss just costs a duplicate query.

Already thread-safe, verified rather than changed: `ResponseCache` (`threading.Lock`), `InstanceRegistry` (`_cache_lock` + `FileLock`), and `jsonrpc.dispatch` (sets its own thread-locals; cancellation goes through a lock-guarded global). The `_protocol_version` / `_enabled_extensions` thread-locals are set only in the HTTP handler, so stdio never depended on cross-request thread affinity.

## Shutdown

On EOF, queued-but-unstarted work is cancelled and running calls get a bounded 5s window to write their reply, so shutdown cannot hang on a wedged IDA.

## Tests

`tests/test_stdio_concurrency.py` covers overlap, write serialization plus framing, inline notification delivery under a saturated pool, and the existing parse-error / oversized-line paths.

Verified the first three **fail** when dispatch is forced back inline — they are not vacuous.

```
python -m pytest -q                                    # 374 passed, 4 skipped
python -m ruff check src/ tests/ --select F821,F811     # All checks passed
```

## Before merging

- [ ] Run against 2+ live GUI instances, confirm calls actually overlap
- [ ] Run against a headless `idalib_open` session alongside a GUI instance
- [ ] Confirm `notifications/cancelled` now interrupts an in-flight call
- [ ] Sanity-check a long `survey_binary` on a large binary no longer blocks other instances

Note: IDA remains single-threaded *within* an instance, so concurrency is across instances, not within one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)