### PR TITLE
feat(sync): fire ida_kernwin.set_cancelled() at the tool deadline (cherry-pick)

### DIFF
--- a/docs/ida-pro-mcp/comparison.md
+++ b/docs/ida-pro-mcp/comparison.md
@@ -49,9 +49,9 @@ call piles up in `execute_sync` and never returns.
 **Current state**: `src/ida_multi_mcp/ida_mcp/sync.py:65` and `:75` still use blocking
 `get()`. Upstream's fix is a two-line change to `get_nowait()` with `queue.Empty` handling.
 
-### 2. `sync.py`: no native cancellation, so slow SDK calls blow past the tool timeout
+### 2. `sync.py`: no native cancellation — ADOPTED
 
-**Upstream fix**: `55533c4` (addresses upstream #235).
+**Cherry-picked from upstream `55533c4`** (addresses upstream #235).
 
 The Python-level `setprofile` timeout cannot preempt pure-C SDK calls. `ida_search.find_*`,
 `ida_bytes.find_bytes`/`bin_search`, `ida_hexrays.decompile*`, `ida_strlist.build_strlist`,
@@ -63,8 +63,12 @@ so upstream schedules a `threading.Timer(timeout, set_cancelled)`, gives the too
 window to format a partial response, then unconditionally `clr_cancelled()` in the `finally`
 (the flag is sticky — without the clear, every later `user_cancelled()` returns True forever).
 
-**Current state**: not implemented. This is the direct remedy for full-scan tools timing out
-on large binaries; it is the highest-value item in this list.
+**Status**: ported. `sync_wrapper` now clears the flag at entry, arms a
+`threading.Timer(timeout, set_cancelled)`, gives the tool a 5s grace window
+(`_NATIVE_CANCEL_GRACE_SEC`) to format a partial response, and clears the sticky flag
+unconditionally in the `finally`. `find` and `find_bytes` gained the
+`cursor.cancelled` marker so callers can tell "we stopped early" from "end of page".
+Upstream's `search_text` changes do not apply — we have no such tool.
 
 ### 3. `sync.py`: `idc.batch()` is called from the requesting thread, not the IDA main thread
 
@@ -155,6 +159,8 @@ return actionable messages instead of bare failures. Applies to our `api_analysi
 | `parse_address` symbol resolution (`idaapi.get_name_ea` fallback) | PR #12 |
 | Lazy caches for functions and globals | PR #14 |
 | Headless detection via `is_idaq()` | PR #15 |
+| Reentrancy `get_nowait()` + batch on the IDA main thread (`85efdf8`, `f0cd877`) | PR #26 |
+| Native cancellation at the tool deadline (`55533c4`) | PR #28 |
 | Tool parameter consistency (PR #362 upstream) | Names already match |
 | HTTP Host/Origin validation | `http.py`; CORS fallback hardened in PR #17 |
 | `@unsafe` gating in idalib | `is_idalib_available()` + worker `--unsafe` |
@@ -186,9 +192,9 @@ return actionable messages instead of bare failures. Applies to our `api_analysi
 
 | # | Item | Upstream commit | Priority | Effort |
 |---|---|---|---|---|
-| 1 | `set_cancelled()` at tool deadline | `55533c4` | HIGH | M |
-| 2 | `get_nowait()` in `call_stack` cleanup | `85efdf8` | HIGH | S |
-| 3 | Move `idc.batch()` onto the IDA main thread | `f0cd877` | HIGH | S |
+| ~~1~~ | ~~`set_cancelled()` at tool deadline~~ — adopted | `55533c4` | HIGH | M |
+| ~~2~~ | ~~`get_nowait()` in `call_stack` cleanup~~ — adopted | `85efdf8` | HIGH | S |
+| ~~3~~ | ~~Move `idc.batch()` onto the IDA main thread~~ — adopted | `f0cd877` | HIGH | S |
 | 4 | `compat.py` guards for 8.4/8.5/9.0-SP0 APIs | `f212140`, `7cca988` | HIGH | M |
 | 5 | `idb_save` native in-place save in GUI | `6673de9` | MED | S |
 | 6 | Richer error reporting on rename/xrefs/decompile/set_type | `c395db9` | MED | M |

--- a/src/ida_multi_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_multi_mcp/ida_mcp/api_analysis.py
@@ -8,6 +8,7 @@ import idaapi
 import idautils
 import ida_typeinf
 import ida_nalt
+import ida_kernwin
 import ida_bytes
 import ida_ida
 import ida_entry
@@ -646,12 +647,21 @@ def find_bytes(
         except Exception:
             pass
 
+        if ida_kernwin.user_cancelled():
+            # The deadline fired set_cancelled() while bin_search was running
+            # and it bailed with BADADDR. Surface partial results with a
+            # cancelled marker rather than claiming the scan finished.
+            cursor = {"next": offset + len(matches), "cancelled": True}
+        elif more:
+            cursor = {"next": offset + limit}
+        else:
+            cursor = {"done": True}
         results.append(
             {
                 "pattern": pattern,
                 "matches": matches,
                 "n": len(matches),
-                "cursor": {"next": offset + limit} if more else {"done": True},
+                "cursor": cursor,
             }
         )
     return results
@@ -820,12 +830,18 @@ def find(
             except Exception:
                 pass
 
+            if ida_kernwin.user_cancelled():
+                cursor = {"next": offset + len(matches), "cancelled": True}
+            elif more:
+                cursor = {"next": offset + limit}
+            else:
+                cursor = {"done": True}
             results.append(
                 {
                     "query": pattern_str,
                     "matches": matches,
                     "count": len(matches),
-                    "cursor": {"next": offset + limit} if more else {"done": True},
+                    "cursor": cursor,
                     "error": None,
                 }
             )
@@ -892,12 +908,18 @@ def find(
             except Exception:
                 pass
 
+            if ida_kernwin.user_cancelled():
+                cursor = {"next": offset + len(matches), "cancelled": True}
+            elif more:
+                cursor = {"next": offset + limit}
+            else:
+                cursor = {"done": True}
             results.append(
                 {
                     "query": value,
                     "matches": matches,
                     "count": len(matches),
-                    "cursor": {"next": offset + limit} if more else {"done": True},
+                    "cursor": cursor,
                     "error": None,
                 }
             )

--- a/src/ida_multi_mcp/ida_mcp/sync.py
+++ b/src/ida_multi_mcp/ida_mcp/sync.py
@@ -3,6 +3,7 @@ import queue
 import functools
 import os
 import sys
+import threading
 import time
 from enum import IntEnum
 import idaapi
@@ -39,6 +40,9 @@ class CancelledError(RequestCancelledError):
 logger = logging.getLogger(__name__)
 _TOOL_TIMEOUT_ENV = "IDA_MCP_TOOL_TIMEOUT_SEC"
 _DEFAULT_TOOL_TIMEOUT_SEC = 15.0
+# After the deadline fires ida_kernwin.set_cancelled(), how long a tool may keep
+# running so it can format a partial response before IDASyncError is raised.
+_NATIVE_CANCEL_GRACE_SEC = 5.0
 
 
 def _get_tool_timeout_seconds() -> float:
@@ -129,10 +133,41 @@ def sync_wrapper(ff, timeout_override: float | None = None):
             # not when the request was queued (avoids stale deadlines)
             deadline = time.monotonic() + timeout if timeout > 0 else None
 
+            # Native cancellation: clear any stale flag and schedule a
+            # set_cancelled() at the deadline. The sys.setprofile hook below
+            # only fires between Python bytecodes, so it cannot preempt a
+            # pure-C SDK call — a slow scan holds the IDA main thread well
+            # past the timeout and every later tool call queues behind it.
+            #
+            # Many SDK calls already poll user_cancelled() and bail within one
+            # poll cycle: ida_search.find_* (unless SEARCH_NOBRK),
+            # ida_bytes.find_bytes/bin_search (unless BIN_SEARCH_NOBREAK),
+            # ida_hexrays.decompile*, ida_strlist.build_strlist,
+            # ida_auto.auto_wait. set_cancelled() is THREAD_SAFE, so firing it
+            # from a Timer thread is safe.
+            ida_kernwin.clr_cancelled()
+            cancel_fired_at: list[float | None] = [None]
+            native_timer: threading.Timer | None = None
+            if deadline is not None:
+                def _fire_native_cancel():
+                    cancel_fired_at[0] = time.monotonic()
+                    ida_kernwin.set_cancelled()
+
+                native_timer = threading.Timer(timeout, _fire_native_cancel)
+                native_timer.daemon = True
+                native_timer.start()
+
             def profilefunc(frame, event, arg):
-                # Check cancellation first (higher priority)
+                # Check request-level cancellation first (higher priority)
                 if cancel_event is not None and cancel_event.is_set():
                     raise CancelledError("Request was cancelled")
+                # If native cancel just fired, give the tool a short grace
+                # period to format a partial response rather than racing the
+                # IDASyncError. Beyond that we still raise to bound the
+                # response time.
+                fired_at = cancel_fired_at[0]
+                if fired_at is not None and time.monotonic() < fired_at + _NATIVE_CANCEL_GRACE_SEC:
+                    return
                 if deadline is not None and time.monotonic() >= deadline:
                     raise IDASyncError(f"Tool timed out after {timeout:.2f}s")
 
@@ -142,6 +177,12 @@ def sync_wrapper(ff, timeout_override: float | None = None):
                 return ff()
             finally:
                 sys.setprofile(old_profile)
+                if native_timer is not None:
+                    native_timer.cancel()
+                # Sticky flag: clear unconditionally so the next tool starts
+                # with a clean state. Without this, every subsequent
+                # user_cancelled() returns True forever.
+                ida_kernwin.clr_cancelled()
 
         timed_ff.__name__ = ff.__name__
         return _sync_wrapper(timed_ff)

--- a/src/ida_multi_mcp/ida_mcp/sync.py
+++ b/src/ida_multi_mcp/ida_mcp/sync.py
@@ -40,9 +40,26 @@ class CancelledError(RequestCancelledError):
 logger = logging.getLogger(__name__)
 _TOOL_TIMEOUT_ENV = "IDA_MCP_TOOL_TIMEOUT_SEC"
 _DEFAULT_TOOL_TIMEOUT_SEC = 15.0
+
 # After the deadline fires ida_kernwin.set_cancelled(), how long a tool may keep
-# running so it can format a partial response before IDASyncError is raised.
-_NATIVE_CANCEL_GRACE_SEC = 5.0
+# running so it can notice the flag and format a partial response before
+# IDASyncError is raised.
+#
+# This does extend the worst case to timeout + grace. It only buys anything for
+# work that actually polls user_cancelled() (the C SDK calls); a pure-Python
+# loop just runs longer. Set to 0 to enforce the timeout strictly.
+_NATIVE_CANCEL_GRACE_ENV = "IDA_MCP_CANCEL_GRACE_SEC"
+_DEFAULT_NATIVE_CANCEL_GRACE_SEC = 5.0
+
+
+def _get_native_cancel_grace_seconds() -> float:
+    value = os.getenv(_NATIVE_CANCEL_GRACE_ENV, "").strip()
+    if value == "":
+        return _DEFAULT_NATIVE_CANCEL_GRACE_SEC
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        return _DEFAULT_NATIVE_CANCEL_GRACE_SEC
 
 
 def _get_tool_timeout_seconds() -> float:
@@ -146,6 +163,7 @@ def sync_wrapper(ff, timeout_override: float | None = None):
             # ida_auto.auto_wait. set_cancelled() is THREAD_SAFE, so firing it
             # from a Timer thread is safe.
             ida_kernwin.clr_cancelled()
+            grace = _get_native_cancel_grace_seconds()
             cancel_fired_at: list[float | None] = [None]
             native_timer: threading.Timer | None = None
             if deadline is not None:
@@ -166,7 +184,7 @@ def sync_wrapper(ff, timeout_override: float | None = None):
                 # IDASyncError. Beyond that we still raise to bound the
                 # response time.
                 fired_at = cancel_fired_at[0]
-                if fired_at is not None and time.monotonic() < fired_at + _NATIVE_CANCEL_GRACE_SEC:
+                if fired_at is not None and time.monotonic() < fired_at + grace:
                     return
                 if deadline is not None and time.monotonic() >= deadline:
                     raise IDASyncError(f"Tool timed out after {timeout:.2f}s")

--- a/tests/test_sync_reentrancy.py
+++ b/tests/test_sync_reentrancy.py
@@ -14,6 +14,7 @@ Regression coverage for two bugs:
 
 import sys
 import threading
+import time
 import types
 from unittest.mock import MagicMock
 
@@ -212,6 +213,52 @@ def test_batch_is_toggled_on_the_ida_main_thread(sync_mod):
     assert tool() == "ok"
     assert observed["during"] == 1, "batch mode was not enabled on the main thread"
     assert sync_mod._test_batch_state["value"] == 0, "batch mode was not restored"
+
+
+def test_native_cancel_fires_at_the_deadline(sync_mod):
+    """A pure-C SDK call can only be preempted via ida_kernwin.set_cancelled().
+
+    Ported from upstream ida-pro-mcp 55533c4. The setprofile hook cannot
+    interrupt a C call, so the deadline schedules set_cancelled() on a Timer;
+    SDK calls that poll user_cancelled() then bail on their own.
+    """
+    kernwin = sys.modules["ida_kernwin"]
+    kernwin.reset_mock()
+    sync_mod._DEFAULT_TOOL_TIMEOUT_SEC = 0.15
+
+    fired = threading.Event()
+    kernwin.set_cancelled.side_effect = lambda: fired.set()
+
+    @sync_mod.idasync
+    def slow_c_call():
+        # Stands in for a C SDK call: no Python bytecode executes during it,
+        # so profilefunc never runs and only the Timer can intervene.
+        fired.wait(3)
+        return "done"
+
+    assert _call_without_hanging(slow_c_call, timeout=10) == "done"
+    assert fired.is_set(), "set_cancelled() was never fired at the deadline"
+    # Sticky flag must be cleared or every later user_cancelled() returns True.
+    assert kernwin.clr_cancelled.call_count >= 2, (
+        f"clr_cancelled called {kernwin.clr_cancelled.call_count}x; "
+        "expected one at entry and one in the finally"
+    )
+
+
+def test_native_cancel_timer_is_cancelled_on_fast_calls(sync_mod):
+    """A tool finishing well inside the deadline must not fire set_cancelled."""
+    kernwin = sys.modules["ida_kernwin"]
+    kernwin.reset_mock()
+    kernwin.set_cancelled.side_effect = None
+    sync_mod._DEFAULT_TOOL_TIMEOUT_SEC = 5.0
+
+    @sync_mod.idasync
+    def quick():
+        return "fast"
+
+    assert _call_without_hanging(quick) == "fast"
+    time.sleep(0.3)
+    assert kernwin.set_cancelled.call_count == 0, "timer was not cancelled"
 
 
 def test_batch_is_restored_when_the_tool_raises(sync_mod):


### PR DESCRIPTION
## Attribution

**Cherry-picked from upstream [mrexodia/ida-pro-mcp@`55533c4`](https://github.com/mrexodia/ida-pro-mcp/commit/55533c4) by Duncan Ogilvie (MIT).** Adapted to our `sync.py`, which has no `keep_batch` parameter. This is shared code we forked from upstream, so taking their fix is maintenance, not reimplementation — recording it here and in `docs/ida-pro-mcp/comparison.md` so the provenance is explicit.

## Why

`sys.setprofile` only fires between Python bytecodes, so it cannot preempt a pure-C SDK call. `ida_search.find_*`, `ida_bytes.find_bytes`/`bin_search`, `ida_hexrays.decompile*`, `ida_strlist.build_strlist` and `ida_auto.auto_wait` therefore run to natural completion regardless of the 15s tool timeout, holding the IDA main thread while every queued call piles up behind it.

#27 fixed cross-instance blocking. This fixes blocking *within* one instance.

Those calls do poll `user_cancelled()`, and `set_cancelled()` is THREAD_SAFE, so `sync_wrapper` now clears the flag at entry, arms a `threading.Timer(timeout, set_cancelled)`, gives the tool a grace window to format a partial response, then cancels the timer and clears the flag unconditionally in the `finally`. **That last clear is load-bearing** — the flag is sticky, so without it every later `user_cancelled()` returns True forever and all subsequent scans bail instantly.

`find` and `find_bytes` gained the `cursor.cancelled` marker from the same commit so callers can tell "we stopped early" from "end of page".

Upstream's `search_text` hunk (`SEARCH_BRK`) is **not** ported — we have no such tool.

## Deviation from upstream: configurable grace window

Live testing surfaced the cost. On an instance with `IDA_MCP_TOOL_TIMEOUT_SEC=1`, a pure-Python 60M-iteration loop **ran to completion in 3.75s** rather than being cut at 1s: `profilefunc` returns early for the whole grace window, so the real ceiling is `timeout + grace` (20s at our 15s default).

That is the right trade for C SDK calls — the grace window is what lets them notice the flag and return partial results. It buys nothing for Python-bound work, which just runs longer.

Upstream hardcodes `5.0`. This exposes `IDA_MCP_CANCEL_GRACE_SEC` so the timeout can be enforced strictly (`0`) where that matters.

## Live verification

Against real IDA Home 9.3 GUI instances.

**Regression** — full harness, 2 instances, **15/15 pass** (same suite used to sign off #26/#27).

**Targeted** — one instance launched with `IDA_MCP_TOOL_TIMEOUT_SEC=1`:

```
[1] find before cancel      -> 0.02s  cursor={"done": true}
[2] py_eval 60M-iter loop   -> 3.75s  completed (grace window, as designed)
[3] find AFTER cancel       -> 0.00s  cursor={"done": true}   <-- sticky flag cleared
[4] list_funcs after cancel -> 0.00s  ok=True
```

Step **[3]** is the one that matters: without `clr_cancelled()` in the `finally` it would report `cancelled: true` and keep doing so for the life of the instance.

## Tests

`tests/test_sync_reentrancy.py` gains two cases: the Timer fires `set_cancelled()` when the profile hook cannot (standing in for a C call), and a fast tool cancels its timer without firing.

```
python -m pytest -q                                   # 376 passed, 4 skipped
python -m ruff check src/ tests/ --select F821,F811    # All checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)