### PR TITLE
fix(compat): shim moved IDA APIs; make auto-analysis completion detectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,17 @@ Every IDA Pro instance auto-registers on startup, so your LLM client sees all of
 
 ## Contents
 
-- [Quick Start](#quick-start)
-- [How It Works](#how-it-works)
-- [Features](#features)
-- [Requirements](#requirements)
-- [Manual Installation](#manual-installation) · [Supported MCP Clients](#supported-mcp-clients) · [Uninstallation](#uninstallation)
-- [Usage](#usage)
-- [Management Tools](#management-tools) · [Function Similarity (BCSD)](#function-similarity-bcsd)
-- [CLI Commands](#cli-commands)
-- [Architecture](#architecture) · [Instance IDs Explained](#instance-ids-explained) · [Design Decisions](#design-decisions)
-- [Performance](#performance) · [Limitations](#limitations)
-- [Troubleshooting](#troubleshooting)
-- [Acknowledgments](#acknowledgments) · [Related Projects](#related-projects)
+**Start here** — [Quick Start](#quick-start) · [How It Works](#how-it-works) · [Features](#features) · [Requirements](#requirements) · [Manual Installation](#manual-installation)
+
+**Using it** — [Usage](#usage) · [Function Similarity (BCSD)](#function-similarity-bcsd) · [Limitations](#limitations)
+
+**Reference** *(collapsed below)* — [Management Tools](#management-tools) · [CLI Commands](#cli-commands) · [Architecture](#architecture) · [Instance IDs](#instance-ids-explained) · [Design Decisions](#design-decisions) · [Performance](#performance) · [Troubleshooting](#troubleshooting) · [Uninstallation](#uninstallation)
 
 ## Quick Start
 
 **Just ask your AI agent to install it.** Copy-paste one of these prompts — it handles the Python version matching, IDA plugin placement, and MCP client registration for you.
 
-**Claude Code / AmpCode:**
+**Claude Code / Codex:**
 > Install and configure ida-multi-mcp by following the instructions here: https://raw.githubusercontent.com/MeroZemory/ida-multi-mcp/main/docs/installation.md
 
 **Cursor:**
@@ -81,7 +74,7 @@ MCP Client (Claude, Cursor, etc.)
 - 🏷️ **Smart instance tracking** — 4-character IDs (`k7m2`, `px3a`) with automatic binary-change detection
 - 🧯 **Graceful fallback** — handles binary changes, stale instances, and crashes with actionable errors
 - 🔒 **Localhost only** — loopback-bound with Host/Origin validation; no remote surface
-- 🧩 **IDA 8.5–9.3 compatible** — version shims (`compat.py`) for entry-point and `inf_*` API moves
+- 🧩 **IDA 8.5–9.3 compatible** — `compat.py` shims the APIs that moved between releases (entry points, `inf_*` accessors, type ordinals, UDM lookup, `guess_tinfo`) and warns on IDA 9.0 SP0, which shipped without several of them
 
 ## Requirements
 
@@ -212,6 +205,9 @@ For clients not auto-detected or to view the raw configuration JSON:
 ida-multi-mcp --config
 ```
 
+<details>
+<summary><b>Uninstallation — per-platform removal steps</b></summary>
+
 ## Uninstallation
 
 <details>
@@ -245,6 +241,8 @@ python -m pip uninstall -y ida-multi-mcp
 </details>
 
 After uninstalling, fully restart IDA Pro and your MCP client(s) so the removed configuration is picked up.
+
+</details>
 
 ## Usage
 
@@ -327,6 +325,9 @@ Decompile main in malware.exe (k7m2) and compare it with the entry point in drop
 Index malware.exe (k7m2) and dropper.dll (px3a), then find the function in dropper.dll most similar to sub_140001000 in malware.exe
 ```
 
+<details>
+<summary><b>Management Tools — list_instances, refresh_tools, idalib_*, similarity tools</b></summary>
+
 ## Management Tools
 
 The server provides built-in management tools:
@@ -355,13 +356,19 @@ List all managed headless idalib sessions.
 ### idalib_status(instance_id) *(IDA Pro only)*
 Health/readiness check for a specific idalib session.
 
-### Function Similarity (BCSD)
+</details>
+
+## Function Similarity (BCSD)
 Local, cross-instance binary code similarity — no cloud, no external service. Signals are name-independent (survive stripping): instruction-shingle MinHash, IDF-weighted imported-API / string / constant anchors, and CFG structure/shape, plus symbol-gated pseudocode tokens. An optional `[neural]` extra adds on-demand jTrans embeddings for anchor-less cross-compiler matches.
 
 - **`index_functions(instance_id, rebuild=False)`** — build/refresh the searchable index for a binary (content-hash keyed, persisted under `~/.ida-mcp/index/`, incremental, backgroundable).
 - **`index_status(instance_id)`** — index readiness, function count, staleness, and background progress.
 - **`similar_functions(instance_id, func, top_k=20, scope="binary"|"instances"|"all")`** — rank the most similar functions within the binary or across instances; returns a per-signal breakdown and confidence label.
 - **`compare_functions(a, b)`** — direct pairwise similarity between two functions (optionally across instances).
+
+
+<details>
+<summary><b>Instance IDs Explained — how the 4-char IDs are derived and when they change</b></summary>
 
 ## Instance IDs Explained
 
@@ -382,6 +389,11 @@ When you open a different binary in an IDA instance:
 1. Old instance expires (e.g., `k7m2` → expired)
 2. New instance registers (e.g., `b12`)
 3. If LLM tries to use old ID, you get a helpful error with the replacement ID
+
+</details>
+
+<details>
+<summary><b>CLI Commands — <code>--list</code>, <code>--install</code>, <code>--uninstall</code>, <code>--config</code></b></summary>
 
 ## CLI Commands
 
@@ -421,6 +433,11 @@ Print the MCP client configuration JSON for easy reference.
 ```bash
 ida-multi-mcp --config
 ```
+
+</details>
+
+<details>
+<summary><b>Architecture — registry layout, plugin directory, routing, health monitoring</b></summary>
 
 ## Architecture
 
@@ -471,6 +488,11 @@ When a binary change is detected:
 - Old instance ID is marked as expired
 - New instance registers with new ID
 - LLM receives helpful message with replacement ID
+
+</details>
+
+<details>
+<summary><b>Troubleshooting — plugin not loading, wrong Python, stale instances, Codex TOML</b></summary>
 
 ## Troubleshooting
 
@@ -579,6 +601,11 @@ Do not use unquoted `\\?\...` project table keys, and do not use double-quoted W
 
 </details>
 
+</details>
+
+<details>
+<summary><b>Design Decisions — the trade-offs behind the architecture</b></summary>
+
 ## Design Decisions
 
 | Decision | Rationale |
@@ -592,6 +619,11 @@ Do not use unquoted `\\?\...` project table keys, and do not use double-quoted W
 | compat.py shims | Single source for IDA 8.5–9.3 API differences |
 | Worker pool for stdio dispatch | Instances are separate processes; serializing at the router wasted that. Only stdout writes are locked (`IDA_MCP_STDIO_WORKERS`) |
 | Deadline fires IDA's `set_cancelled()` | A Python-level timeout cannot preempt a C SDK call; IDA's own cancel flag can (`IDA_MCP_CANCEL_GRACE_SEC`) |
+
+</details>
+
+<details>
+<summary><b>Performance — benchmarks on a 736K-function binary</b></summary>
 
 ## Performance
 
@@ -626,6 +658,8 @@ instance B while instance A was busy for ~3.7 s:
 
 [Full benchmark report with per-tool detail &rarr;](docs/benchmark-report.md)
 
+</details>
+
 ## Limitations
 
 - **Localhost only.** The router binds loopback and refuses non-loopback instances; remote IDA instances are not supported.
@@ -652,8 +686,6 @@ Contributions welcome! Please ensure:
 This project was inspired by and builds upon [ida-pro-mcp](https://github.com/mrexodia/ida-pro-mcp) by [Duncan Ogilvie (mrexodia)](https://github.com/mrexodia). The IDA tool implementations originated from ida-pro-mcp and have been absorbed into ida-multi-mcp as a bundled package, adding multi-instance orchestration and headless idalib support on top. Fixes still flow both ways — see [`docs/ida-pro-mcp/comparison.md`](docs/ida-pro-mcp/comparison.md) for what has been adopted from upstream and what has been sent back.
 
 Upstream has since grown its own multi-session story: `idalib-mcp` is now a supervisor that keeps each open database in a persistent worker process, requires an explicit `database` argument per call, and can adopt an already-running worker or GUI for the same path. The two projects have converged on explicit session routing but differ in approach — ida-multi-mcp discovers GUI instances through a shared file registry that each IDA plugin auto-registers with on startup, so no per-database endpoint configuration is needed on the client side.
-
-The installation approach (AI-agent-friendly installation guides) was influenced by [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) by [Yeongyu Yun (code-yeongyu)](https://github.com/code-yeongyu).
 
 ## Related Projects
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,9 @@ Every IDA Pro instance auto-registers on startup, so your LLM client sees all of
 
 ## Contents
 
-**Start here** — [Quick Start](#quick-start) · [How It Works](#how-it-works) · [Features](#features) · [Requirements](#requirements) · [Manual Installation](#manual-installation)
+**On this page** — [Quick Start](#quick-start) · [How It Works](#how-it-works) · [Features](#features) · [Requirements](#requirements) · [Manual Installation](#manual-installation) · [Usage](#usage) · [Function Similarity (BCSD)](#function-similarity-bcsd) · [Limitations](#limitations)
 
-**Using it** — [Usage](#usage) · [Function Similarity (BCSD)](#function-similarity-bcsd) · [Limitations](#limitations)
-
-**Reference** *(collapsed below)* — [Management Tools](#management-tools) · [CLI Commands](#cli-commands) · [Architecture](#architecture) · [Instance IDs](#instance-ids-explained) · [Design Decisions](#design-decisions) · [Performance](#performance) · [Troubleshooting](#troubleshooting) · [Uninstallation](#uninstallation)
+**Reference** — [Tools](docs/tools.md) · [CLI](docs/cli.md) · [Architecture](docs/architecture.md) · [Performance](docs/performance.md) · [Troubleshooting](docs/troubleshooting.md)
 
 ## Quick Start
 
@@ -43,7 +41,8 @@ Every IDA Pro instance auto-registers on startup, so your LLM client sees all of
 Once installed, open your binaries in IDA Pro (instances auto-register) and ask your LLM:
 > *"Decompile `main` in malware.exe (k7m2) and compare it with the entry point in dropper.dll (px3a)"*
 
-Prefer to install by hand? See [Manual Installation](#manual-installation) below.
+Prefer to install by hand? See [Manual Installation](#manual-installation) below; removing it
+again is covered in [Troubleshooting](docs/troubleshooting.md#uninstallation).
 
 ## How It Works
 
@@ -206,45 +205,6 @@ For clients not auto-detected or to view the raw configuration JSON:
 ida-multi-mcp --config
 ```
 
-<details>
-<summary><b>Uninstallation — per-platform removal steps</b></summary>
-
-## Uninstallation
-
-<details>
-<summary><b>macOS</b></summary>
-
-```bash
-# 1. Remove IDA plugin + MCP client configurations
-ida-multi-mcp --uninstall
-
-# 2. Remove packages
-pipx uninstall ida-multi-mcp
-python3.11 -m pip uninstall -y ida-multi-mcp  # replace 3.11 with IDA's version
-```
-
-</details>
-
-<details>
-<summary><b>Windows</b></summary>
-
-```bash
-# 1. Remove IDA plugin + MCP client configurations
-ida-multi-mcp --uninstall
-
-# (optional) If IDA is installed in a custom location
-ida-multi-mcp --uninstall --ida-dir "C:\Program Files\IDA Pro 9.0"
-
-# 2. Remove the Python package
-python -m pip uninstall -y ida-multi-mcp
-```
-
-</details>
-
-After uninstalling, fully restart IDA Pro and your MCP client(s) so the removed configuration is picked up.
-
-</details>
-
 ## Usage
 
 ### Opening Multiple Binaries (GUI Mode)
@@ -354,39 +314,6 @@ Decompile main in malware.exe (k7m2) and compare it with the entry point in drop
 Index malware.exe (k7m2) and dropper.dll (px3a), then find the function in dropper.dll most similar to sub_140001000 in malware.exe
 ```
 
-<details>
-<summary><b>Management Tools — list_instances, refresh_tools, idalib_*, similarity tools</b></summary>
-
-## Management Tools
-
-The server provides built-in management tools:
-
-### list_instances()
-Lists all registered instances with metadata (binary name, path, architecture, port, **type**: `gui` or `idalib`).
-
-### refresh_tools()
-Re-discovers tools from IDA instances. Use this if you update the IDA plugin.
-
-### get_cached_output(cache_id, offset, size)
-Retrieve cached output from a previous tool call that was truncated.
-
-### decompile_to_file(...)
-Decompile functions and save results directly to files on disk. Requires `instance_id`.
-
-### idalib_open(input_path, timeout, unsafe) *(IDA Pro only)*
-Open a binary in a new headless idalib session. Spawns a subprocess, waits for auto-analysis, registers in the shared registry.
-
-### idalib_close(instance_id) *(IDA Pro only)*
-Terminate a headless idalib session and remove it from the registry.
-
-### idalib_list() *(IDA Pro only)*
-List all managed headless idalib sessions.
-
-### idalib_status(instance_id) *(IDA Pro only)*
-Health/readiness check for a specific idalib session.
-
-</details>
-
 ## Function Similarity (BCSD)
 Local, cross-instance binary code similarity — no cloud, no external service. Signals are name-independent (survive stripping): instruction-shingle MinHash, IDF-weighted imported-API / string / constant anchors, and CFG structure/shape, plus symbol-gated pseudocode tokens. An optional `[neural]` extra adds on-demand jTrans embeddings for anchor-less cross-compiler matches.
 
@@ -396,298 +323,18 @@ Local, cross-instance binary code similarity — no cloud, no external service. 
 - **`compare_functions(a, b)`** — direct pairwise similarity between two functions (optionally across instances).
 
 
-<details>
-<summary><b>Instance IDs Explained — how the 4-char IDs are derived and when they change</b></summary>
-
-## Instance IDs Explained
-
-Instance IDs are 4-character base36 strings (0-9, a-z) like `k7m2`, `px3a`, `9bf1`.
-
-**Why 4 characters?**
-- Short and readable
-- 1.68 million combinations (collision-free for typical use)
-- Auto-expands to 5 characters if collision detected
-
-**How are they generated?**
-- Based on: process ID, port, and IDB file path
-- Same binary reopened = same ID (deterministic)
-- Binary replaced/changed = new ID (automatic)
-
-**What happens when you change binaries?**
-When you open a different binary in an IDA instance:
-1. Old instance expires (e.g., `k7m2` → expired)
-2. New instance registers (e.g., `b12`)
-3. If LLM tries to use old ID, you get a helpful error with the replacement ID
-
-</details>
-
-<details>
-<summary><b>CLI Commands — <code>--list</code>, <code>--install</code>, <code>--uninstall</code>, <code>--config</code></b></summary>
-
-## CLI Commands
-
-### `ida-multi-mcp`
-Start the MCP server (stdio). Used by MCP clients. This is the default command.
-
-```bash
-ida-multi-mcp
-ida-multi-mcp --idalib-python /path/to/python3  # custom Python for headless sessions
-```
-
-### `ida-multi-mcp --list`
-List all registered IDA instances.
-
-```bash
-ida-multi-mcp --list
-```
-
-### `ida-multi-mcp --install [--ida-dir DIR]`
-Install the IDA plugin and auto-configure all detected MCP clients (Claude Code, Claude Desktop, Cursor, Windsurf, VS Code, Zed, and 20+ more).
-
-```bash
-ida-multi-mcp --install
-ida-multi-mcp --install --ida-dir "C:\Program Files\IDA Pro 9.0"  # Windows custom path
-```
-
-### `ida-multi-mcp --uninstall [--ida-dir DIR]`
-Remove the IDA plugin, clean up registry, and remove MCP client configurations.
-
-```bash
-ida-multi-mcp --uninstall
-```
-
-### `ida-multi-mcp --config`
-Print the MCP client configuration JSON for easy reference.
-
-```bash
-ida-multi-mcp --config
-```
-
-</details>
-
-<details>
-<summary><b>Architecture — registry layout, plugin directory, routing, health monitoring</b></summary>
-
-## Architecture
-
-### Instance Registry
-
-Location:
-- macOS/Linux: `~/.ida-mcp/instances.json`
-- Windows: `%USERPROFILE%\.ida-mcp\instances.json`
-
-Each registered instance includes:
-- **id** — 4-char instance identifier (k7m2, px3a, etc.)
-- **pid** — Process ID of the IDA Pro instance
-- **host** — Always 127.0.0.1 (localhost)
-- **port** — Dynamically assigned HTTP port
-- **binary_name** — Filename (malware.exe, driver.dll, etc.)
-- **binary_path** — Full path to binary
-- **arch** — Architecture (x86_64, x86, arm64, etc.)
-- **registered_at** — Timestamp when instance registered
-- **last_heartbeat** — Last heartbeat check timestamp
-
-### IDA Plugin Directory
-
-- macOS/Linux: `~/.idapro/plugins/`
-- Windows: `%APPDATA%\Hex-Rays\IDA Pro\plugins\`
-
-### Request Routing
-
-1. MCP client calls a tool (e.g., `decompile`) with required `instance_id` parameter
-2. Server routes to the target instance via HTTP JSON-RPC
-3. IDA instance processes the request
-4. Result returned to client
-
-### Health Monitoring
-
-- Each IDA instance sends a heartbeat every 60 seconds
-- Stale instances (no heartbeat for 2+ minutes) are automatically cleaned up
-- On server startup, dead processes are removed from the registry
-- If an instance crashes, subsequent requests get a helpful error message
-
-### Binary Change Detection
-
-Uses dual-strategy detection:
-
-**Primary (Fast)** — IDA event hooks trigger immediately when binary changes
-**Fallback (Safe)** — Every tool call verifies binary hasn't changed, handles hook failures
-
-When a binary change is detected:
-- Old instance ID is marked as expired
-- New instance registers with new ID
-- LLM receives helpful message with replacement ID
-
-</details>
-
-<details>
-<summary><b>Troubleshooting — plugin not loading, wrong Python, stale instances, Codex TOML</b></summary>
-
-## Troubleshooting
-
-<details>
-<summary>"No IDA instances registered"</summary>
-
-Make sure:
-1. IDA Pro is running with a binary loaded
-2. Check IDA's plugin list (Edit → Plugins → Scan) to confirm `ida-multi-mcp` plugin loaded
-3. Check IDA console for error messages
-4. Run `ida-multi-mcp --list` again
-
-</details>
-
-<details>
-<summary>"Instance 'k7m2' not found"</summary>
-
-The instance has crashed or expired. Run:
-```bash
-ida-multi-mcp --list
-```
-to see available instances, then use a valid ID.
-
-</details>
-
-<details>
-<summary>"Instance 'k7m2' expired. Replaced by 'px3a'"</summary>
-
-You opened a different binary in that IDA instance. This is expected. Use the new instance ID (`px3a`).
-
-</details>
-
-<details>
-<summary>Plugin doesn't load in IDA / "No module named 'ida_multi_mcp'"</summary>
-
-This usually means IDA's Python cannot find the package due to a **Python version mismatch**.
-
-1. Check IDA's Python version — in the IDA console, run:
-   ```
-   import sys; print(sys.version)
-   ```
-2. Install the package for that specific Python version:
-
-   **macOS:**
-   ```bash
-   # Replace 3.11 with IDA's actual Python version
-   python3.11 -m pip install --user git+https://github.com/MeroZemory/ida-multi-mcp.git
-   ```
-
-   **Windows:**
-   ```bash
-   # Replace 3.12 with IDA's actual Python version
-   py -3.12 -m pip install git+https://github.com/MeroZemory/ida-multi-mcp.git
-   ```
-
-3. Ensure the IDA plugins directory contains `ida_multi_mcp.py`:
-   - macOS/Linux: `~/.idapro/plugins/`
-   - Windows: `%APPDATA%\Hex-Rays\IDA Pro\plugins\`
-4. Restart IDA Pro
-
-</details>
-
-<details>
-<summary>MCP server fails to connect (macOS)</summary>
-
-If your MCP client shows `Status: failed` for ida-multi-mcp, the registered command may point to the wrong Python version.
-
-1. Check what command is configured (e.g., in `.claude.json`, `.cursor/mcp.json`)
-2. If it shows `python3 -m ida_multi_mcp`, replace it with the pipx-managed CLI:
-
-   **Claude Code:**
-   ```bash
-   claude mcp remove ida-multi-mcp -s user
-   claude mcp add ida-multi-mcp -s user -- ida-multi-mcp
-   ```
-
-   **Other clients:** Edit the MCP config JSON and change:
-   ```json
-   {
-     "command": "ida-multi-mcp",
-     "args": []
-   }
-   ```
-
-3. Restart the MCP client
-
-</details>
-
-<details>
-<summary>Codex fails to start on Windows with TOML parse error</summary>
-
-If Codex prints an error like `invalid unquoted key` for `%USERPROFILE%\.codex\config.toml`, the config contains Windows paths that are not valid TOML syntax.
-
-Use literal quoted keys/strings for Windows paths:
-
-```toml
-[projects.'\\?\C:\Git\MeroZemory\tidy-up']
-trust_level = "trusted"
-
-[mcp_servers.ida-multi-mcp]
-command = 'C:\Users\MeroZemory\AppData\Local\Programs\Python\Python311\python.exe'
-args = ["-m", "ida_multi_mcp"]
-```
-
-Do not use unquoted `\\?\...` project table keys, and do not use double-quoted Windows paths unless backslashes are escaped.
-
-</details>
-
-</details>
-
-<details>
-<summary><b>Design Decisions — the trade-offs behind the architecture</b></summary>
-
-## Design Decisions
-
-| Decision | Rationale |
-|----------|-----------|
-| Port 0 (auto-assigned) | Eliminates port conflicts, scales to unlimited instances |
-| 4-char base36 IDs | Short, readable, 1.68M combinations, easy to remember |
-| File-based registry | Simple, cross-process, debuggable, no database dependency |
-| Dynamic tool discovery | Future-proof, automatic updates, no hardcoded tool list |
-| Dual binary-change detection | Robust fallback if IDA hooks fail |
-| Subprocess-per-binary (idalib) | True parallelism, crash isolation, no in-process DB switching |
-| compat.py shims | Single source for IDA 8.5–9.3 API differences |
-| Worker pool for stdio dispatch | Instances are separate processes; serializing at the router wasted that. Only stdout writes are locked (`IDA_MCP_STDIO_WORKERS`) |
-| Deadline fires IDA's `set_cancelled()` | A Python-level timeout cannot preempt a C SDK call; IDA's own cancel flag can (`IDA_MCP_CANCEL_GRACE_SEC`) |
-
-</details>
-
-<details>
-<summary><b>Performance — benchmarks on a 736K-function binary</b></summary>
-
-## Performance
-
-Benchmarked against a large game client (736K functions, x86-64, IDA 9.3):
-
-| Metric | Value |
-|---|---:|
-| Total tool latency (28 tools) | **32.0 s** |
-| Total response payload | 373 KB |
-| Estimated token cost | ~93K tokens |
-
-| Category | Latency | Tokens |
-|---|---:|---:|
-| Triage (`survey_binary`) | 17.0 s | ~77K |
-| Query (`func_query`, `imports_query`) | 7.5 s | ~2.4K |
-| Navigation (`list_funcs`, `find_*`, `xrefs_*`) | 5.5 s | ~8.5K |
-| Analysis (`decompile`, `analyze_function`) | 41 ms | ~3.7K |
-| Modification (`set_comments`, `append_comments`) | 4 ms | ~125 |
-
-Infrastructure overhead:
-- Registry operations: <1ms (JSON file, file-locked)
-- Tool discovery: ~50ms per IDA instance (one-time cache)
-- Tool call routing: <5ms (local HTTP JSON-RPC)
-- Heartbeat interval: 60 seconds (negligible overhead)
-
-**Cross-instance dispatch.** Measured against two live GUI instances, issuing a call to
-instance B while instance A was busy for ~3.7 s:
-
-| | Before ([#27](https://github.com/MeroZemory/ida-multi-mcp/pull/27)) | After |
-|---|---:|---:|
-| Response time for the call to instance B | 3.41 s | **0.01 s** |
-
-[Full benchmark report with per-tool detail &rarr;](docs/benchmark-report.md)
-
-</details>
+## Documentation
+
+| | |
+|---|---|
+| [Tools](docs/tools.md) | Management tools, idalib session control, similarity tools |
+| [CLI](docs/cli.md) | `--list`, `--install`, `--uninstall`, `--config` |
+| [Architecture](docs/architecture.md) | Registry layout, request routing, health monitoring, instance IDs, design trade-offs |
+| [Performance](docs/performance.md) | Benchmarks on a 736K-function binary |
+| [Troubleshooting](docs/troubleshooting.md) | Plugin not loading, Python mismatch, stale instances, uninstalling |
+| [Installation guide](docs/installation.md) | The canonical guide an AI agent should follow |
+| [Function similarity examples](docs/function-similarity-usage.md) | Worked BCSD examples against stripped binaries |
+| [Upstream comparison](docs/ida-pro-mcp/comparison.md) | What has been adopted from ida-pro-mcp, and contributed back |
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Every IDA Pro instance auto-registers on startup, so your LLM client sees all of
 
 *Newest first.*
 
+- **⏳ Reliable auto-analysis gating** — `analysis_status()` and `analysis_wait()` let an agent tell whether IDA has actually finished analysing before it draws conclusions. `server_health`'s `auto_analysis_ready` flag was inverted, so it reported "ready" exactly when analysis was still running; on an 8.5 MB DLL, waiting properly added **3,672 functions** (9,580 → 13,252) that an unwaiting agent would never have seen. `idb_save` also no longer takes the save-as path in the GUI.
 - **⚡ Genuinely parallel instances** — the router used to dispatch one request at a time, so a slow call on one binary stalled every other binary behind it. Requests now run on a worker pool with only the stdout writes serialized. Measured against two live instances: a call to instance B while instance A was busy went from **3.41 s → 0.01 s**. ([#27](https://github.com/MeroZemory/ida-multi-mcp/pull/27))
 - **⏱️ Slow scans no longer freeze an instance** — a long C-level SDK call (`find_bytes`, `decompile`, string building) could hold IDA's main thread far past the tool timeout, because a Python-level timeout cannot preempt C. The deadline now fires IDA's own `set_cancelled()`, which those calls poll and honour; `find`/`find_bytes` report `cursor.cancelled` so a partial page is distinguishable from a finished one. ([#28](https://github.com/MeroZemory/ida-multi-mcp/pull/28))
 - **🔎 Function similarity search (BCSD)** — locate the same or similar function *within a binary or across instances* (patch diffing, library-function ID, variant hunting). Name-independent signals that survive stripping — instruction-shingle MinHash + imported-API / string / constant anchors + CFG structure/shape — with an optional on-demand **local neural** recall (jTrans embeddings) for cross-compiler twins. All local, no cloud. → [details](#function-similarity-bcsd)
@@ -256,6 +257,34 @@ After uninstalling, fully restart IDA Pro and your MCP client(s) so the removed 
    - Another instance auto-registers (e.g., `px3a`)
 
 3. Repeat for more binaries
+
+**Skipping the load dialog.** Opening a new binary normally pops IDA's "Load a new file"
+configuration dialog, which blocks before the plugin is running — nothing on the MCP side
+can dismiss it. Launch IDA in autonomous mode to accept the defaults and go straight to
+analysis:
+
+```bash
+ida -A path/to/binary.exe
+```
+
+### Wait for auto-analysis before you trust anything
+
+On a freshly opened binary IDA analyses in the background, and **function lists, xrefs and
+decompilation are incomplete until it finishes**. On an 8.5 MB DLL the function count went
+from 9,580 to 13,252 — 28% of the functions did not exist yet — over the ~37 s the analysis
+still had left to run.
+
+```
+analysis_status()               -> {"finished": false, "state": "...", "function_count": 9580}
+analysis_wait(timeout_sec=120)  -> {"finished": true, "waited_sec": 37.25, "functions_added": 3672}
+```
+
+- **`analysis_status()`** — non-blocking check. Returns `finished`, the current analysis
+  phase, and the function count so far.
+- **`analysis_wait(timeout_sec=120)`** — blocks until analysis completes. `finished: false`
+  means the wait timed out, not that it failed; call it again to keep waiting.
+
+`server_health()` also reports this as `auto_analysis_ready`.
 
 ### Headless Analysis (IDA Pro Only)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Every IDA Pro instance auto-registers on startup, so your LLM client sees all of
 
 *Newest first.*
 
-- **⏳ Reliable auto-analysis gating** — `analysis_status()` and `analysis_wait()` let an agent tell whether IDA has actually finished analysing before it draws conclusions. `server_health`'s `auto_analysis_ready` flag was inverted, so it reported "ready" exactly when analysis was still running; on an 8.5 MB DLL, waiting properly added **3,672 functions** (9,580 → 13,252) that an unwaiting agent would never have seen. `idb_save` also no longer takes the save-as path in the GUI.
+- **⏳ Auto-analysis gating** — `analysis_status()` and `analysis_wait()` let an agent find out whether IDA has actually settled before it draws conclusions, and the router attaches a warning to results from analysis-dependent tools while an instance is still analysing. `server_health`'s `auto_analysis_ready` flag was **inverted**, reporting "ready" exactly when analysis was still running. Waiting properly is worth **12,885 functions** on a 23 MB DLL (61,044 → 73,929) that an unwaiting agent would never see. Note the completion flag is a snapshot rather than a latch — [why](#wait-for-auto-analysis-before-you-trust-anything). `idb_save` also no longer takes the save-as path in the GUI.
 - **⚡ Genuinely parallel instances** — the router used to dispatch one request at a time, so a slow call on one binary stalled every other binary behind it. Requests now run on a worker pool with only the stdout writes serialized. Measured against two live instances: a call to instance B while instance A was busy went from **3.41 s → 0.01 s**. ([#27](https://github.com/MeroZemory/ida-multi-mcp/pull/27))
 - **⏱️ Slow scans no longer freeze an instance** — a long C-level SDK call (`find_bytes`, `decompile`, string building) could hold IDA's main thread far past the tool timeout, because a Python-level timeout cannot preempt C. The deadline now fires IDA's own `set_cancelled()`, which those calls poll and honour; `find`/`find_bytes` report `cursor.cancelled` so a partial page is distinguishable from a finished one. ([#28](https://github.com/MeroZemory/ida-multi-mcp/pull/28))
 - **🔎 Function similarity search (BCSD)** — locate the same or similar function *within a binary or across instances* (patch diffing, library-function ID, variant hunting). Name-independent signals that survive stripping — instruction-shingle MinHash + imported-API / string / constant anchors + CFG structure/shape — with an optional on-demand **local neural** recall (jTrans embeddings) for cross-compiler twins. All local, no cloud. → [details](#function-similarity-bcsd)
@@ -230,21 +230,42 @@ ida -A path/to/binary.exe
 ### Wait for auto-analysis before you trust anything
 
 On a freshly opened binary IDA analyses in the background, and **function lists, xrefs and
-decompilation are incomplete until it finishes**. On an 8.5 MB DLL the function count went
-from 9,580 to 13,252 — 28% of the functions did not exist yet — over the ~37 s the analysis
-still had left to run.
+decompilation are incomplete until it settles**. On an 8.5 MB DLL the function count went
+from 9,580 to 13,252 — 28% of the functions did not exist yet. On a 23 MB DLL it was 12,885.
 
 ```
-analysis_status()               -> {"finished": false, "state": "...", "function_count": 9580}
-analysis_wait(timeout_sec=120)  -> {"finished": true, "waited_sec": 37.25, "functions_added": 3672}
+analysis_status()               -> {"queue_empty": false, "function_count": 61044}
+analysis_wait(timeout_sec=200)  -> {"finished": true, "functions_added": 12884}
 ```
 
-- **`analysis_status()`** — non-blocking check. Returns `finished`, the current analysis
-  phase, and the function count so far.
-- **`analysis_wait(timeout_sec=120)`** — blocks until analysis completes. `finished: false`
-  means the wait timed out, not that it failed; call it again to keep waiting.
+- **`analysis_status()`** — non-blocking snapshot: queue state, current phase, function
+  count so far.
+- **`analysis_wait(timeout_sec=120)`** — drives analysis to completion and returns.
+  `finished: false` means the wait timed out, not that it failed; call it again.
 
-`server_health()` also reports this as `auto_analysis_ready`.
+If you only do one thing, call `analysis_wait` once after opening a binary. The router also
+attaches a warning to results from analysis-dependent tools while an instance is still
+analysing, so a partial answer is not silently mistaken for a complete one.
+
+<details>
+<summary>Why "finished" is a snapshot, not a latch</summary>
+
+`finished` / `queue_empty` come from IDA's `auto_is_ok()`, which answers *"are the analysis
+queues empty right now"*. IDA re-queues work as it goes, so the flag can read `true` and then
+`false` again moments later — observed directly on a 23 MB DLL, where `analysis_wait`
+returned `finished: true` and the very next `analysis_status` reported `false` on the same
+idle instance.
+
+Read it as: **`false` means definitely not done**. `true` means nothing is queued at that
+instant. The durable signal is `functions_added` reaching 0 across successive calls.
+
+Three phases are involved, which is why this is fiddly. IDA's background analysis does the
+bulk on its own and then plateaus without ever flipping the flag; `auto_make_step()` drains
+the residual queue; and a final `auto_wait()` pass — 34.5 s on that DLL, adding zero
+functions — is the only thing that clears the queues. `analysis_wait` handles all three, in
+bounded slices, so the instance stays responsive throughout.
+
+</details>
 
 ### Headless Analysis (IDA Pro Only)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,87 @@
+# Architecture
+
+[← back to README](../README.md)
+
+## Architecture
+
+### Instance Registry
+
+Location:
+- macOS/Linux: `~/.ida-mcp/instances.json`
+- Windows: `%USERPROFILE%\.ida-mcp\instances.json`
+
+Each registered instance includes:
+- **id** — 4-char instance identifier (k7m2, px3a, etc.)
+- **pid** — Process ID of the IDA Pro instance
+- **host** — Always 127.0.0.1 (localhost)
+- **port** — Dynamically assigned HTTP port
+- **binary_name** — Filename (malware.exe, driver.dll, etc.)
+- **binary_path** — Full path to binary
+- **arch** — Architecture (x86_64, x86, arm64, etc.)
+- **registered_at** — Timestamp when instance registered
+- **last_heartbeat** — Last heartbeat check timestamp
+
+### IDA Plugin Directory
+
+- macOS/Linux: `~/.idapro/plugins/`
+- Windows: `%APPDATA%\Hex-Rays\IDA Pro\plugins\`
+
+### Request Routing
+
+1. MCP client calls a tool (e.g., `decompile`) with required `instance_id` parameter
+2. Server routes to the target instance via HTTP JSON-RPC
+3. IDA instance processes the request
+4. Result returned to client
+
+### Health Monitoring
+
+- Each IDA instance sends a heartbeat every 60 seconds
+- Stale instances (no heartbeat for 2+ minutes) are automatically cleaned up
+- On server startup, dead processes are removed from the registry
+- If an instance crashes, subsequent requests get a helpful error message
+
+### Binary Change Detection
+
+Uses dual-strategy detection:
+
+**Primary (Fast)** — IDA event hooks trigger immediately when binary changes
+**Fallback (Safe)** — Every tool call verifies binary hasn't changed, handles hook failures
+
+When a binary change is detected:
+- Old instance ID is marked as expired
+- New instance registers with new ID
+- LLM receives helpful message with replacement ID
+
+## Instance IDs Explained
+
+Instance IDs are 4-character base36 strings (0-9, a-z) like `k7m2`, `px3a`, `9bf1`.
+
+**Why 4 characters?**
+- Short and readable
+- 1.68 million combinations (collision-free for typical use)
+- Auto-expands to 5 characters if collision detected
+
+**How are they generated?**
+- Based on: process ID, port, and IDB file path
+- Same binary reopened = same ID (deterministic)
+- Binary replaced/changed = new ID (automatic)
+
+**What happens when you change binaries?**
+When you open a different binary in an IDA instance:
+1. Old instance expires (e.g., `k7m2` → expired)
+2. New instance registers (e.g., `b12`)
+3. If LLM tries to use old ID, you get a helpful error with the replacement ID
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Port 0 (auto-assigned) | Eliminates port conflicts, scales to unlimited instances |
+| 4-char base36 IDs | Short, readable, 1.68M combinations, easy to remember |
+| File-based registry | Simple, cross-process, debuggable, no database dependency |
+| Dynamic tool discovery | Future-proof, automatic updates, no hardcoded tool list |
+| Dual binary-change detection | Robust fallback if IDA hooks fail |
+| Subprocess-per-binary (idalib) | True parallelism, crash isolation, no in-process DB switching |
+| compat.py shims | Single source for IDA 8.5–9.3 API differences |
+| Worker pool for stdio dispatch | Instances are separate processes; serializing at the router wasted that. Only stdout writes are locked (`IDA_MCP_STDIO_WORKERS`) |
+| Deadline fires IDA's `set_cancelled()` | A Python-level timeout cannot preempt a C SDK call; IDA's own cancel flag can (`IDA_MCP_CANCEL_GRACE_SEC`) |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,42 @@
+# CLI Reference
+
+[← back to README](../README.md)
+
+## CLI Commands
+
+### `ida-multi-mcp`
+Start the MCP server (stdio). Used by MCP clients. This is the default command.
+
+```bash
+ida-multi-mcp
+ida-multi-mcp --idalib-python /path/to/python3  # custom Python for headless sessions
+```
+
+### `ida-multi-mcp --list`
+List all registered IDA instances.
+
+```bash
+ida-multi-mcp --list
+```
+
+### `ida-multi-mcp --install [--ida-dir DIR]`
+Install the IDA plugin and auto-configure all detected MCP clients (Claude Code, Claude Desktop, Cursor, Windsurf, VS Code, Zed, and 20+ more).
+
+```bash
+ida-multi-mcp --install
+ida-multi-mcp --install --ida-dir "C:\Program Files\IDA Pro 9.0"  # Windows custom path
+```
+
+### `ida-multi-mcp --uninstall [--ida-dir DIR]`
+Remove the IDA plugin, clean up registry, and remove MCP client configurations.
+
+```bash
+ida-multi-mcp --uninstall
+```
+
+### `ida-multi-mcp --config`
+Print the MCP client configuration JSON for easy reference.
+
+```bash
+ida-multi-mcp --config
+```

--- a/docs/ida-pro-mcp/comparison.md
+++ b/docs/ida-pro-mcp/comparison.md
@@ -34,9 +34,9 @@ configuration; upstream routes through a supervisor process that owns the worker
 
 ---
 
-## HIGH Priority — Not Yet Adopted
+## HIGH Priority
 
-### 1. `sync.py`: reentrant `@idasync` deadlocks the IDA main thread
+### 1. `sync.py`: reentrant `@idasync` deadlocks the IDA main thread — ADOPTED
 
 **Upstream fix**: `85efdf8` (closes upstream #406).
 
@@ -46,8 +46,12 @@ inner call drains the LifoQueue; the outer call's `finally` then parks forever o
 `Queue.get()` against an empty queue. IDA's main thread freezes and every subsequent tool
 call piles up in `execute_sync` and never returns.
 
-**Current state**: `src/ida_multi_mcp/ida_mcp/sync.py:65` and `:75` still use blocking
-`get()`. Upstream's fix is a two-line change to `get_nowait()` with `queue.Empty` handling.
+**Status**: ported in PR #26. Both sites use `get_nowait()` with `queue.Empty` handling.
+We went one step further than upstream: the non-empty-call-stack guard raised `IDASyncError`
+from inside the `execute_sync` callback, where IDA swallows it, leaving the requesting thread
+blocked forever on `res_container.get()`. That error is now delivered through
+`res_container`. Sent back upstream as
+[mrexodia/ida-pro-mcp#489](https://github.com/mrexodia/ida-pro-mcp/pull/489).
 
 ### 2. `sync.py`: no native cancellation — ADOPTED
 
@@ -70,7 +74,7 @@ unconditionally in the `finally`. `find` and `find_bytes` gained the
 `cursor.cancelled` marker so callers can tell "we stopped early" from "end of page".
 Upstream's `search_text` changes do not apply — we have no such tool.
 
-### 3. `sync.py`: `idc.batch()` is called from the requesting thread, not the IDA main thread
+### 3. `sync.py`: `idc.batch()` called off the IDA main thread — ADOPTED
 
 **Upstream fix**: part of `f0cd877`.
 
@@ -79,10 +83,11 @@ worker thread, and restores it in a `finally` that also runs off-thread. Upstrea
 into `runned()` so they execute on the IDA main thread, and added `get_pre_call_batch()` so
 tools restore the caller's real prior state instead of a hard-coded default.
 
-**Current state**: `src/ida_multi_mcp/ida_mcp/sync.py:97` and `:126` still call `idc.batch()`
-off the main thread.
+**Status**: ported in PR #26 — `idc.batch()` now runs inside `runned()`, on the IDA main
+thread. Upstream's `get_pre_call_batch()` is not ported: it exists for their `keep_batch`
+debugger tools, which we do not have.
 
-### 4. IDA 8.5+ APIs used without version guards
+### 4. IDA 8.5+ APIs used without version guards — ADOPTED
 
 **Upstream fix**: `f212140`, `7cca988`, `dd4e730`, plus `compat.py`'s `tinfo_get_udm()`,
 `inf_get_*()`, `get_ordinal_limit()`, `get_func_name()`, `get_func_prototype()`.
@@ -101,14 +106,22 @@ sites bypass it and will raise on older or early builds:
 Upstream additionally *rejects* IDA 9.0 SP0 (build 240925) at import time with an explicit
 error listing the missing methods, rather than failing deep inside a tool.
 
-**Current state**: README now documents an 8.5+ floor and the 9.0 SP0 exclusion. Adding the
-`compat.py` wrappers would restore the original 8.3+ claim.
+**Status**: ported in PR #30. `inf_get_*`, `get_ordinal_limit` and `tinfo_t.get_udm` now go
+through `compat`, which dispatches on `hasattr` rather than a parsed version so a surprising
+`get_kernel_version()` string cannot route a modern IDA down the legacy path.
+`missing_required_apis()` reports what 9.0 SP0 dropped and the plugin warns at load.
+
+This also fixed a live bug: `infer_types` called `ida_hexrays.guess_tinfo`, which moved to
+`ida_typeinf`, so it failed on every call on IDA 9.x.
+
+The README still says 8.5+ — the hard blockers are gone, but the 8.3/8.4 branches have only
+been exercised against stubs, never a real old IDA.
 
 ---
 
 ## MEDIUM Priority — Not Yet Adopted
 
-### 5. `idb_save` uses save-as semantics in the GUI
+### 5. `idb_save` uses save-as semantics in the GUI — ADOPTED
 
 **Upstream fix**: `6673de9` (closes upstream #446).
 
@@ -116,7 +129,11 @@ Upstream's bug was packing with `DBFL_KILL|DBFL_COMP`, deleting the loose `.id0/
 .nam/.til` files the GUI is actively using. We pass `flags=0`, so we do **not** have the
 corruption bug — but we always pass an explicit `save_path` (`api_core.py:661`), which is a
 save-as rather than IDA's native in-place save. Upstream branches on `ida_kernwin.is_idaq()`
-and uses `save_database(None, 0)` in the GUI. Worth mirroring; we already detect `is_idaq`.
+and uses `save_database(None, 0)` in the GUI.
+
+**Status**: ported in PR #30. GUI in-place save via `save_database(None, 0)`, a compressed
+copy only for an explicit different destination, and `DBFL_KILL|DBFL_COMP` packing only when
+headless. The result reports which mode it took.
 
 ### 6. Bounded HTTP session registry
 
@@ -161,6 +178,8 @@ return actionable messages instead of bare failures. Applies to our `api_analysi
 | Headless detection via `is_idaq()` | PR #15 |
 | Reentrancy `get_nowait()` + batch on the IDA main thread (`85efdf8`, `f0cd877`) | PR #26 |
 | Native cancellation at the tool deadline (`55533c4`) | PR #28 |
+| compat wrappers for moved APIs (`f212140`, `7cca988`) | PR #30 |
+| GUI-safe `idb_save` (`6673de9`) | PR #30 |
 | Tool parameter consistency (PR #362 upstream) | Names already match |
 | HTTP Host/Origin validation | `http.py`; CORS fallback hardened in PR #17 |
 | `@unsafe` gating in idalib | `is_idalib_available()` + worker `--unsafe` |
@@ -192,9 +211,17 @@ return actionable messages instead of bare failures. Applies to our `api_analysi
 
 | # | Item | Upstream commit | Priority | Effort |
 |---|---|---|---|---|
-| ~~1~~ | ~~`set_cancelled()` at tool deadline~~ — adopted | `55533c4` | HIGH | M |
-| ~~2~~ | ~~`get_nowait()` in `call_stack` cleanup~~ — adopted | `85efdf8` | HIGH | S |
-| ~~3~~ | ~~Move `idc.batch()` onto the IDA main thread~~ — adopted | `f0cd877` | HIGH | S |
-| 4 | `compat.py` guards for 8.4/8.5/9.0-SP0 APIs | `f212140`, `7cca988` | HIGH | M |
-| 5 | `idb_save` native in-place save in GUI | `6673de9` | MED | S |
+| ~~1~~ | ~~`set_cancelled()` at tool deadline~~ — adopted (#28) | `55533c4` | HIGH | M |
+| ~~2~~ | ~~`get_nowait()` in `call_stack` cleanup~~ — adopted (#26) | `85efdf8` | HIGH | S |
+| ~~3~~ | ~~Move `idc.batch()` onto the IDA main thread~~ — adopted (#26) | `f0cd877` | HIGH | S |
+| ~~4~~ | ~~`compat.py` guards for 8.4/8.5/9.0-SP0 APIs~~ — adopted (#30) | `f212140`, `7cca988` | HIGH | M |
+| ~~5~~ | ~~`idb_save` native in-place save in GUI~~ — adopted (#30) | `6673de9` | MED | S |
 | 6 | Richer error reporting on rename/xrefs/decompile/set_type | `c395db9` | MED | M |
+
+---
+
+## Contributed back upstream
+
+| Change | Upstream PR |
+|---|---|
+| `_sync_wrapper` guard raised into `execute_sync`, leaving the caller blocked forever on `res_container.get()` — a reachable path into upstream #217 | [mrexodia/ida-pro-mcp#489](https://github.com/mrexodia/ida-pro-mcp/pull/489) |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,36 @@
+# Performance
+
+[← back to README](../README.md)
+
+## Performance
+
+Benchmarked against a large game client (736K functions, x86-64, IDA 9.3):
+
+| Metric | Value |
+|---|---:|
+| Total tool latency (28 tools) | **32.0 s** |
+| Total response payload | 373 KB |
+| Estimated token cost | ~93K tokens |
+
+| Category | Latency | Tokens |
+|---|---:|---:|
+| Triage (`survey_binary`) | 17.0 s | ~77K |
+| Query (`func_query`, `imports_query`) | 7.5 s | ~2.4K |
+| Navigation (`list_funcs`, `find_*`, `xrefs_*`) | 5.5 s | ~8.5K |
+| Analysis (`decompile`, `analyze_function`) | 41 ms | ~3.7K |
+| Modification (`set_comments`, `append_comments`) | 4 ms | ~125 |
+
+Infrastructure overhead:
+- Registry operations: <1ms (JSON file, file-locked)
+- Tool discovery: ~50ms per IDA instance (one-time cache)
+- Tool call routing: <5ms (local HTTP JSON-RPC)
+- Heartbeat interval: 60 seconds (negligible overhead)
+
+**Cross-instance dispatch.** Measured against two live GUI instances, issuing a call to
+instance B while instance A was busy for ~3.7 s:
+
+| | Before ([#27](https://github.com/MeroZemory/ida-multi-mcp/pull/27)) | After |
+|---|---:|---:|
+| Response time for the call to instance B | 3.41 s | **0.01 s** |
+
+[Full benchmark report with per-tool detail &rarr;](benchmark-report.md)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,39 @@
+# Tool Reference
+
+[← back to README](../README.md)
+
+## Management Tools
+
+The server provides built-in management tools:
+
+### list_instances()
+Lists all registered instances with metadata (binary name, path, architecture, port, **type**: `gui` or `idalib`).
+
+### refresh_tools()
+Re-discovers tools from IDA instances. Use this if you update the IDA plugin.
+
+### get_cached_output(cache_id, offset, size)
+Retrieve cached output from a previous tool call that was truncated.
+
+### decompile_to_file(...)
+Decompile functions and save results directly to files on disk. Requires `instance_id`.
+
+### idalib_open(input_path, timeout, unsafe) *(IDA Pro only)*
+Open a binary in a new headless idalib session. Spawns a subprocess, waits for auto-analysis, registers in the shared registry.
+
+### idalib_close(instance_id) *(IDA Pro only)*
+Terminate a headless idalib session and remove it from the registry.
+
+### idalib_list() *(IDA Pro only)*
+List all managed headless idalib sessions.
+
+### idalib_status(instance_id) *(IDA Pro only)*
+Health/readiness check for a specific idalib session.
+
+### Function Similarity (BCSD)
+Local, cross-instance binary code similarity — no cloud, no external service. Signals are name-independent (survive stripping): instruction-shingle MinHash, IDF-weighted imported-API / string / constant anchors, and CFG structure/shape, plus symbol-gated pseudocode tokens. An optional `[neural]` extra adds on-demand jTrans embeddings for anchor-less cross-compiler matches.
+
+- **`index_functions(instance_id, rebuild=False)`** — build/refresh the searchable index for a binary (content-hash keyed, persisted under `~/.ida-mcp/index/`, incremental, backgroundable).
+- **`index_status(instance_id)`** — index readiness, function count, staleness, and background progress.
+- **`similar_functions(instance_id, func, top_k=20, scope="binary"|"instances"|"all")`** — rank the most similar functions within the binary or across instances; returns a per-signal breakdown and confidence label.
+- **`compare_functions(a, b)`** — direct pairwise similarity between two functions (optionally across instances).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,144 @@
+# Troubleshooting
+
+[← back to README](../README.md)
+
+## Troubleshooting
+
+<details>
+<summary>"No IDA instances registered"</summary>
+
+Make sure:
+1. IDA Pro is running with a binary loaded
+2. Check IDA's plugin list (Edit → Plugins → Scan) to confirm `ida-multi-mcp` plugin loaded
+3. Check IDA console for error messages
+4. Run `ida-multi-mcp --list` again
+
+</details>
+
+<details>
+<summary>"Instance 'k7m2' not found"</summary>
+
+The instance has crashed or expired. Run:
+```bash
+ida-multi-mcp --list
+```
+to see available instances, then use a valid ID.
+
+</details>
+
+<details>
+<summary>"Instance 'k7m2' expired. Replaced by 'px3a'"</summary>
+
+You opened a different binary in that IDA instance. This is expected. Use the new instance ID (`px3a`).
+
+</details>
+
+<details>
+<summary>Plugin doesn't load in IDA / "No module named 'ida_multi_mcp'"</summary>
+
+This usually means IDA's Python cannot find the package due to a **Python version mismatch**.
+
+1. Check IDA's Python version — in the IDA console, run:
+   ```
+   import sys; print(sys.version)
+   ```
+2. Install the package for that specific Python version:
+
+   **macOS:**
+   ```bash
+   # Replace 3.11 with IDA's actual Python version
+   python3.11 -m pip install --user git+https://github.com/MeroZemory/ida-multi-mcp.git
+   ```
+
+   **Windows:**
+   ```bash
+   # Replace 3.12 with IDA's actual Python version
+   py -3.12 -m pip install git+https://github.com/MeroZemory/ida-multi-mcp.git
+   ```
+
+3. Ensure the IDA plugins directory contains `ida_multi_mcp.py`:
+   - macOS/Linux: `~/.idapro/plugins/`
+   - Windows: `%APPDATA%\Hex-Rays\IDA Pro\plugins\`
+4. Restart IDA Pro
+
+</details>
+
+<details>
+<summary>MCP server fails to connect (macOS)</summary>
+
+If your MCP client shows `Status: failed` for ida-multi-mcp, the registered command may point to the wrong Python version.
+
+1. Check what command is configured (e.g., in `.claude.json`, `.cursor/mcp.json`)
+2. If it shows `python3 -m ida_multi_mcp`, replace it with the pipx-managed CLI:
+
+   **Claude Code:**
+   ```bash
+   claude mcp remove ida-multi-mcp -s user
+   claude mcp add ida-multi-mcp -s user -- ida-multi-mcp
+   ```
+
+   **Other clients:** Edit the MCP config JSON and change:
+   ```json
+   {
+     "command": "ida-multi-mcp",
+     "args": []
+   }
+   ```
+
+3. Restart the MCP client
+
+</details>
+
+<details>
+<summary>Codex fails to start on Windows with TOML parse error</summary>
+
+If Codex prints an error like `invalid unquoted key` for `%USERPROFILE%\.codex\config.toml`, the config contains Windows paths that are not valid TOML syntax.
+
+Use literal quoted keys/strings for Windows paths:
+
+```toml
+[projects.'\\?\C:\Git\MeroZemory\tidy-up']
+trust_level = "trusted"
+
+[mcp_servers.ida-multi-mcp]
+command = 'C:\Users\MeroZemory\AppData\Local\Programs\Python\Python311\python.exe'
+args = ["-m", "ida_multi_mcp"]
+```
+
+Do not use unquoted `\\?\...` project table keys, and do not use double-quoted Windows paths unless backslashes are escaped.
+
+</details>
+
+## Uninstallation
+
+<details>
+<summary><b>macOS</b></summary>
+
+```bash
+# 1. Remove IDA plugin + MCP client configurations
+ida-multi-mcp --uninstall
+
+# 2. Remove packages
+pipx uninstall ida-multi-mcp
+python3.11 -m pip uninstall -y ida-multi-mcp  # replace 3.11 with IDA's version
+```
+
+</details>
+
+<details>
+<summary><b>Windows</b></summary>
+
+```bash
+# 1. Remove IDA plugin + MCP client configurations
+ida-multi-mcp --uninstall
+
+# (optional) If IDA is installed in a custom location
+ida-multi-mcp --uninstall --ida-dir "C:\Program Files\IDA Pro 9.0"
+
+# 2. Remove the Python package
+python -m pip uninstall -y ida-multi-mcp
+```
+
+</details>
+
+After uninstalling, fully restart IDA Pro and your MCP client(s) so the removed configuration is picked up.

--- a/scripts/dump_tool_schemas.py
+++ b/scripts/dump_tool_schemas.py
@@ -1,0 +1,98 @@
+"""Regenerate src/ida_multi_mcp/ida_tool_schemas.json from a live IDA instance.
+
+The router falls back to this file for tools/list when no IDA instance is
+connected - which is exactly when an agent is deciding what to do. The schemas
+themselves come from the @tool docstrings and type hints inside IDA, so this
+file drifts silently every time one of those is edited. Regenerate it whenever
+you change a tool's signature or docstring.
+
+Usage:
+    # with at least one IDA instance running the plugin
+    python scripts/dump_tool_schemas.py
+    python scripts/dump_tool_schemas.py --instance k7m2
+    python scripts/dump_tool_schemas.py --check      # CI-style drift check
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+OUT_PATH = SRC / "ida_multi_mcp" / "ida_tool_schemas.json"
+
+from ida_multi_mcp.registry import InstanceRegistry  # noqa: E402
+from ida_multi_mcp.server import IdaMultiMcpServer  # noqa: E402
+
+
+def fetch_schemas(instance_id: str | None) -> list[dict]:
+    registry = InstanceRegistry()
+    instances = registry.list_instances()
+    if not instances:
+        raise SystemExit(
+            "No IDA instances registered. Start IDA with the ida-multi-mcp plugin "
+            "and load a binary first."
+        )
+    if instance_id is None:
+        instance_id = next(iter(instances))
+    info = instances.get(instance_id)
+    if info is None:
+        raise SystemExit(
+            f"Instance {instance_id!r} not found. Available: {', '.join(instances)}"
+        )
+
+    server = IdaMultiMcpServer()
+    schemas = server._discover_ida_tools(info)
+    if not schemas:
+        raise SystemExit(f"Instance {instance_id!r} returned no tools.")
+
+    # Strip instance_id: the router injects it per tool, and baking it in here
+    # would double up when the static entry is merged with a discovered one.
+    cleaned = []
+    for schema in schemas:
+        s = json.loads(json.dumps(schema))
+        props = s.get("inputSchema", {}).get("properties", {})
+        props.pop("instance_id", None)
+        required = s.get("inputSchema", {}).get("required", [])
+        s["inputSchema"]["required"] = [r for r in required if r != "instance_id"]
+        cleaned.append(s)
+    cleaned.sort(key=lambda t: t["name"])
+    return cleaned
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--instance", help="instance_id to read schemas from")
+    ap.add_argument("--check", action="store_true",
+                    help="exit non-zero if the file is out of date instead of writing it")
+    args = ap.parse_args()
+
+    schemas = fetch_schemas(args.instance)
+    rendered = json.dumps(schemas, indent=2, ensure_ascii=False) + "\n"
+
+    if args.check:
+        current = OUT_PATH.read_text(encoding="utf-8") if OUT_PATH.exists() else ""
+        if current != rendered:
+            print(
+                f"{OUT_PATH.relative_to(REPO_ROOT)} is out of date "
+                f"({len(json.loads(current or '[]'))} tools on disk vs {len(schemas)} live). "
+                f"Run: python scripts/dump_tool_schemas.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"{OUT_PATH.relative_to(REPO_ROOT)} is up to date ({len(schemas)} tools).")
+        return 0
+
+    OUT_PATH.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {len(schemas)} tool schemas to {OUT_PATH.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ida_multi_mcp/__main__.py
+++ b/src/ida_multi_mcp/__main__.py
@@ -45,7 +45,7 @@ def _detect_ida_dir() -> str | None:
     else:
         config_path = Path.home() / ".idapro" / "ida-config.json"
     try:
-        with open(config_path, "r") as f:
+        with open(config_path, "r", encoding="utf-8") as f:
             cfg = json.load(f)
         cfg_dir = cfg.get("Paths", {}).get("ida-install-dir", "").strip()
         if cfg_dir and os.path.isdir(cfg_dir):
@@ -1009,7 +1009,7 @@ def _configure_idalib_path():
         config_path = Path.home() / ".idapro" / "ida-config.json"
 
     try:
-        with open(config_path, "r") as f:
+        with open(config_path, "r", encoding="utf-8") as f:
             cfg = json.load(f)
         existing = cfg.get("Paths", {}).get("ida-install-dir", "").strip()
         if existing and os.path.isdir(existing):
@@ -1031,7 +1031,7 @@ def _configure_idalib_path():
 
     config_path.parent.mkdir(parents=True, exist_ok=True)
     try:
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             json.dump(cfg, f, indent=4)
         print(f"\n  [ok] Auto-detected IDA at: {detected}")
         print(f"       Written to: {config_path}")

--- a/src/ida_multi_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_multi_mcp/ida_mcp/api_analysis.py
@@ -166,7 +166,11 @@ def _resolve_immediate_insn_start(
 def decompile(
     addr: Annotated[str, "Function address to decompile"],
 ) -> dict:
-    """Decompile function to pseudocode"""
+    """Decompile one function to Hex-Rays pseudocode.
+
+    The single most useful tool for understanding behaviour. Requires the
+    Hex-Rays decompiler. For many functions at once use decompile_to_file —
+    decompiling in a loop blocks the instance for every other caller."""
     try:
         start = parse_address(addr)
         code = decompile_function_safe(start)
@@ -1171,7 +1175,10 @@ def export_funcs(
         str, "Export format: json (default), c_header, or prototypes"
     ] = "json",
 ) -> dict:
-    """Export function data in various formats"""
+    """Export function data (addresses, names, sizes, prototypes) in bulk.
+
+    Prefer this over looping a per-function tool — one call instead of N round
+    trips against a single-threaded IDA instance."""
     addrs = normalize_list_input(addrs)
     results = []
 

--- a/src/ida_multi_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_multi_mcp/ida_mcp/api_analysis.py
@@ -17,6 +17,8 @@ import ida_xref
 import ida_ua
 import ida_name
 import idc
+
+from . import compat
 from .rpc import tool
 from .sync import idasync, tool_timeout
 from .utils import (
@@ -611,7 +613,7 @@ def find_bytes(
             # Parse the pattern
             compiled = ida_bytes.compiled_binpat_vec_t()
             err = ida_bytes.parse_binpat_str(
-                compiled, ida_ida.inf_get_min_ea(), pattern, 16
+                compiled, compat.inf_get_min_ea(), pattern, 16
             )
             if err:
                 results.append(
@@ -625,8 +627,8 @@ def find_bytes(
                 continue
 
             # Search with early exit
-            ea = ida_ida.inf_get_min_ea()
-            max_ea = ida_ida.inf_get_max_ea()
+            ea = compat.inf_get_min_ea()
+            max_ea = compat.inf_get_max_ea()
             while ea != idaapi.BADADDR:
                 ea = ida_bytes.bin_search(
                     ea, max_ea, compiled, ida_bytes.BIN_SEARCH_FORWARD
@@ -802,8 +804,8 @@ def find(
             skipped = 0
             more = False
             try:
-                ea = ida_ida.inf_get_min_ea()
-                max_ea = ida_ida.inf_get_max_ea()
+                ea = compat.inf_get_min_ea()
+                max_ea = compat.inf_get_max_ea()
                 mask = b"\xFF" * len(pattern_bytes)
                 flags = ida_bytes.BIN_SEARCH_FORWARD | ida_bytes.BIN_SEARCH_NOSHOW
                 while ea != idaapi.BADADDR:

--- a/src/ida_multi_mcp/ida_mcp/api_core.py
+++ b/src/ida_multi_mcp/ida_mcp/api_core.py
@@ -198,7 +198,10 @@ def _parse_func_query(query: str) -> int:
 def lookup_funcs(
     queries: Annotated[list[str] | str, "Address(es) or name(s)"],
 ) -> list[dict]:
-    """Get functions by address or name (auto-detects)"""
+    """Resolve functions by address or by name; the form is auto-detected.
+
+    Accepts 0x-prefixed addresses, sub_XXXX names, or real symbol names. Use
+    this to turn a name from decompiler output into an address to work with."""
     queries = normalize_list_input(queries)
 
     # Treat empty/"*" as "all functions" - but add limit
@@ -243,7 +246,9 @@ def int_convert(
         "Convert numbers to various formats (hex, decimal, binary, ascii)",
     ],
 ) -> list[dict]:
-    """Convert numbers to different formats"""
+    """Convert numbers between hex, decimal, binary and ASCII, in batch.
+
+    Pure computation — no IDB access, so it needs no instance state."""
     inputs = normalize_dict_list(inputs, lambda s: {"text": s, "size": 64})
 
     results = []
@@ -313,7 +318,12 @@ def list_funcs(
         "List functions with optional filtering and pagination",
     ],
 ) -> list[Page[Function]]:
-    """List functions"""
+    """List functions in the binary, paginated.
+
+    Requires auto-analysis to be finished — call analysis_wait() first on a
+    freshly opened binary or this returns a partial list. On large binaries use
+    count/offset rather than fetching everything; count=0 with a glob filter is
+    a full scan."""
     queries = normalize_dict_list(
         queries, lambda s: {"offset": 0, "count": 50, "filter": s}
     )
@@ -343,7 +353,10 @@ def list_globals(
         "List global variables with optional filtering and pagination",
     ],
 ) -> list[Page[Global]]:
-    """List globals"""
+    """List global variables (non-function named addresses), paginated.
+
+    Requires auto-analysis to be finished — call analysis_wait() first on a
+    freshly opened binary or names will still be missing."""
     queries = normalize_dict_list(
         queries, lambda s: {"offset": 0, "count": 50, "filter": s}
     )
@@ -371,7 +384,10 @@ def imports(
     offset: Annotated[int, "Offset"],
     count: Annotated[int, "Count (0=all)"],
 ) -> Page[Import]:
-    """List imports"""
+    """List imported functions grouped by source module.
+
+    Useful early: the import set is a fast signal of what a binary can do
+    (networking, crypto, process injection) before you decompile anything."""
     nimps = ida_nalt.get_import_module_qty()
 
     rv = []

--- a/src/ida_multi_mcp/ida_mcp/api_core.py
+++ b/src/ida_multi_mcp/ida_mcp/api_core.py
@@ -1,7 +1,6 @@
 """Core API Functions - IDB metadata and basic queries"""
 
 import re
-import threading
 import time
 from typing import Annotated, Optional
 
@@ -552,82 +551,6 @@ def analysis_status() -> dict:
             "Analysis is complete; results are trustworthy."
             if finished
             else "Analysis is still running — call analysis_wait() before relying on results."
-        ),
-    }
-
-
-# Hard ceiling on analysis_wait. The router gives an IDA call 300s before it
-# gives up on the socket, so a wait allowed to run longer than this comes back
-# to the caller as a transport error instead of a clean finished=false.
-_ANALYSIS_WAIT_MAX_SEC = 240.0
-
-
-@tool
-@idasync
-@tool_timeout(_ANALYSIS_WAIT_MAX_SEC + 30.0)
-def analysis_wait(
-    timeout_sec: Annotated[
-        float, "Seconds to wait before returning (default 120, max 240)"
-    ] = 120.0,
-) -> dict:
-    """Block until IDA's auto-analysis finishes, then return.
-
-    Call this once after opening a binary, before any analysis work. If it
-    returns finished=false the wait timed out rather than failed — call it
-    again to keep waiting. Large binaries routinely need several calls.
-
-    Returns the elapsed wait and the resulting function count, so a caller can
-    see analysis actually progressing across successive calls."""
-    t0 = time.perf_counter()
-    before = ida_funcs.get_func_qty()
-
-    if ida_auto.auto_is_ok():
-        return {
-            "finished": True,
-            "waited_sec": 0.0,
-            "function_count": before,
-            "functions_added": 0,
-            "note": "Analysis had already finished.",
-        }
-
-    requested = max(0.0, float(timeout_sec))
-    budget = min(requested, _ANALYSIS_WAIT_MAX_SEC)
-
-    # auto_wait() is one blocking call that runs until the queues drain — it
-    # does not come back to let us check a deadline, so looping around it does
-    # NOT bound the wait. On a large binary that overran the router's socket
-    # timeout and surfaced as a transport error rather than finished=false.
-    #
-    # auto_wait() does poll user_cancelled(), and set_cancelled() is THREAD_SAFE,
-    # so a Timer gives us the bound. sync.py's own deadline uses the same flag
-    # but keys its grace period off its own timer, so firing it here does not
-    # confuse it; clear it afterwards either way since the flag is sticky.
-    timer = threading.Timer(budget, ida_kernwin.set_cancelled)
-    timer.daemon = True
-    timer.start()
-    try:
-        deadline = time.monotonic() + budget
-        while not ida_auto.auto_is_ok() and time.monotonic() < deadline:
-            ida_auto.auto_wait()
-    finally:
-        timer.cancel()
-        ida_kernwin.clr_cancelled()
-
-    finished = bool(ida_auto.auto_is_ok())
-    after = ida_funcs.get_func_qty()
-    return {
-        "finished": finished,
-        "waited_sec": round(time.perf_counter() - t0, 2),
-        "function_count": after,
-        "functions_added": after - before,
-        "state": _auto_state_label(finished),
-        "note": (
-            "Analysis complete."
-            if finished
-            else (
-                f"Waited {budget:.0f}s and analysis is still running — call "
-                f"analysis_wait() again to continue."
-            )
         ),
     }
 

--- a/src/ida_multi_mcp/ida_mcp/api_core.py
+++ b/src/ida_multi_mcp/ida_mcp/api_core.py
@@ -1,6 +1,7 @@
 """Core API Functions - IDB metadata and basic queries"""
 
 import re
+import threading
 import time
 from typing import Annotated, Optional
 
@@ -555,17 +556,25 @@ def analysis_status() -> dict:
     }
 
 
+# Hard ceiling on analysis_wait. The router gives an IDA call 300s before it
+# gives up on the socket, so a wait allowed to run longer than this comes back
+# to the caller as a transport error instead of a clean finished=false.
+_ANALYSIS_WAIT_MAX_SEC = 240.0
+
+
 @tool
 @idasync
-@tool_timeout(300.0)
+@tool_timeout(_ANALYSIS_WAIT_MAX_SEC + 30.0)
 def analysis_wait(
-    timeout_sec: Annotated[float, "Seconds to wait before returning (default 120)"] = 120.0,
+    timeout_sec: Annotated[
+        float, "Seconds to wait before returning (default 120, max 240)"
+    ] = 120.0,
 ) -> dict:
     """Block until IDA's auto-analysis finishes, then return.
 
     Call this once after opening a binary, before any analysis work. If it
     returns finished=false the wait timed out rather than failed — call it
-    again to keep waiting.
+    again to keep waiting. Large binaries routinely need several calls.
 
     Returns the elapsed wait and the resulting function count, so a caller can
     see analysis actually progressing across successive calls."""
@@ -581,14 +590,28 @@ def analysis_wait(
             "note": "Analysis had already finished.",
         }
 
-    deadline = time.monotonic() + max(0.0, float(timeout_sec))
-    # auto_wait() processes the queues and returns False if it was cancelled —
-    # which is exactly what the tool deadline's set_cancelled() does. Loop so a
-    # cancelled slice resumes rather than aborting the whole wait.
-    while time.monotonic() < deadline:
-        ida_auto.auto_wait()
-        if ida_auto.auto_is_ok():
-            break
+    requested = max(0.0, float(timeout_sec))
+    budget = min(requested, _ANALYSIS_WAIT_MAX_SEC)
+
+    # auto_wait() is one blocking call that runs until the queues drain — it
+    # does not come back to let us check a deadline, so looping around it does
+    # NOT bound the wait. On a large binary that overran the router's socket
+    # timeout and surfaced as a transport error rather than finished=false.
+    #
+    # auto_wait() does poll user_cancelled(), and set_cancelled() is THREAD_SAFE,
+    # so a Timer gives us the bound. sync.py's own deadline uses the same flag
+    # but keys its grace period off its own timer, so firing it here does not
+    # confuse it; clear it afterwards either way since the flag is sticky.
+    timer = threading.Timer(budget, ida_kernwin.set_cancelled)
+    timer.daemon = True
+    timer.start()
+    try:
+        deadline = time.monotonic() + budget
+        while not ida_auto.auto_is_ok() and time.monotonic() < deadline:
+            ida_auto.auto_wait()
+    finally:
+        timer.cancel()
+        ida_kernwin.clr_cancelled()
 
     finished = bool(ida_auto.auto_is_ok())
     after = ida_funcs.get_func_qty()
@@ -601,7 +624,10 @@ def analysis_wait(
         "note": (
             "Analysis complete."
             if finished
-            else "Timed out while analysis was still running — call analysis_wait() again to continue."
+            else (
+                f"Waited {budget:.0f}s and analysis is still running — call "
+                f"analysis_wait() again to continue."
+            )
         ),
     }
 

--- a/src/ida_multi_mcp/ida_mcp/api_core.py
+++ b/src/ida_multi_mcp/ida_mcp/api_core.py
@@ -8,6 +8,7 @@ import ida_auto
 import ida_funcs
 import ida_hexrays
 import ida_loader
+import ida_kernwin
 import idaapi
 import idautils
 import ida_nalt
@@ -455,7 +456,10 @@ def _build_health_payload() -> dict:
         "uptime_sec": round(time.time() - _SERVER_START_TIME, 1),
         "idb_path": path,
         "module": module,
-        "auto_analysis_ready": not ida_auto.auto_is_ok(),
+        # auto_is_ok() is "are all queues empty", i.e. True once analysis has
+        # finished. This was negated, so the field reported the opposite of the
+        # truth in both directions and agents proceeded on a half-analysed IDB.
+        "auto_analysis_ready": bool(ida_auto.auto_is_ok()),
         "hexrays_ready": bool(ida_hexrays.init_hexrays_plugin()),
         "strings_cache_ready": _strings_cache is not None,
         "strings_cache_size": len(_strings_cache) if _strings_cache else 0,
@@ -469,6 +473,121 @@ def server_health() -> dict:
     uptime, IDB path, auto-analysis status, Hex-Rays availability, and
     strings cache state."""
     return _build_health_payload()
+
+
+_AUTO_STATE_NAMES = {
+    "AU_NONE": "idle",
+    "AU_UNK": "reanalysing unexplored bytes",
+    "AU_CODE": "converting to instructions",
+    "AU_WEAK": "converting to instructions (weak)",
+    "AU_PROC": "creating functions",
+    "AU_TAIL": "adding function tails",
+    "AU_FCHUNK": "finding function chunks",
+    "AU_USED": "reanalysing dependent instructions",
+    "AU_TYPE": "applying type information",
+    "AU_LIBF": "identifying library functions",
+    "AU_CHLB": "identifying library functions (delayed)",
+    "AU_FINAL": "final analysis pass",
+}
+
+
+def _auto_state_label(finished: bool) -> str:
+    """Human-readable name of whatever the autoanalyser is doing right now.
+
+    Note this runs on the IDA main thread, which is exactly what IDA borrows
+    back from the analyser to service our request — so get_auto_state() very
+    often reads AU_NONE even with work still queued. Report that as "queued"
+    rather than "idle", which would contradict finished=False.
+    """
+    if finished:
+        return "idle"
+    try:
+        state = ida_auto.get_auto_state()
+    except Exception:
+        return "unknown"
+    if state == getattr(ida_auto, "AU_NONE", 0):
+        return "queued (paused while servicing this request)"
+    for const, label in _AUTO_STATE_NAMES.items():
+        if const == "AU_NONE":
+            continue
+        value = getattr(ida_auto, const, None)
+        if value is not None and state == value:
+            return label
+    return f"running (state={state})"
+
+
+@tool
+@idasync
+def analysis_status() -> dict:
+    """Check whether IDA's initial auto-analysis has finished. Returns
+    immediately without blocking.
+
+    IMPORTANT: on a freshly opened binary, analysis runs in the background and
+    function lists, xrefs, and decompilation are INCOMPLETE until it finishes.
+    Check this before drawing conclusions from a first pass over a new binary,
+    and use analysis_wait() to block until it is done."""
+    finished = bool(ida_auto.auto_is_ok())
+    return {
+        "finished": finished,
+        "state": _auto_state_label(finished),
+        "function_count": ida_funcs.get_func_qty(),
+        "hint": (
+            "Analysis is complete; results are trustworthy."
+            if finished
+            else "Analysis is still running — call analysis_wait() before relying on results."
+        ),
+    }
+
+
+@tool
+@idasync
+@tool_timeout(300.0)
+def analysis_wait(
+    timeout_sec: Annotated[float, "Seconds to wait before returning (default 120)"] = 120.0,
+) -> dict:
+    """Block until IDA's auto-analysis finishes, then return.
+
+    Call this once after opening a binary, before any analysis work. If it
+    returns finished=false the wait timed out rather than failed — call it
+    again to keep waiting.
+
+    Returns the elapsed wait and the resulting function count, so a caller can
+    see analysis actually progressing across successive calls."""
+    t0 = time.perf_counter()
+    before = ida_funcs.get_func_qty()
+
+    if ida_auto.auto_is_ok():
+        return {
+            "finished": True,
+            "waited_sec": 0.0,
+            "function_count": before,
+            "functions_added": 0,
+            "note": "Analysis had already finished.",
+        }
+
+    deadline = time.monotonic() + max(0.0, float(timeout_sec))
+    # auto_wait() processes the queues and returns False if it was cancelled —
+    # which is exactly what the tool deadline's set_cancelled() does. Loop so a
+    # cancelled slice resumes rather than aborting the whole wait.
+    while time.monotonic() < deadline:
+        ida_auto.auto_wait()
+        if ida_auto.auto_is_ok():
+            break
+
+    finished = bool(ida_auto.auto_is_ok())
+    after = ida_funcs.get_func_qty()
+    return {
+        "finished": finished,
+        "waited_sec": round(time.perf_counter() - t0, 2),
+        "function_count": after,
+        "functions_added": after - before,
+        "state": _auto_state_label(finished),
+        "note": (
+            "Analysis complete."
+            if finished
+            else "Timed out while analysis was still running — call analysis_wait() again to continue."
+        ),
+    }
 
 
 @tool
@@ -649,17 +768,45 @@ def imports_query(
 def idb_save(
     path: Annotated[str, "Optional destination path (default: current IDB path)"] = "",
 ) -> dict:
-    """Save active IDB to disk. Call after renaming, retyping, or commenting
-    to persist changes. Optionally specify a custom output path."""
+    """Save active IDB to disk, with no dialogs. Call after renaming, retyping,
+    or commenting to persist changes. Optionally specify a custom output path
+    to write a copy instead, leaving the open database untouched."""
     try:
-        save_path = path.strip() if path else ""
-        if not save_path:
-            save_path = ida_loader.get_path(ida_loader.PATH_TYPE_IDB)
+        requested = path.strip() if path else ""
+        current = ida_loader.get_path(ida_loader.PATH_TYPE_IDB)
+        save_path = requested or current
         if not save_path:
             return {"ok": False, "path": None, "error": "Could not resolve IDB path"}
 
-        ok = bool(ida_loader.save_database(save_path, 0))
-        result: dict = {"ok": ok, "path": save_path}
+        try:
+            is_gui = bool(ida_kernwin.is_idaq())
+        except Exception:
+            is_gui = False
+
+        saving_copy = bool(requested) and requested != current
+
+        if saving_copy:
+            # Explicit different destination: write a compressed snapshot and
+            # leave the live working files alone.
+            flags = getattr(ida_loader, "DBFL_COMP", 0)
+            ok = bool(ida_loader.save_database(save_path, flags))
+        elif is_gui:
+            # In the GUI the open database is backed by loose .id0/.id1/.id2/
+            # .nam/.til files that IDA is actively using. Pass None for the
+            # in-place save IDA itself performs on Ctrl+W; handing it an
+            # explicit path takes the save-as route instead.
+            ok = bool(ida_loader.save_database(None, 0))
+        else:
+            # Headless: nothing else holds the working files, so pack into one
+            # compressed database.
+            flags = getattr(ida_loader, "DBFL_KILL", 0) | getattr(ida_loader, "DBFL_COMP", 0)
+            ok = bool(ida_loader.save_database(save_path, flags))
+
+        result: dict = {
+            "ok": ok,
+            "path": save_path,
+            "mode": "copy" if saving_copy else ("gui-in-place" if is_gui else "headless-packed"),
+        }
         if not ok:
             result["error"] = "save_database returned false"
         return result

--- a/src/ida_multi_mcp/ida_mcp/api_core.py
+++ b/src/ida_multi_mcp/ida_mcp/api_core.py
@@ -16,6 +16,7 @@ import ida_typeinf
 import ida_segment
 import idc
 
+from . import compat
 from .rpc import tool
 from .sync import idasync, tool_timeout
 
@@ -535,23 +536,98 @@ def _auto_state_label(finished: bool) -> str:
 @tool
 @idasync
 def analysis_status() -> dict:
-    """Check whether IDA's initial auto-analysis has finished. Returns
-    immediately without blocking.
+    """Check whether IDA's auto-analysis has work outstanding. Non-blocking.
 
-    IMPORTANT: on a freshly opened binary, analysis runs in the background and
-    function lists, xrefs, and decompilation are INCOMPLETE until it finishes.
-    Check this before drawing conclusions from a first pass over a new binary,
-    and use analysis_wait() to block until it is done."""
-    finished = bool(ida_auto.auto_is_ok())
+    On a freshly opened binary, analysis runs in the background and the function
+    list, xrefs, strings and decompiler output are all INCOMPLETE until it
+    settles. Check this before drawing conclusions from a first pass, and use
+    analysis_wait() to drive it to completion.
+
+    `queue_empty` is a SNAPSHOT, not a latch. It reports IDA's auto_is_ok() at
+    this instant — "are the analysis queues empty right now". IDA re-queues work
+    as it goes, so the value can read True and then False again moments later;
+    observed live on a 23MB DLL. Read it as:
+
+      queue_empty=False -> definitely still working, do not trust results yet
+      queue_empty=True  -> nothing queued at this instant; combine with a stable
+                           function_count across calls before treating analysis
+                           as done
+
+    `finished` is kept as an alias of `queue_empty` for compatibility and
+    carries the same caveat."""
+    queue_empty = bool(ida_auto.auto_is_ok())
     return {
-        "finished": finished,
-        "state": _auto_state_label(finished),
+        "queue_empty": queue_empty,
+        # Alias: same snapshot value, same caveat. Not a completion latch.
+        "finished": queue_empty,
+        "state": _auto_state_label(queue_empty),
         "function_count": ida_funcs.get_func_qty(),
         "hint": (
-            "Analysis is complete; results are trustworthy."
-            if finished
-            else "Analysis is still running — call analysis_wait() before relying on results."
+            "No analysis queued at this instant. This is a snapshot, not a "
+            "guarantee — confirm function_count has stopped changing before "
+            "treating the database as fully analysed."
+            if queue_empty
+            else "Analysis still has work queued — call analysis_wait() before relying on results."
         ),
+    }
+
+
+@tool
+@idasync
+@tool_timeout(300.0)
+def analysis_step(
+    max_sec: Annotated[float, "Seconds to spend driving analysis (default 5, max 30)"] = 5.0,
+) -> dict:
+    """Drive IDA's auto-analysis queue for a bounded slice, then return.
+
+    Prefer analysis_wait(), which calls this in a loop with a real timeout.
+
+    IDA's background analysis stalls short of completion: measured on a 23MB
+    DLL it climbed to 73,928 functions on its own and then sat there, never
+    flipping auto_is_ok(). Something has to drain the residual queue.
+
+    Stepping one address at a time keeps each call bounded by max_sec, so the
+    instance stays responsive through the long bulk phase. Once the range is
+    drained this makes one closing auto_wait() call, which is unbounded and is
+    the only thing that actually flips auto_is_ok() — see the comment below.
+    That final slice therefore runs past max_sec.
+    """
+    budget = max(0.0, min(float(max_sec), 30.0))
+    lo, hi = compat.inf_get_min_ea(), compat.inf_get_max_ea()
+    before = ida_funcs.get_func_qty()
+    t0 = time.perf_counter()
+    deadline = time.monotonic() + budget
+
+    steps = 0
+    drained = False
+    finalized = False
+    while time.monotonic() < deadline:
+        if ida_auto.auto_is_ok():
+            break
+        if not ida_auto.auto_make_step(lo, hi):
+            # Range drained, but auto_is_ok() can still be False: there is a
+            # closing pass that only auto_wait() performs. Measured on a 23MB
+            # DLL, stepping produced all 73,929 functions and left the flag
+            # False; one auto_wait() then took 34.5s, added zero functions, and
+            # flipped it. So the last slice runs long by design — it is the only
+            # way to reach a genuine "analysis finished".
+            drained = True
+            ida_auto.auto_wait()
+            finalized = True
+            break
+        steps += 1
+
+    finished = bool(ida_auto.auto_is_ok())
+    after = ida_funcs.get_func_qty()
+    return {
+        "finished": finished,
+        "steps": steps,
+        "drained_range": drained,
+        "finalized": finalized,
+        "elapsed_sec": round(time.perf_counter() - t0, 2),
+        "function_count": after,
+        "functions_added": after - before,
+        "state": _auto_state_label(finished),
     }
 
 

--- a/src/ida_multi_mcp/ida_mcp/api_memory.py
+++ b/src/ida_multi_mcp/ida_mcp/api_memory.py
@@ -36,7 +36,10 @@ _MAX_BATCH_SIZE = 500     # Max items in a single batch request
 @tool
 @idasync
 def get_bytes(regions: list[MemoryRead] | MemoryRead) -> list[dict]:
-    """Read bytes from memory addresses"""
+    """Read raw bytes at one or more addresses.
+
+    Reads the static IDB image, not a live process. Uninitialised BSS reads
+    back as zeroes rather than 0xFF."""
     if isinstance(regions, dict):
         regions = [regions]
 
@@ -146,7 +149,10 @@ def get_int(
 def get_string(
     addrs: Annotated[list[str] | str, "Addresses to read strings from"],
 ) -> list[dict]:
-    """Read strings from memory addresses"""
+    """Read NUL-terminated strings at one or more addresses.
+
+    Use when you have a pointer from decompiler output; to search for a string
+    by content use find(type="string") instead."""
     addrs = normalize_list_input(addrs)
     results = []
 

--- a/src/ida_multi_mcp/ida_mcp/api_modify.py
+++ b/src/ida_multi_mcp/ida_mcp/api_modify.py
@@ -11,6 +11,8 @@ import ida_hexrays
 import ida_typeinf
 import ida_ua
 
+from . import compat
+
 from .rpc import tool
 from .sync import idasync, IDAError
 from .api_core import invalidate_funcs_cache, invalidate_globals_cache
@@ -373,7 +375,7 @@ def rename(batch: RenameBatch) -> dict:
                     )
                     continue
 
-                idx, udm = frame_tif.get_udm(item["old"])
+                idx, udm = compat.tinfo_get_udm(frame_tif, item["old"])
                 if not udm:
                     results.append(
                         {

--- a/src/ida_multi_mcp/ida_mcp/api_resources.py
+++ b/src/ida_multi_mcp/ida_mcp/api_resources.py
@@ -174,7 +174,7 @@ def types_resource() -> list[dict]:
 def structs_resource() -> list[dict]:
    """Get all structures/unions"""
    structs = []
-   limit = ida_typeinf.get_ordinal_limit()
+   limit = compat.get_ordinal_limit()
    for ordinal in range(1, limit):
       tif = ida_typeinf.tinfo_t()
       if tif.get_numbered_type(None, ordinal) and tif.is_udt():

--- a/src/ida_multi_mcp/ida_mcp/api_stack.py
+++ b/src/ida_multi_mcp/ida_mcp/api_stack.py
@@ -9,6 +9,8 @@ import ida_typeinf
 import ida_frame
 import idaapi
 
+from . import compat
+
 from .rpc import tool
 from .sync import idasync
 from .utils import (
@@ -118,7 +120,7 @@ def delete_stack(
                 )
                 continue
 
-            idx, udm = frame_tif.get_udm(var_name)
+            idx, udm = compat.tinfo_get_udm(frame_tif, var_name)
             if not udm:
                 results.append(
                     {

--- a/src/ida_multi_mcp/ida_mcp/api_stack.py
+++ b/src/ida_multi_mcp/ida_mcp/api_stack.py
@@ -32,7 +32,10 @@ from .utils import (
 @tool
 @idasync
 def stack_frame(addrs: Annotated[list[str] | str, "Address(es)"]) -> list[dict]:
-    """Get stack vars"""
+    """List the stack frame variables of one or more functions.
+
+    Returns each local's name, offset, size and type — the frame layout behind
+    the var_NN names in decompiler output."""
     addrs = normalize_list_input(addrs)
     results = []
 

--- a/src/ida_multi_mcp/ida_mcp/api_types.py
+++ b/src/ida_multi_mcp/ida_mcp/api_types.py
@@ -39,7 +39,10 @@ from .utils import (
 def declare_type(
     decls: Annotated[list[str] | str, "C type declarations"],
 ) -> list[dict]:
-    """Declare types"""
+    """Declare C types (structs, unions, enums, typedefs) into the IDB.
+
+    Takes ordinary C declaration text. Declare a type here first, then apply it
+    to an address with set_type."""
     decls = normalize_list_input(decls)
     results = []
 
@@ -213,7 +216,10 @@ def search_structs(
         str, "Case-insensitive substring to search for in structure names"
     ],
 ) -> list[dict]:
-    """Search structs"""
+    """Find structures whose name contains a substring (case-insensitive).
+
+    Returns name, size and field count. Use read_struct to see the fields or to
+    overlay the struct on an address."""
     results = []
     limit = compat.get_ordinal_limit()
 
@@ -388,7 +394,10 @@ def set_type(edits: list[TypeEdit] | TypeEdit) -> list[dict]:
 def infer_types(
     addrs: Annotated[list[str] | str, "Addresses to infer types for"],
 ) -> list[dict]:
-    """Infer types"""
+    """Infer the type of data or a function at an address.
+
+    Asks Hex-Rays first and falls back to IDA's own guess. Returns the inferred
+    type plus a confidence label; a null type means neither could decide."""
     addrs = normalize_list_input(addrs)
     results = []
 

--- a/src/ida_multi_mcp/ida_mcp/api_types.py
+++ b/src/ida_multi_mcp/ida_mcp/api_types.py
@@ -9,6 +9,8 @@ import ida_ida
 import idaapi
 import idc
 
+from . import compat
+
 from .rpc import tool
 from .sync import idasync, ida_major
 from .utils import (
@@ -162,7 +164,6 @@ def read_struct(queries: list[StructRead] | StructRead) -> list[dict]:
                 member_addr = addr + offset
                 try:
                     if member.type.is_ptr():
-                        from . import compat
                         is_64bit = compat.inf_is_64bit()
                         ptr_size = 8 if is_64bit else 4
                         value = read_int_bss_safe(member_addr, ptr_size)
@@ -214,7 +215,7 @@ def search_structs(
 ) -> list[dict]:
     """Search structs"""
     results = []
-    limit = ida_typeinf.get_ordinal_limit()
+    limit = compat.get_ordinal_limit()
 
     for ordinal in range(1, limit):
         tif = ida_typeinf.tinfo_t()
@@ -353,7 +354,7 @@ def set_type(edits: list[TypeEdit] | TypeEdit) -> list[dict]:
                     results.append({"edit": edit, "error": "No frame"})
                     continue
 
-                idx, udm = frame_tif.get_udm(edit["name"])
+                idx, udm = compat.tinfo_get_udm(frame_tif, edit["name"])
                 if not udm:
                     results.append({"edit": edit, "error": f"{edit['name']} not found"})
                     continue
@@ -396,8 +397,9 @@ def infer_types(
             ea = parse_address(addr)
             tif = ida_typeinf.tinfo_t()
 
-            # Try Hex-Rays inference
-            if ida_hexrays.init_hexrays_plugin() and ida_hexrays.guess_tinfo(tif, ea):
+            # Try type inference. guess_tinfo moved from ida_hexrays to
+            # ida_typeinf; compat prefers the modern location and falls back.
+            if compat.guess_tinfo(tif, ea):
                 results.append(
                     {
                         "addr": addr,

--- a/src/ida_multi_mcp/ida_mcp/compat.py
+++ b/src/ida_multi_mcp/ida_mcp/compat.py
@@ -1,28 +1,87 @@
 """IDA SDK version compatibility shims.
 
-Provides unified wrappers for APIs that moved between IDA 8.3 and 9.3.
-Import from this module instead of from version-specific ``ida_*`` modules.
+Provides unified wrappers for APIs that moved or changed shape between IDA 8.3
+and 9.3. Import from this module instead of from version-specific ``ida_*``
+modules, so a call site does not silently pin us to one IDA generation.
+
+The version-gating strategy below is ported from upstream ida-pro-mcp's
+``ida_mcp/compat.py`` by Duncan Ogilvie (MIT); the wrappers here cover the call
+sites this fork actually has.
 
 Known migrations:
 - Entry point functions (get_entry_qty, get_entry_ordinal, get_entry,
-  get_entry_name): ida_nalt (8.x) → ida_entry (9.0+, exclusive in 9.3+).
-- inf_is_64bit: idaapi (8.x) → ida_ida (9.0+).
+  get_entry_name): ida_nalt (8.x) -> ida_entry (8.4+, exclusive in 9.3+).
+- inf_* accessors: idaapi.get_inf_structure() (<8.5) -> ida_ida.inf_get_* (8.5+).
+- Type ordinal count: ida_typeinf.get_ordinal_qty (<8.4) -> get_ordinal_limit (8.4+).
+- func_t.get_name / func_t.get_prototype: added in 8.5.
+- tinfo_t.get_udm: added in 8.5.
+
+IDA 9.0 SP0 (build 240925) is a special case: it shipped *without* several
+methods that 8.5 had introduced and that 9.0 SP1 reinstated. The wrappers below
+fall back where they can; :func:`assert_supported_ida` reports the rest loudly
+rather than letting a tool fail deep in a call stack.
 """
 
 from __future__ import annotations
 
+import re
 import idaapi
+import ida_funcs
+import ida_nalt
+import ida_typeinf
 
 # ---------------------------------------------------------------------------
 # Version detection
 # ---------------------------------------------------------------------------
 
+
+def _parse_kernel_version(v) -> tuple[int, int, int]:
+    """Parse "9.2", "9.2.0", "9.2sp1" and friends into a comparable tuple.
+
+    Defensive about the input: get_kernel_version() is an SDK call, and under
+    test it is a stub. An unparseable value yields (0, 0, 0), which is safe
+    because every wrapper below dispatches on hasattr rather than on version —
+    the constants are advisory.
+    """
+    nums = [int(x) for x in re.findall(r"\d+", str(v))]
+    return (
+        nums[0] if len(nums) > 0 else 0,
+        nums[1] if len(nums) > 1 else 0,
+        nums[2] if len(nums) > 2 else 0,
+    )
+
+
 _kernel_version = idaapi.get_kernel_version()  # e.g. "9.3"
-_major, _minor = (int(x) for x in _kernel_version.split(".")[:2])
+IDA_VERSION = _parse_kernel_version(_kernel_version)
+IDA_GE_90 = IDA_VERSION >= (9, 0, 0)
+IDA_GE_85 = IDA_VERSION >= (8, 5, 0)
+IDA_GE_84 = IDA_VERSION >= (8, 4, 0)
+
+# Retained for callers that imported these before this module grew up.
+_major, _minor = IDA_VERSION[0], IDA_VERSION[1]
+
+# ---------------------------------------------------------------------------
+# Optional module imports
+# ---------------------------------------------------------------------------
+#
+# Imported unconditionally and probed with hasattr rather than gated on the
+# parsed version. Feature detection is what actually decides which API exists,
+# and it keeps a surprising version string from routing a modern IDA down the
+# legacy path (where idaapi.get_inf_structure no longer exists at all).
+
+try:
+    import ida_ida
+except ImportError:  # pragma: no cover - only on very old IDA
+    ida_ida = None
+
+try:
+    import ida_hexrays
+except ImportError:  # pragma: no cover - Hex-Rays not licensed
+    ida_hexrays = None
 
 
 # ---------------------------------------------------------------------------
-# Entry point API (ida_nalt in 8.x, ida_entry in 9.x)
+# Entry point API (ida_nalt in early 8.x, ida_entry in 8.4+)
 # ---------------------------------------------------------------------------
 
 try:
@@ -50,16 +109,173 @@ def get_entry_name(ordinal: int) -> str:
 
 
 # ---------------------------------------------------------------------------
-# inf_is_64bit (idaapi in 8.x, ida_ida in 9.x)
+# inf_* accessors (idaapi.get_inf_structure() before 8.5, ida_ida.inf_* after)
 # ---------------------------------------------------------------------------
 
-try:
-    import ida_ida
-    if hasattr(ida_ida, "inf_is_64bit"):
-        def inf_is_64bit() -> bool:
-            return ida_ida.inf_is_64bit()
-    else:
-        raise AttributeError
-except (ImportError, AttributeError):
-    def inf_is_64bit() -> bool:  # type: ignore[misc]
+
+def _inf_attr(name: str):
+    """Read one field off the legacy inf structure."""
+    return getattr(idaapi.get_inf_structure(), name)
+
+
+def inf_get_min_ea() -> int:
+    if ida_ida is not None and hasattr(ida_ida, "inf_get_min_ea"):
+        return ida_ida.inf_get_min_ea()
+    return _inf_attr("min_ea")
+
+
+def inf_get_max_ea() -> int:
+    if ida_ida is not None and hasattr(ida_ida, "inf_get_max_ea"):
+        return ida_ida.inf_get_max_ea()
+    return _inf_attr("max_ea")
+
+
+def inf_get_omin_ea() -> int:
+    if ida_ida is not None and hasattr(ida_ida, "inf_get_omin_ea"):
+        return ida_ida.inf_get_omin_ea()
+    return _inf_attr("omin_ea")
+
+
+def inf_get_omax_ea() -> int:
+    if ida_ida is not None and hasattr(ida_ida, "inf_get_omax_ea"):
+        return ida_ida.inf_get_omax_ea()
+    return _inf_attr("omax_ea")
+
+
+def inf_is_64bit() -> bool:
+    if ida_ida is not None and hasattr(ida_ida, "inf_is_64bit"):
+        return ida_ida.inf_is_64bit()
+    if hasattr(idaapi, "inf_is_64bit"):
         return idaapi.inf_is_64bit()
+    return bool(idaapi.get_inf_structure().is_64bit())
+
+
+# ---------------------------------------------------------------------------
+# Type ordinal count (get_ordinal_qty before 8.4, get_ordinal_limit after)
+# ---------------------------------------------------------------------------
+
+
+def get_ordinal_limit(til: "ida_typeinf.til_t | None" = None) -> int:
+    fn = getattr(ida_typeinf, "get_ordinal_limit", None)
+    if fn is None:
+        fn = ida_typeinf.get_ordinal_qty
+    return fn(til) if til is not None else fn()
+
+
+# ---------------------------------------------------------------------------
+# func_t helpers (get_name / get_prototype added in 8.5, absent in 9.0 SP0)
+# ---------------------------------------------------------------------------
+
+
+def get_func_name(func: "ida_funcs.func_t") -> str | None:
+    if hasattr(func, "get_name"):
+        return func.get_name()
+    return ida_funcs.get_func_name(func.start_ea)
+
+
+def get_func_prototype(func: "ida_funcs.func_t"):
+    if hasattr(func, "get_prototype"):
+        return func.get_prototype()
+    tif = ida_typeinf.tinfo_t()
+    if ida_nalt.get_tinfo(tif, func.start_ea) and tif.is_func():
+        return tif
+    return None
+
+
+# ---------------------------------------------------------------------------
+# UDM (struct / union / frame member) lookup
+# ---------------------------------------------------------------------------
+
+
+def tinfo_get_udm(
+    tif: "ida_typeinf.tinfo_t", name: str
+) -> tuple[int, "ida_typeinf.udm_t | None"]:
+    """Look up a member on a tinfo_t by name.
+
+    ``tinfo_t.get_udm()`` arrived in 8.5 and is missing from IDA 9.0 SP0
+    (build 240925). Fall back to find_udm() + get_udm_by_tid().
+
+    Returns (index, udm); udm is None when the member does not exist.
+    """
+    if hasattr(tif, "get_udm"):
+        return tif.get_udm(name)
+
+    idx = tif.find_udm(name)
+    if idx == -1:
+        return -1, None
+
+    udm = ida_typeinf.udm_t()
+    tid = tif.get_udm_tid(idx)
+    # get_udm_by_tid returns 0 on success (C convention), so check whether the
+    # struct actually got populated rather than trusting the return value.
+    tif.get_udm_by_tid(udm, tid)
+    if udm.name:
+        return idx, udm
+    return -1, None
+
+
+# ---------------------------------------------------------------------------
+# Type guessing (moved out of ida_hexrays)
+# ---------------------------------------------------------------------------
+
+
+def guess_tinfo(tif: "ida_typeinf.tinfo_t", ea: int) -> bool:
+    try:
+        rc = ida_typeinf.guess_tinfo(tif, ea)
+        if isinstance(rc, bool):
+            if rc:
+                return True
+        elif int(rc) > 0:
+            return True
+    except Exception:
+        pass
+
+    if ida_hexrays is not None:
+        try:
+            if ida_hexrays.init_hexrays_plugin() and ida_hexrays.guess_tinfo(tif, ea):
+                return True
+        except Exception:
+            pass
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Startup check
+# ---------------------------------------------------------------------------
+
+
+def missing_required_apis() -> list[str]:
+    """Return names of 8.5-era APIs this IDA build is missing.
+
+    Only meaningful on 9.0+: IDA 9.0 SP0 (build 240925) dropped methods that
+    8.5 had added and 9.0 SP1 restored. Older builds legitimately lack them and
+    are served by the fallbacks above, so they are not reported here.
+    """
+    if not IDA_GE_90:
+        return []
+
+    missing = []
+    try:
+        func = ida_funcs.func_t()
+        if not hasattr(func, "get_name"):
+            missing.append("func_t.get_name")
+        if not hasattr(func, "get_prototype"):
+            missing.append("func_t.get_prototype")
+        tif = ida_typeinf.tinfo_t()
+        if not hasattr(tif, "get_udm"):
+            missing.append("tinfo_t.get_udm")
+    except Exception:
+        return []
+    return missing
+
+
+def assert_supported_ida() -> None:
+    """Raise if running on an IDA build known to break tools in confusing ways."""
+    missing = missing_required_apis()
+    if missing:
+        raise RuntimeError(
+            f"IDA Pro {_kernel_version} is missing required Python API methods: "
+            f"{', '.join(missing)}. If this is IDA 9.0, upgrade to 9.0 SP1 "
+            f"(build 241217) or later."
+        )

--- a/src/ida_multi_mcp/ida_mcp/utils.py
+++ b/src/ida_multi_mcp/ida_mcp/utils.py
@@ -1248,7 +1248,7 @@ def handle_large_output(result: Any, line_threshold: int = 3000) -> Any:
                 suffix=".json", prefix="ida_mcp_", text=True
             )
             try:
-                with os.fdopen(fd, "w") as f:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
                     f.write(serialized)
 
                 return {

--- a/src/ida_multi_mcp/ida_mcp/utils.py
+++ b/src/ida_multi_mcp/ida_mcp/utils.py
@@ -28,6 +28,8 @@ import idaapi
 import idautils
 import idc
 
+from . import compat
+
 from .sync import IDAError
 
 # ============================================================================
@@ -431,8 +433,8 @@ def get_image_size() -> int:
     except AttributeError:
         import ida_ida
 
-        omin_ea = ida_ida.inf_get_omin_ea()
-        omax_ea = ida_ida.inf_get_omax_ea()
+        omin_ea = compat.inf_get_omin_ea()
+        omax_ea = compat.inf_get_omax_ea()
     image_size = omax_ea - omin_ea
     header = idautils.peutils_t().header()
     if header and header[:4] == b"PE\0\0":

--- a/src/ida_multi_mcp/ida_tool_schemas.json
+++ b/src/ida_multi_mcp/ida_tool_schemas.json
@@ -1,362 +1,36 @@
 [
   {
-    "name": "lookup_funcs",
-    "description": "Get functions by address or name (auto-detects)",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "queries": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "description": "Address(es) or name(s)"
-        }
-      },
-      "required": [
-        "queries"
-      ]
-    },
-    "outputSchema": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
-    }
-  },
-  {
-    "name": "int_convert",
-    "description": "Convert numbers to different formats",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "inputs": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "text": {
-                    "type": "string",
-                    "description": "Number string to convert"
-                  },
-                  "size": {
-                    "type": "integer",
-                    "description": "Byte size for conversion (omit for auto)"
-                  }
-                },
-                "required": [],
-                "additionalProperties": false
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
-                "text": {
-                  "type": "string",
-                  "description": "Number string to convert"
-                },
-                "size": {
-                  "type": "integer",
-                  "description": "Byte size for conversion (omit for auto)"
-                }
-              },
-              "required": [],
-              "additionalProperties": false
-            }
-          ],
-          "description": "Convert numbers to various formats (hex, decimal, binary, ascii)"
-        }
-      },
-      "required": [
-        "inputs"
-      ]
-    },
-    "outputSchema": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
-    }
-  },
-  {
-    "name": "list_funcs",
-    "description": "List functions",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "queries": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "filter": {
-                    "type": "string",
-                    "description": "Optional glob pattern to filter results"
-                  },
-                  "offset": {
-                    "type": "integer",
-                    "description": "Starting index (default: 0)"
-                  },
-                  "count": {
-                    "type": "integer",
-                    "description": "Maximum number of results (default: 50, 0 for all)"
-                  }
-                },
-                "required": [],
-                "additionalProperties": false
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
-                "filter": {
-                  "type": "string",
-                  "description": "Optional glob pattern to filter results"
-                },
-                "offset": {
-                  "type": "integer",
-                  "description": "Starting index (default: 0)"
-                },
-                "count": {
-                  "type": "integer",
-                  "description": "Maximum number of results (default: 50, 0 for all)"
-                }
-              },
-              "required": [],
-              "additionalProperties": false
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "description": "List functions with optional filtering and pagination"
-        }
-      },
-      "required": [
-        "queries"
-      ]
-    },
-    "outputSchema": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
-    }
-  },
-  {
-    "name": "list_globals",
-    "description": "List globals",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "queries": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "filter": {
-                    "type": "string",
-                    "description": "Optional glob pattern to filter results"
-                  },
-                  "offset": {
-                    "type": "integer",
-                    "description": "Starting index (default: 0)"
-                  },
-                  "count": {
-                    "type": "integer",
-                    "description": "Maximum number of results (default: 50, 0 for all)"
-                  }
-                },
-                "required": [],
-                "additionalProperties": false
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
-                "filter": {
-                  "type": "string",
-                  "description": "Optional glob pattern to filter results"
-                },
-                "offset": {
-                  "type": "integer",
-                  "description": "Starting index (default: 0)"
-                },
-                "count": {
-                  "type": "integer",
-                  "description": "Maximum number of results (default: 50, 0 for all)"
-                }
-              },
-              "required": [],
-              "additionalProperties": false
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "description": "List global variables with optional filtering and pagination"
-        }
-      },
-      "required": [
-        "queries"
-      ]
-    },
-    "outputSchema": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
-    }
-  },
-  {
-    "name": "refresh_caches",
-    "description": "Force-refresh all caches (strings, functions, globals). Call this after bulk modifications to ensure list_funcs/list_globals return fresh data.",
+    "name": "analysis_status",
+    "description": "Check whether IDA's auto-analysis has work outstanding. Non-blocking.\n\n    On a freshly opened binary, analysis runs in the background and the function\n    list, xrefs, strings and decompiler output are all INCOMPLETE until it\n    settles. Check this before drawing conclusions from a first pass, and use\n    analysis_wait() to drive it to completion.\n\n    `queue_empty` is a SNAPSHOT, not a latch. It reports IDA's auto_is_ok() at\n    this instant — \"are the analysis queues empty right now\". IDA re-queues work\n    as it goes, so the value can read True and then False again moments later;\n    observed live on a 23MB DLL. Read it as:\n\n      queue_empty=False -> definitely still working, do not trust results yet\n      queue_empty=True  -> nothing queued at this instant; combine with a stable\n                           function_count across calls before treating analysis\n                           as done\n\n    `finished` is kept as an alias of `queue_empty` for compatibility and\n    carries the same caveat.",
     "inputSchema": {
       "type": "object",
       "properties": {},
       "required": []
     },
     "outputSchema": {
-      "type": "object",
-      "properties": {
-        "strings": {
-          "type": "integer"
-        },
-        "functions": {
-          "type": "integer"
-        },
-        "globals": {
-          "type": "integer"
-        },
-        "time_ms": {
-          "type": "integer"
-        }
-      },
-      "required": [
-        "strings",
-        "functions",
-        "globals",
-        "time_ms"
-      ]
+      "type": "object"
     }
   },
   {
-    "name": "imports",
-    "description": "List imports",
+    "name": "analysis_step",
+    "description": "Drive IDA's auto-analysis queue for a bounded slice, then return.\n\n    Prefer analysis_wait(), which calls this in a loop with a real timeout.\n\n    IDA's background analysis stalls short of completion: measured on a 23MB\n    DLL it climbed to 73,928 functions on its own and then sat there, never\n    flipping auto_is_ok(). Something has to drain the residual queue.\n\n    Stepping one address at a time keeps each call bounded by max_sec, so the\n    instance stays responsive through the long bulk phase. Once the range is\n    drained this makes one closing auto_wait() call, which is unbounded and is\n    the only thing that actually flips auto_is_ok() — see the comment below.\n    That final slice therefore runs past max_sec.",
     "inputSchema": {
       "type": "object",
       "properties": {
-        "offset": {
-          "type": "integer",
-          "description": "Offset"
-        },
-        "count": {
-          "type": "integer",
-          "description": "Count (0=all)"
+        "max_sec": {
+          "type": "number",
+          "description": "Seconds to spend driving analysis (default 5, max 30)"
         }
       },
-      "required": [
-        "offset",
-        "count"
-      ]
+      "required": []
     },
     "outputSchema": {
       "type": "object"
     }
   },
   {
-    "name": "find_regex",
-    "description": "Search strings with case-insensitive regex patterns",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "pattern": {
-          "type": "string",
-          "description": "Regex pattern to search for in strings"
-        },
-        "limit": {
-          "type": "integer",
-          "description": "Max matches (default: 30, max: 500)"
-        },
-        "offset": {
-          "type": "integer",
-          "description": "Skip first N matches (default: 0)"
-        }
-      },
-      "required": [
-        "pattern"
-      ]
-    },
-    "outputSchema": {
-      "type": "object"
-    }
-  },
-  {
-    "name": "decompile",
-    "description": "Decompile function to pseudocode",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "addr": {
-          "type": "string",
-          "description": "Function address to decompile"
-        }
-      },
-      "required": [
-        "addr"
-      ]
-    },
-    "outputSchema": {
-      "type": "object"
-    }
-  },
-  {
-    "name": "disasm",
-    "description": "Disassemble function to assembly instructions",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "addr": {
-          "type": "string",
-          "description": "Function address to disassemble"
-        },
-        "max_instructions": {
-          "type": "integer",
-          "description": "Max instructions per function (default: 5000, max: 50000)"
-        },
-        "offset": {
-          "type": "integer",
-          "description": "Skip first N instructions (default: 0)"
-        },
-        "include_total": {
-          "type": "boolean",
-          "description": "Compute total instruction count (default: false)"
-        }
-      },
-      "required": [
-        "addr"
-      ]
-    },
-    "outputSchema": {
-      "type": "object"
-    }
-  },
-  {
-    "name": "xrefs_to",
-    "description": "Get cross-references to specified addresses",
+    "name": "analyze_batch",
+    "description": "Analyze multiple functions in one call. Selectively include decompilation,\n    disassembly, xrefs, strings, and callees per function. More efficient than\n    calling analyze_function N times — single IDA round-trip.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -372,11 +46,27 @@
               "type": "string"
             }
           ],
-          "description": "Addresses to find cross-references to"
+          "description": "Function addresses to analyze"
         },
-        "limit": {
-          "type": "integer",
-          "description": "Max xrefs per address (default: 100, max: 1000)"
+        "include_decompile": {
+          "type": "boolean",
+          "description": "Include pseudocode (default: true)"
+        },
+        "include_asm": {
+          "type": "boolean",
+          "description": "Include disassembly (default: false)"
+        },
+        "include_xrefs": {
+          "type": "boolean",
+          "description": "Include xrefs (default: true)"
+        },
+        "include_strings": {
+          "type": "boolean",
+          "description": "Include strings (default: true)"
+        },
+        "include_callees": {
+          "type": "boolean",
+          "description": "Include callees (default: true)"
         }
       },
       "required": [
@@ -391,30 +81,344 @@
     }
   },
   {
-    "name": "xrefs_to_field",
-    "description": "Get cross-references to structure fields",
+    "name": "analyze_component",
+    "description": "Analyze related functions as a group: per-function compact summaries,\n    internal call graph (edges only between supplied functions), shared globals,\n    interface vs internal classification, and strings used by multiple members.",
     "inputSchema": {
       "type": "object",
       "properties": {
-        "queries": {
+        "addrs": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Function addresses (comma-separated or list)"
+        }
+      },
+      "required": [
+        "addrs"
+      ]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "functions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "addr": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "prototype": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "size": {
+                "type": "integer"
+              },
+              "callees": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "strings": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "basic_blocks": {
+                "type": "integer"
+              },
+              "complexity": {
+                "type": "integer"
+              },
+              "error": {
+                "type": "string"
+              }
+            },
+            "required": [],
+            "additionalProperties": false
+          }
+        },
+        "internal_call_graph": {
+          "type": "object",
+          "properties": {
+            "nodes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "edges": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string"
+                  },
+                  "to": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "from",
+                  "to",
+                  "name"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "nodes",
+            "edges"
+          ],
+          "additionalProperties": false
+        },
+        "shared_globals": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "addr": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "accessed_by": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "addr",
+              "name",
+              "accessed_by"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "interface_functions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "internal_only": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "string_usage": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "analyze_function",
+    "description": "Compact single-function analysis: pseudocode (capped at 100 lines), top\n    strings, top non-trivial constants, callers, callees, xrefs, comments, and\n    basic block summary. Use this for \"tell me everything about function X\" in\n    one call instead of chaining decompile + callees + xrefs_to separately.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "addr": {
+          "type": "string",
+          "description": "Function address or name"
+        },
+        "include_asm": {
+          "type": "boolean",
+          "description": "Include full disassembly (default: false, saves tokens)"
+        }
+      },
+      "required": [
+        "addr"
+      ]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "addr": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "prototype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "size": {
+          "type": "integer"
+        },
+        "decompiled": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "decompile_truncated": {
+          "type": "integer"
+        },
+        "assembly": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "constants": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          }
+        },
+        "callees": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "callers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "xrefs": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "comments": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "basic_blocks": {
+          "type": "object",
+          "properties": {
+            "count": {
+              "type": "integer"
+            },
+            "cyclomatic_complexity": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "count",
+            "cyclomatic_complexity"
+          ],
+          "additionalProperties": false
+        },
+        "error": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "append_comments",
+    "description": "Append comments at addresses, deduping exact text by default. Unlike\n    set_comments (which overwrites), this preserves existing annotations — use\n    it for incremental commentary. scope='auto' (default) writes a function\n    comment when addr is a function start, otherwise a line comment; force\n    with scope='func' or 'line'. dedupe=True skips writes when the exact\n    stripped text already appears on its own line.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "items": {
           "anyOf": [
             {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
-                  "struct": {
+                  "addr": {
                     "type": "string",
-                    "description": "Structure name"
+                    "description": "Address (hex or decimal)"
                   },
-                  "field": {
+                  "comment": {
                     "type": "string",
-                    "description": "Field name"
+                    "description": "Comment text to append"
+                  },
+                  "scope": {
+                    "type": "string",
+                    "description": "auto|func|line (default: auto)"
+                  },
+                  "dedupe": {
+                    "type": "boolean",
+                    "description": "Skip if exact text already exists (default: true)"
                   }
                 },
                 "required": [
-                  "struct",
-                  "field"
+                  "addr",
+                  "comment"
                 ],
                 "additionalProperties": false
               }
@@ -422,112 +426,59 @@
             {
               "type": "object",
               "properties": {
-                "struct": {
+                "addr": {
                   "type": "string",
-                  "description": "Structure name"
+                  "description": "Address (hex or decimal)"
                 },
-                "field": {
+                "comment": {
                   "type": "string",
-                  "description": "Field name"
+                  "description": "Comment text to append"
+                },
+                "scope": {
+                  "type": "string",
+                  "description": "auto|func|line (default: auto)"
+                },
+                "dedupe": {
+                  "type": "boolean",
+                  "description": "Skip if exact text already exists (default: true)"
                 }
               },
               "required": [
-                "struct",
-                "field"
+                "addr",
+                "comment"
               ],
               "additionalProperties": false
             }
           ]
-        },
-        "limit": {
-          "type": "integer",
-          "description": "Max xrefs per field (default: 100, max: 1000)"
         }
       },
       "required": [
-        "queries"
+        "items"
       ]
     },
     "outputSchema": {
       "type": "array",
       "items": {
-        "type": "object"
-      }
-    }
-  },
-  {
-    "name": "callees",
-    "description": "Get functions called by the specified functions",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "addrs": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "description": "Function addresses to get callees for"
+        "type": "object",
+        "properties": {
+          "addr": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "appended": {
+            "type": "boolean"
+          },
+          "skipped": {
+            "type": "boolean"
+          },
+          "error": {
+            "type": "string"
+          }
         },
-        "limit": {
-          "type": "integer",
-          "description": "Max callees per function (default: 200, max: 500)"
-        }
-      },
-      "required": [
-        "addrs"
-      ]
-    },
-    "outputSchema": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
-    }
-  },
-  {
-    "name": "find_bytes",
-    "description": "Search for byte patterns in the binary (supports wildcards with ??)",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "patterns": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "description": "Byte patterns to search for (e.g. '48 8B ?? ??')"
-        },
-        "limit": {
-          "type": "integer",
-          "description": "Max matches per pattern (default: 1000, max: 10000)"
-        },
-        "offset": {
-          "type": "integer",
-          "description": "Skip first N matches (default: 0)"
-        }
-      },
-      "required": [
-        "patterns"
-      ]
-    },
-    "outputSchema": {
-      "type": "array",
-      "items": {
-        "type": "object"
+        "required": [],
+        "additionalProperties": false
       }
     }
   },
@@ -569,6 +520,671 @@
       "items": {
         "type": "object"
       }
+    }
+  },
+  {
+    "name": "binary_fingerprint",
+    "description": "Content fingerprint of the loaded binary for similarity index keying.\n\n    Returns the input file's sha256 and md5 (hex, or null if unavailable), the\n    total function count, and an arch label (e.g. 'x86_64'). The sha256 keys the\n    per-binary similarity index so the same binary shares one index across\n    instances; md5 is the fallback when sha256 is unavailable.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "sha256": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "md5": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "function_count": {
+          "type": "integer"
+        },
+        "arch": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "sha256",
+        "md5",
+        "function_count",
+        "arch"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "callees",
+    "description": "Get functions called by the specified functions",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "addrs": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Function addresses to get callees for"
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Max callees per function (default: 200, max: 500)"
+        }
+      },
+      "required": [
+        "addrs"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "callgraph",
+    "description": "Build call graph starting from root functions",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "roots": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Root function addresses to start call graph traversal from"
+        },
+        "max_depth": {
+          "type": "integer",
+          "description": "Maximum depth for call graph traversal"
+        },
+        "max_nodes": {
+          "type": "integer",
+          "description": "Max nodes across the graph (default: 1000, max: 100000)"
+        },
+        "max_edges": {
+          "type": "integer",
+          "description": "Max edges across the graph (default: 5000, max: 200000)"
+        },
+        "max_edges_per_func": {
+          "type": "integer",
+          "description": "Max edges per function (default: 200, max: 5000)"
+        }
+      },
+      "required": [
+        "roots"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "classify_functions",
+    "description": "Classify functions as thunk/wrapper/leaf/dispatcher/complex based on\n    size, callee count, and flags. Use '*' (default) for all non-library\n    functions. Returns paginated results sorted by address.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "addrs": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Function addresses (or '*' for all non-library functions)"
+        },
+        "offset": {
+          "type": "integer",
+          "description": "Skip first N results (default: 0)"
+        },
+        "count": {
+          "type": "integer",
+          "description": "Max results (default: 500, max: 5000)"
+        }
+      },
+      "required": []
+    },
+    "outputSchema": {
+      "type": "object"
+    }
+  },
+  {
+    "name": "declare_stack",
+    "description": "Create stack vars",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string",
+                    "description": "Function address"
+                  },
+                  "offset": {
+                    "type": "string",
+                    "description": "Stack offset"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Variable name"
+                  },
+                  "ty": {
+                    "type": "string",
+                    "description": "Type name"
+                  }
+                },
+                "required": [
+                  "addr",
+                  "offset",
+                  "name",
+                  "ty"
+                ],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "addr": {
+                  "type": "string",
+                  "description": "Function address"
+                },
+                "offset": {
+                  "type": "string",
+                  "description": "Stack offset"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Variable name"
+                },
+                "ty": {
+                  "type": "string",
+                  "description": "Type name"
+                }
+              },
+              "required": [
+                "addr",
+                "offset",
+                "name",
+                "ty"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": [
+        "items"
+      ]
+    }
+  },
+  {
+    "name": "declare_type",
+    "description": "Declare C types (structs, unions, enums, typedefs) into the IDB.\n\n    Takes ordinary C declaration text. Declare a type here first, then apply it\n    to an address with set_type.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "decls": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "C type declarations"
+        }
+      },
+      "required": [
+        "decls"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "decompile",
+    "description": "Decompile one function to Hex-Rays pseudocode.\n\n    The single most useful tool for understanding behaviour. Requires the\n    Hex-Rays decompiler. For many functions at once use decompile_to_file —\n    decompiling in a loop blocks the instance for every other caller.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "addr": {
+          "type": "string",
+          "description": "Function address to decompile"
+        }
+      },
+      "required": [
+        "addr"
+      ]
+    },
+    "outputSchema": {
+      "type": "object"
+    }
+  },
+  {
+    "name": "define_code",
+    "description": "Convert raw bytes to a code instruction at each given address. Returns\n    {addr, ea, length} on success (length is the instruction byte length) or\n    {addr, ea, error} if create_insn failed. Use this when IDA classified an\n    instruction as data or failed to decode.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string",
+                    "description": "Address to define (hex or decimal)"
+                  },
+                  "end": {
+                    "type": "string",
+                    "description": "Optional end address for explicit bounds"
+                  }
+                },
+                "required": [],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "addr": {
+                  "type": "string",
+                  "description": "Address to define (hex or decimal)"
+                },
+                "end": {
+                  "type": "string",
+                  "description": "Optional end address for explicit bounds"
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": [
+        "items"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "addr": {
+            "type": "string"
+          },
+          "ea": {
+            "type": "string"
+          },
+          "start": {
+            "type": "string"
+          },
+          "end": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "length": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [],
+        "additionalProperties": false
+      }
+    }
+  },
+  {
+    "name": "define_func",
+    "description": "Define a function at each given address. IDA infers bounds unless an\n    explicit end address is provided. Returns {addr, start, end} on success or\n    {addr, start, error} if the function already exists or add_func fails.\n    Use this when IDA auto-analysis missed a function entry point.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string",
+                    "description": "Address to define (hex or decimal)"
+                  },
+                  "end": {
+                    "type": "string",
+                    "description": "Optional end address for explicit bounds"
+                  }
+                },
+                "required": [],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "addr": {
+                  "type": "string",
+                  "description": "Address to define (hex or decimal)"
+                },
+                "end": {
+                  "type": "string",
+                  "description": "Optional end address for explicit bounds"
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": [
+        "items"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "addr": {
+            "type": "string"
+          },
+          "ea": {
+            "type": "string"
+          },
+          "start": {
+            "type": "string"
+          },
+          "end": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "length": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [],
+        "additionalProperties": false
+      }
+    }
+  },
+  {
+    "name": "delete_stack",
+    "description": "Delete stack vars",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string",
+                    "description": "Function address"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Variable name"
+                  }
+                },
+                "required": [
+                  "addr",
+                  "name"
+                ],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "addr": {
+                  "type": "string",
+                  "description": "Function address"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Variable name"
+                }
+              },
+              "required": [
+                "addr",
+                "name"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": [
+        "items"
+      ]
+    }
+  },
+  {
+    "name": "diff_before_after",
+    "description": "Apply a rename/type/comment action and return the before/after decompilation\n    side by side. Actions: 'rename_func' ({name}), 'set_type' ({type}),\n    'set_comment' ({comment}). Useful to verify a rename or type change actually\n    improved readability. Returns {before, after, action_applied, changes_detected}.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "addr": {
+          "type": "string",
+          "description": "Function address"
+        },
+        "action": {
+          "type": "string",
+          "description": "Action: 'rename_func', 'set_type', 'set_comment'"
+        },
+        "action_args": {
+          "type": "object",
+          "description": "Arguments for the action"
+        }
+      },
+      "required": [
+        "addr",
+        "action",
+        "action_args"
+      ]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "before": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "after": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "action_applied": {
+          "type": "string"
+        },
+        "changes_detected": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "disasm",
+    "description": "Disassemble function to assembly instructions",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "addr": {
+          "type": "string",
+          "description": "Function address to disassemble"
+        },
+        "max_instructions": {
+          "type": "integer",
+          "description": "Max instructions per function (default: 5000, max: 50000)"
+        },
+        "offset": {
+          "type": "integer",
+          "description": "Skip first N instructions (default: 0)"
+        },
+        "include_total": {
+          "type": "boolean",
+          "description": "Compute total instruction count (default: false)"
+        }
+      },
+      "required": [
+        "addr"
+      ]
+    },
+    "outputSchema": {
+      "type": "object"
+    }
+  },
+  {
+    "name": "enum_upsert",
+    "description": "Create or extend local enums in an idempotent way. Creates the enum if\n    it doesn't exist, then upserts each member: skips if name+value already match,\n    reports conflict if name or value collides with a different entry. Never\n    destructively replaces existing members.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "queries": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "description": "Enum upsert: name, members [{name, value}], bitfield (optional bool)"
+        }
+      },
+      "required": [
+        "queries"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "export_funcs",
+    "description": "Export function data (addresses, names, sizes, prototypes) in bulk.\n\n    Prefer this over looping a per-function tool — one call instead of N round\n    trips against a single-threaded IDA instance.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "addrs": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Function addresses to export"
+        },
+        "format": {
+          "type": "string",
+          "description": "Export format: json (default), c_header, or prototypes"
+        }
+      },
+      "required": [
+        "addrs"
+      ]
+    },
+    "outputSchema": {
+      "type": "object"
     }
   },
   {
@@ -627,8 +1243,75 @@
     }
   },
   {
-    "name": "export_funcs",
-    "description": "Export function data in various formats",
+    "name": "find_bytes",
+    "description": "Search for byte patterns in the binary (supports wildcards with ??)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "patterns": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Byte patterns to search for (e.g. '48 8B ?? ??')"
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Max matches per pattern (default: 1000, max: 10000)"
+        },
+        "offset": {
+          "type": "integer",
+          "description": "Skip first N matches (default: 0)"
+        }
+      },
+      "required": [
+        "patterns"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "find_regex",
+    "description": "Search strings with case-insensitive regex patterns",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "Regex pattern to search for in strings"
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Max matches (default: 30, max: 500)"
+        },
+        "offset": {
+          "type": "integer",
+          "description": "Skip first N matches (default: 0)"
+        }
+      },
+      "required": [
+        "pattern"
+      ]
+    },
+    "outputSchema": {
+      "type": "object"
+    }
+  },
+  {
+    "name": "func_features",
+    "description": "Extract name-independent similarity features for functions, page by page.\n\n    Per function returns: size, is_named, CFG metrics (bb/edge/complexity/loops/\n    callee/caller counts + out-degree sequence), a 64-perm instruction-shingle\n    MinHash, external API (import) callees, referenced strings, non-trivial\n    immediate constants, and — only for named functions — pseudocode identifier\n    tokens. Feed pages into the server-side similarity indexer. Use '*' to iterate\n    all functions; only the page slice is analyzed so large binaries stay bounded.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -644,28 +1327,138 @@
               "type": "string"
             }
           ],
-          "description": "Function addresses to export"
+          "description": "Function addresses (comma-separated or list), or '*' for all"
         },
-        "format": {
-          "type": "string",
-          "description": "Export format: json (default), c_header, or prototypes"
+        "offset": {
+          "type": "integer",
+          "description": "Skip first N functions (default: 0)"
+        },
+        "count": {
+          "type": "integer",
+          "description": "Max functions per page (default: 500, max: 2000)"
+        }
+      },
+      "required": []
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "functions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "addr": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "is_named": {
+                "type": "boolean"
+              },
+              "size": {
+                "type": "integer"
+              },
+              "cfg": {
+                "type": "object",
+                "properties": {
+                  "bb_count": {
+                    "type": "integer"
+                  },
+                  "edge_count": {
+                    "type": "integer"
+                  },
+                  "complexity": {
+                    "type": "integer"
+                  },
+                  "loops": {
+                    "type": "integer"
+                  },
+                  "callee_count": {
+                    "type": "integer"
+                  },
+                  "caller_count": {
+                    "type": "integer"
+                  },
+                  "out_deg_seq": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "required": [
+                  "bb_count",
+                  "edge_count",
+                  "complexity",
+                  "loops",
+                  "callee_count",
+                  "caller_count",
+                  "out_deg_seq"
+                ],
+                "additionalProperties": false
+              },
+              "minhash": {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              },
+              "apis": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "strings": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "consts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pseudo_tokens": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "error": {
+                "type": "string"
+              }
+            },
+            "required": [],
+            "additionalProperties": false
+          }
+        },
+        "total": {
+          "type": "integer"
+        },
+        "cursor": {
+          "type": "object"
         }
       },
       "required": [
-        "addrs"
-      ]
-    },
-    "outputSchema": {
-      "type": "object"
+        "functions",
+        "total",
+        "cursor"
+      ],
+      "additionalProperties": false
     }
   },
   {
-    "name": "callgraph",
-    "description": "Build call graph starting from root functions",
+    "name": "func_profile",
+    "description": "Per-function profile: size, basic block count, cyclomatic complexity,\n    callee/caller counts, and string count. Useful for prioritizing which\n    functions to analyze deeply. Fills the gap between list_funcs (too little\n    info) and analyze_function (too expensive per call).",
     "inputSchema": {
       "type": "object",
       "properties": {
-        "roots": {
+        "addrs": {
           "anyOf": [
             {
               "type": "array",
@@ -677,27 +1470,54 @@
               "type": "string"
             }
           ],
-          "description": "Root function addresses to start call graph traversal from"
+          "description": "Function addresses (or '*' for all)"
         },
-        "max_depth": {
+        "offset": {
           "type": "integer",
-          "description": "Maximum depth for call graph traversal"
+          "description": "Skip first N (default: 0)"
         },
-        "max_nodes": {
+        "count": {
           "type": "integer",
-          "description": "Max nodes across the graph (default: 1000, max: 100000)"
+          "description": "Max results (default: 100, max: 1000)"
         },
-        "max_edges": {
-          "type": "integer",
-          "description": "Max edges across the graph (default: 5000, max: 200000)"
+        "sort_by": {
+          "type": "string",
+          "description": "Sort key: size, complexity, xref_count, callee_count, name (default: size)"
         },
-        "max_edges_per_func": {
-          "type": "integer",
-          "description": "Max edges per function (default: 200, max: 5000)"
+        "descending": {
+          "type": "boolean",
+          "description": "Sort descending (default: true)"
+        }
+      },
+      "required": []
+    },
+    "outputSchema": {
+      "type": "object"
+    }
+  },
+  {
+    "name": "func_query",
+    "description": "Query functions with richer filtering than list_funcs. Supports regex\n    name filter, size range, type filter, sort by size/name/addr, and pagination.\n    Example: {name_regex: 'crypt', min_size: 100, sort_by: 'size', descending: true}",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "queries": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "description": "Function query: filter, name_regex, min_size, max_size, has_type, sort_by, descending, offset, count"
         }
       },
       "required": [
-        "roots"
+        "queries"
       ]
     },
     "outputSchema": {
@@ -708,8 +1528,43 @@
     }
   },
   {
+    "name": "func_tokens",
+    "description": "Emit jTrans-style normalized instruction token streams per function, for a\n    neural BCSD embedding backend. Uses IDA's own operand normalization (registers\n    kept, stack vars -> var_xxx/arg_xxx, imm/disp -> CONST, intra-function jumps ->\n    JUMP_ADDR_<idx>) -- which a byte/objdump reproduction cannot match. Paginated\n    like func_features; returns ``{addr: [token, ...]}``.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "addrs": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Function addresses (comma-separated or list), or '*' for all"
+        },
+        "offset": {
+          "type": "integer",
+          "description": "Skip first N functions (default: 0)"
+        },
+        "count": {
+          "type": "integer",
+          "description": "Max functions per page (default: 500, max: 2000)"
+        }
+      },
+      "required": []
+    },
+    "outputSchema": {
+      "type": "object"
+    }
+  },
+  {
     "name": "get_bytes",
-    "description": "Read bytes from memory addresses",
+    "description": "Read raw bytes at one or more addresses.\n\n    Reads the static IDB image, not a live process. Uninitialised BSS reads\n    back as zeroes rather than 0xFF.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -759,6 +1614,38 @@
       },
       "required": [
         "regions"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "get_global_value",
+    "description": "Read global variable values by address or name\n    (auto-detects hex addresses vs names)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "queries": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Global variable addresses or names to read values from"
+        }
+      },
+      "required": [
+        "queries"
       ]
     },
     "outputSchema": {
@@ -832,7 +1719,7 @@
   },
   {
     "name": "get_string",
-    "description": "Read strings from memory addresses",
+    "description": "Read NUL-terminated strings at one or more addresses.\n\n    Use when you have a pointer from decompiler output; to search for a string\n    by content use find(type=\"string\") instead.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -863,8 +1750,335 @@
     }
   },
   {
-    "name": "get_global_value",
-    "description": "Read global variable values by address or name\n    (auto-detects hex addresses vs names)",
+    "name": "idb_save",
+    "description": "Save active IDB to disk, with no dialogs. Call after renaming, retyping,\n    or commenting to persist changes. Optionally specify a custom output path\n    to write a copy instead, leaving the open database untouched.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Optional destination path (default: current IDB path)"
+        }
+      },
+      "required": []
+    },
+    "outputSchema": {
+      "type": "object"
+    }
+  },
+  {
+    "name": "imports",
+    "description": "List imported functions grouped by source module.\n\n    Useful early: the import set is a fast signal of what a binary can do\n    (networking, crypto, process injection) before you decompile anything.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "offset": {
+          "type": "integer",
+          "description": "Offset"
+        },
+        "count": {
+          "type": "integer",
+          "description": "Count (0=all)"
+        }
+      },
+      "required": [
+        "offset",
+        "count"
+      ]
+    },
+    "outputSchema": {
+      "type": "object"
+    }
+  },
+  {
+    "name": "imports_query",
+    "description": "Query imports with module and name filters. Example:\n    {module: 'kernel32', filter: '*File*'} to find all kernel32 file I/O imports.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "queries": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "description": "Import query: filter (import name pattern), module (module name pattern), offset, count"
+        }
+      },
+      "required": [
+        "queries"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "infer_types",
+    "description": "Infer the type of data or a function at an address.\n\n    Asks Hex-Rays first and falls back to IDA's own guess. Returns the inferred\n    type plus a confidence label; a null type means neither could decide.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "addrs": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Addresses to infer types for"
+        }
+      },
+      "required": [
+        "addrs"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "insn_query",
+    "description": "Search instructions by mnemonic and/or operand values within a function,\n    segment, or global scope. Uses existing scan infrastructure.\n    Example: {mnem: 'call', func: '0x401000'} or {mnem: 'syscall'}",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "queries": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "description": "Instruction pattern: mnem, op0, op1, op2, op_any, func, segment, offset, count"
+        }
+      },
+      "required": [
+        "queries"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "int_convert",
+    "description": "Convert numbers between hex, decimal, binary and ASCII, in batch.\n\n    Pure computation — no IDB access, so it needs no instance state.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "inputs": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "description": "Number string to convert"
+                  },
+                  "size": {
+                    "type": "integer",
+                    "description": "Byte size for conversion (omit for auto)"
+                  }
+                },
+                "required": [],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "text": {
+                  "type": "string",
+                  "description": "Number string to convert"
+                },
+                "size": {
+                  "type": "integer",
+                  "description": "Byte size for conversion (omit for auto)"
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            }
+          ],
+          "description": "Convert numbers to various formats (hex, decimal, binary, ascii)"
+        }
+      },
+      "required": [
+        "inputs"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "list_funcs",
+    "description": "List functions in the binary, paginated.\n\n    Requires auto-analysis to be finished — call analysis_wait() first on a\n    freshly opened binary or this returns a partial list. On large binaries use\n    count/offset rather than fetching everything; count=0 with a glob filter is\n    a full scan.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "queries": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "filter": {
+                    "type": "string",
+                    "description": "Optional glob pattern to filter results"
+                  },
+                  "offset": {
+                    "type": "integer",
+                    "description": "Starting index (default: 0)"
+                  },
+                  "count": {
+                    "type": "integer",
+                    "description": "Maximum number of results (default: 50, 0 for all)"
+                  }
+                },
+                "required": [],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "filter": {
+                  "type": "string",
+                  "description": "Optional glob pattern to filter results"
+                },
+                "offset": {
+                  "type": "integer",
+                  "description": "Starting index (default: 0)"
+                },
+                "count": {
+                  "type": "integer",
+                  "description": "Maximum number of results (default: 50, 0 for all)"
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "List functions with optional filtering and pagination"
+        }
+      },
+      "required": [
+        "queries"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "list_globals",
+    "description": "List global variables (non-function named addresses), paginated.\n\n    Requires auto-analysis to be finished — call analysis_wait() first on a\n    freshly opened binary or names will still be missing.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "queries": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "filter": {
+                    "type": "string",
+                    "description": "Optional glob pattern to filter results"
+                  },
+                  "offset": {
+                    "type": "integer",
+                    "description": "Starting index (default: 0)"
+                  },
+                  "count": {
+                    "type": "integer",
+                    "description": "Maximum number of results (default: 50, 0 for all)"
+                  }
+                },
+                "required": [],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "filter": {
+                  "type": "string",
+                  "description": "Optional glob pattern to filter results"
+                },
+                "offset": {
+                  "type": "integer",
+                  "description": "Starting index (default: 0)"
+                },
+                "count": {
+                  "type": "integer",
+                  "description": "Maximum number of results (default: 50, 0 for all)"
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "List global variables with optional filtering and pagination"
+        }
+      },
+      "required": [
+        "queries"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "lookup_funcs",
+    "description": "Resolve functions by address or by name; the form is auto-detected.\n\n    Accepts 0x-prefixed addresses, sub_XXXX names, or real symbol names. Use\n    this to turn a name from decompiler output into an address to work with.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -880,7 +2094,7 @@
               "type": "string"
             }
           ],
-          "description": "Global variable addresses or names to read values from"
+          "description": "Address(es) or name(s)"
         }
       },
       "required": [
@@ -946,6 +2160,67 @@
       },
       "required": [
         "patches"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "patch_asm",
+    "description": "Patch assembly instructions at addresses",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string",
+                    "description": "Address (hex or decimal)"
+                  },
+                  "asm": {
+                    "type": "string",
+                    "description": "Assembly instruction(s), semicolon-separated"
+                  }
+                },
+                "required": [
+                  "addr",
+                  "asm"
+                ],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "addr": {
+                  "type": "string",
+                  "description": "Address (hex or decimal)"
+                },
+                "asm": {
+                  "type": "string",
+                  "description": "Assembly instruction(s), semicolon-separated"
+                }
+              },
+              "required": [
+                "addr",
+                "asm"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": [
+        "items"
       ]
     },
     "outputSchema": {
@@ -1028,35 +2303,22 @@
     }
   },
   {
-    "name": "declare_type",
-    "description": "Declare types",
+    "name": "py_eval",
+    "description": "Execute Python code in IDA context.\n    Returns dict with result/stdout/stderr.\n    Has access to all IDA API modules.\n    Supports Jupyter-style evaluation.",
     "inputSchema": {
       "type": "object",
       "properties": {
-        "decls": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "description": "C type declarations"
+        "code": {
+          "type": "string",
+          "description": "Python code"
         }
       },
       "required": [
-        "decls"
+        "code"
       ]
     },
     "outputSchema": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
+      "type": "object"
     }
   },
   {
@@ -1115,260 +2377,15 @@
     }
   },
   {
-    "name": "search_structs",
-    "description": "Search structs",
+    "name": "refresh_caches",
+    "description": "Force-refresh all caches (strings, functions, globals).",
     "inputSchema": {
       "type": "object",
-      "properties": {
-        "filter": {
-          "type": "string",
-          "description": "Case-insensitive substring to search for in structure names"
-        }
-      },
-      "required": [
-        "filter"
-      ]
+      "properties": {},
+      "required": []
     },
     "outputSchema": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
-    }
-  },
-  {
-    "name": "set_type",
-    "description": "Apply types (function/global/local/stack)",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "edits": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "addr": {
-                    "type": "string",
-                    "description": "Memory address"
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "Variable/function name"
-                  },
-                  "ty": {
-                    "type": "string",
-                    "description": "Type name or declaration"
-                  },
-                  "kind": {
-                    "type": "string",
-                    "description": "Type of entity (auto-detected if omitted)"
-                  },
-                  "signature": {
-                    "type": "string",
-                    "description": "Function signature (for kind=function)"
-                  },
-                  "variable": {
-                    "type": "string",
-                    "description": "Local variable name (for kind=local)"
-                  }
-                },
-                "required": [],
-                "additionalProperties": false
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
-                "addr": {
-                  "type": "string",
-                  "description": "Memory address"
-                },
-                "name": {
-                  "type": "string",
-                  "description": "Variable/function name"
-                },
-                "ty": {
-                  "type": "string",
-                  "description": "Type name or declaration"
-                },
-                "kind": {
-                  "type": "string",
-                  "description": "Type of entity (auto-detected if omitted)"
-                },
-                "signature": {
-                  "type": "string",
-                  "description": "Function signature (for kind=function)"
-                },
-                "variable": {
-                  "type": "string",
-                  "description": "Local variable name (for kind=local)"
-                }
-              },
-              "required": [],
-              "additionalProperties": false
-            }
-          ]
-        }
-      },
-      "required": [
-        "edits"
-      ]
-    },
-    "outputSchema": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
-    }
-  },
-  {
-    "name": "infer_types",
-    "description": "Infer types",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "addrs": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "description": "Addresses to infer types for"
-        }
-      },
-      "required": [
-        "addrs"
-      ]
-    },
-    "outputSchema": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
-    }
-  },
-  {
-    "name": "set_comments",
-    "description": "Set comments at addresses (both disassembly and decompiler views)",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "items": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "addr": {
-                    "type": "string",
-                    "description": "Address (hex or decimal)"
-                  },
-                  "comment": {
-                    "type": "string",
-                    "description": "Comment text"
-                  }
-                },
-                "required": [
-                  "addr",
-                  "comment"
-                ],
-                "additionalProperties": false
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
-                "addr": {
-                  "type": "string",
-                  "description": "Address (hex or decimal)"
-                },
-                "comment": {
-                  "type": "string",
-                  "description": "Comment text"
-                }
-              },
-              "required": [
-                "addr",
-                "comment"
-              ],
-              "additionalProperties": false
-            }
-          ]
-        }
-      },
-      "required": [
-        "items"
-      ]
-    }
-  },
-  {
-    "name": "patch_asm",
-    "description": "Patch assembly instructions at addresses",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "items": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "addr": {
-                    "type": "string",
-                    "description": "Address (hex or decimal)"
-                  },
-                  "asm": {
-                    "type": "string",
-                    "description": "Assembly instruction(s), semicolon-separated"
-                  }
-                },
-                "required": [
-                  "addr",
-                  "asm"
-                ],
-                "additionalProperties": false
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
-                "addr": {
-                  "type": "string",
-                  "description": "Address (hex or decimal)"
-                },
-                "asm": {
-                  "type": "string",
-                  "description": "Assembly instruction(s), semicolon-separated"
-                }
-              },
-              "required": [
-                "addr",
-                "asm"
-              ],
-              "additionalProperties": false
-            }
-          ]
-        }
-      },
-      "required": [
-        "items"
-      ]
-    },
-    "outputSchema": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
+      "type": "object"
     }
   },
   {
@@ -1602,8 +2619,67 @@
     }
   },
   {
-    "name": "append_comments",
-    "description": "Append comments at addresses, deduping exact text by default. Unlike\n    set_comments (which overwrites), this preserves existing annotations \u2014 use\n    it for incremental commentary. scope='auto' (default) writes a function\n    comment when addr is a function start, otherwise a line comment; force\n    with scope='func' or 'line'. dedupe=True skips writes when the exact\n    stripped text already appears on its own line.",
+    "name": "search_structs",
+    "description": "Find structures whose name contains a substring (case-insensitive).\n\n    Returns name, size and field count. Use read_struct to see the fields or to\n    overlay the struct on an address.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "filter": {
+          "type": "string",
+          "description": "Case-insensitive substring to search for in structure names"
+        }
+      },
+      "required": [
+        "filter"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "server_health",
+    "description": "Health/ready probe for MCP server and current IDB state. Returns\n    uptime, IDB path, auto-analysis status, Hex-Rays availability, and\n    strings cache state.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    },
+    "outputSchema": {
+      "type": "object"
+    }
+  },
+  {
+    "name": "server_warmup",
+    "description": "Warm up IDA subsystems to reduce first-call latency. Call after\n    connecting to a new instance to ensure analysis is complete and caches\n    are populated before running tools.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "wait_auto_analysis": {
+          "type": "boolean",
+          "description": "Wait for auto analysis queue"
+        },
+        "build_caches": {
+          "type": "boolean",
+          "description": "Build core caches (currently strings)"
+        },
+        "init_hexrays": {
+          "type": "boolean",
+          "description": "Initialize Hex-Rays decompiler plugin"
+        }
+      },
+      "required": []
+    },
+    "outputSchema": {
+      "type": "object"
+    }
+  },
+  {
+    "name": "set_comments",
+    "description": "Set comments at addresses (both disassembly and decompiler views)",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1620,15 +2696,7 @@
                   },
                   "comment": {
                     "type": "string",
-                    "description": "Comment text to append"
-                  },
-                  "scope": {
-                    "type": "string",
-                    "description": "auto|func|line (default: auto)"
-                  },
-                  "dedupe": {
-                    "type": "boolean",
-                    "description": "Skip if exact text already exists (default: true)"
+                    "description": "Comment text"
                   }
                 },
                 "required": [
@@ -1647,15 +2715,7 @@
                 },
                 "comment": {
                   "type": "string",
-                  "description": "Comment text to append"
-                },
-                "scope": {
-                  "type": "string",
-                  "description": "auto|func|line (default: auto)"
-                },
-                "dedupe": {
-                  "type": "boolean",
-                  "description": "Skip if exact text already exists (default: true)"
+                  "description": "Comment text"
                 }
               },
               "required": [
@@ -1670,40 +2730,15 @@
       "required": [
         "items"
       ]
-    },
-    "outputSchema": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "addr": {
-            "type": "string"
-          },
-          "scope": {
-            "type": "string"
-          },
-          "appended": {
-            "type": "boolean"
-          },
-          "skipped": {
-            "type": "boolean"
-          },
-          "error": {
-            "type": "string"
-          }
-        },
-        "required": [],
-        "additionalProperties": false
-      }
     }
   },
   {
-    "name": "define_func",
-    "description": "Define a function at each given address. IDA infers bounds unless an\n    explicit end address is provided. Returns {addr, start, end} on success or\n    {addr, start, error} if the function already exists or add_func fails.\n    Use this when IDA auto-analysis missed a function entry point.",
+    "name": "set_type",
+    "description": "Apply types (function/global/local/stack)",
     "inputSchema": {
       "type": "object",
       "properties": {
-        "items": {
+        "edits": {
           "anyOf": [
             {
               "type": "array",
@@ -1712,11 +2747,27 @@
                 "properties": {
                   "addr": {
                     "type": "string",
-                    "description": "Address to define (hex or decimal)"
+                    "description": "Memory address"
                   },
-                  "end": {
+                  "name": {
                     "type": "string",
-                    "description": "Optional end address for explicit bounds"
+                    "description": "Variable/function name"
+                  },
+                  "ty": {
+                    "type": "string",
+                    "description": "Type name or declaration"
+                  },
+                  "kind": {
+                    "type": "string",
+                    "description": "Type of entity (auto-detected if omitted)"
+                  },
+                  "signature": {
+                    "type": "string",
+                    "description": "Function signature (for kind=function)"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "description": "Local variable name (for kind=local)"
                   }
                 },
                 "required": [],
@@ -1728,11 +2779,27 @@
               "properties": {
                 "addr": {
                   "type": "string",
-                  "description": "Address to define (hex or decimal)"
+                  "description": "Memory address"
                 },
-                "end": {
+                "name": {
                   "type": "string",
-                  "description": "Optional end address for explicit bounds"
+                  "description": "Variable/function name"
+                },
+                "ty": {
+                  "type": "string",
+                  "description": "Type name or declaration"
+                },
+                "kind": {
+                  "type": "string",
+                  "description": "Type of entity (auto-detected if omitted)"
+                },
+                "signature": {
+                  "type": "string",
+                  "description": "Function signature (for kind=function)"
+                },
+                "variable": {
+                  "type": "string",
+                  "description": "Local variable name (for kind=local)"
                 }
               },
               "required": [],
@@ -1742,212 +2809,19 @@
         }
       },
       "required": [
-        "items"
+        "edits"
       ]
     },
     "outputSchema": {
       "type": "array",
       "items": {
-        "type": "object",
-        "properties": {
-          "addr": {
-            "type": "string"
-          },
-          "ea": {
-            "type": "string"
-          },
-          "start": {
-            "type": "string"
-          },
-          "end": {
-            "type": "string"
-          },
-          "size": {
-            "type": "integer"
-          },
-          "length": {
-            "type": "integer"
-          },
-          "error": {
-            "type": "string"
-          }
-        },
-        "required": [],
-        "additionalProperties": false
-      }
-    }
-  },
-  {
-    "name": "define_code",
-    "description": "Convert raw bytes to a code instruction at each given address. Returns\n    {addr, ea, length} on success (length is the instruction byte length) or\n    {addr, ea, error} if create_insn failed. Use this when IDA classified an\n    instruction as data or failed to decode.",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "items": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "addr": {
-                    "type": "string",
-                    "description": "Address to define (hex or decimal)"
-                  },
-                  "end": {
-                    "type": "string",
-                    "description": "Optional end address for explicit bounds"
-                  }
-                },
-                "required": [],
-                "additionalProperties": false
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
-                "addr": {
-                  "type": "string",
-                  "description": "Address to define (hex or decimal)"
-                },
-                "end": {
-                  "type": "string",
-                  "description": "Optional end address for explicit bounds"
-                }
-              },
-              "required": [],
-              "additionalProperties": false
-            }
-          ]
-        }
-      },
-      "required": [
-        "items"
-      ]
-    },
-    "outputSchema": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "addr": {
-            "type": "string"
-          },
-          "ea": {
-            "type": "string"
-          },
-          "start": {
-            "type": "string"
-          },
-          "end": {
-            "type": "string"
-          },
-          "size": {
-            "type": "integer"
-          },
-          "length": {
-            "type": "integer"
-          },
-          "error": {
-            "type": "string"
-          }
-        },
-        "required": [],
-        "additionalProperties": false
-      }
-    }
-  },
-  {
-    "name": "undefine",
-    "description": "Undefine item(s) at each address, converting them back to raw bytes.\n    Size is determined from `end` (exclusive) or `size`; defaults to 1 byte.\n    Uses ida_bytes.DELIT_EXPAND so adjacent items spanning into the range are\n    fully removed. Returns {addr, start, size} on success.",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "items": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "addr": {
-                    "type": "string",
-                    "description": "Address to undefine (hex or decimal)"
-                  },
-                  "end": {
-                    "type": "string",
-                    "description": "Optional end address"
-                  },
-                  "size": {
-                    "type": "integer",
-                    "description": "Optional size in bytes"
-                  }
-                },
-                "required": [],
-                "additionalProperties": false
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
-                "addr": {
-                  "type": "string",
-                  "description": "Address to undefine (hex or decimal)"
-                },
-                "end": {
-                  "type": "string",
-                  "description": "Optional end address"
-                },
-                "size": {
-                  "type": "integer",
-                  "description": "Optional size in bytes"
-                }
-              },
-              "required": [],
-              "additionalProperties": false
-            }
-          ]
-        }
-      },
-      "required": [
-        "items"
-      ]
-    },
-    "outputSchema": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "addr": {
-            "type": "string"
-          },
-          "ea": {
-            "type": "string"
-          },
-          "start": {
-            "type": "string"
-          },
-          "end": {
-            "type": "string"
-          },
-          "size": {
-            "type": "integer"
-          },
-          "length": {
-            "type": "integer"
-          },
-          "error": {
-            "type": "string"
-          }
-        },
-        "required": [],
-        "additionalProperties": false
+        "type": "object"
       }
     }
   },
   {
     "name": "stack_frame",
-    "description": "Get stack vars",
+    "description": "List the stack frame variables of one or more functions.\n\n    Returns each local's name, offset, size and type — the frame layout behind\n    the var_NN names in decompiler output.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1978,157 +2852,8 @@
     }
   },
   {
-    "name": "declare_stack",
-    "description": "Create stack vars",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "items": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "addr": {
-                    "type": "string",
-                    "description": "Function address"
-                  },
-                  "offset": {
-                    "type": "string",
-                    "description": "Stack offset"
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "Variable name"
-                  },
-                  "ty": {
-                    "type": "string",
-                    "description": "Type name"
-                  }
-                },
-                "required": [
-                  "addr",
-                  "offset",
-                  "name",
-                  "ty"
-                ],
-                "additionalProperties": false
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
-                "addr": {
-                  "type": "string",
-                  "description": "Function address"
-                },
-                "offset": {
-                  "type": "string",
-                  "description": "Stack offset"
-                },
-                "name": {
-                  "type": "string",
-                  "description": "Variable name"
-                },
-                "ty": {
-                  "type": "string",
-                  "description": "Type name"
-                }
-              },
-              "required": [
-                "addr",
-                "offset",
-                "name",
-                "ty"
-              ],
-              "additionalProperties": false
-            }
-          ]
-        }
-      },
-      "required": [
-        "items"
-      ]
-    }
-  },
-  {
-    "name": "delete_stack",
-    "description": "Delete stack vars",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "items": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "addr": {
-                    "type": "string",
-                    "description": "Function address"
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "Variable name"
-                  }
-                },
-                "required": [
-                  "addr",
-                  "name"
-                ],
-                "additionalProperties": false
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
-                "addr": {
-                  "type": "string",
-                  "description": "Function address"
-                },
-                "name": {
-                  "type": "string",
-                  "description": "Variable name"
-                }
-              },
-              "required": [
-                "addr",
-                "name"
-              ],
-              "additionalProperties": false
-            }
-          ]
-        }
-      },
-      "required": [
-        "items"
-      ]
-    }
-  },
-  {
-    "name": "py_eval",
-    "description": "Execute Python code in IDA context.\n    Returns dict with result/stdout/stderr.\n    Has access to all IDA API modules.\n    Supports Jupyter-style evaluation.",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "code": {
-          "type": "string",
-          "description": "Python code"
-        }
-      },
-      "required": [
-        "code"
-      ]
-    },
-    "outputSchema": {
-      "type": "object"
-    }
-  },
-  {
     "name": "survey_binary",
-    "description": "Get a compact overview of the binary in one call. Returns file metadata,\n    segment layout, entry points, statistics, top 15 strings and functions ranked\n    by xref count (functions include classification: thunk/wrapper/leaf/dispatcher/\n    complex), imports by category, and call graph summary. Use this as your FIRST\n    tool call when starting analysis. Do not call list_funcs, imports, or find_regex\n    separately for triage \u2014 this returns all of that. Use detail_level='minimal'\n    for binaries with >10k functions.",
+    "description": "Get a compact overview of the binary in one call. Returns file metadata,\n    segment layout, entry points, statistics, top 15 strings and functions ranked\n    by xref count (functions include classification: thunk/wrapper/leaf/dispatcher/\n    complex), imports by category, and call graph summary. Use this as your FIRST\n    tool call when starting analysis. Do not call list_funcs, imports, or find_regex\n    separately for triage — this returns all of that. Use detail_level='minimal'\n    for binaries with >10k functions.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -2510,376 +3235,8 @@
     }
   },
   {
-    "name": "analyze_function",
-    "description": "Compact single-function analysis: pseudocode (capped at 100 lines), top\n    strings, top non-trivial constants, callers, callees, xrefs, comments, and\n    basic block summary. Use this for \"tell me everything about function X\" in\n    one call instead of chaining decompile + callees + xrefs_to separately.",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "addr": {
-          "type": "string",
-          "description": "Function address or name"
-        },
-        "include_asm": {
-          "type": "boolean",
-          "description": "Include full disassembly (default: false, saves tokens)"
-        }
-      },
-      "required": [
-        "addr"
-      ]
-    },
-    "outputSchema": {
-      "type": "object",
-      "properties": {
-        "addr": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "prototype": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "size": {
-          "type": "integer"
-        },
-        "decompiled": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "decompile_truncated": {
-          "type": "integer"
-        },
-        "assembly": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "strings": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "constants": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object"
-            }
-          }
-        },
-        "callees": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "callers": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "xrefs": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "object"
-          }
-        },
-        "comments": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "object"
-          }
-        },
-        "basic_blocks": {
-          "type": "object",
-          "properties": {
-            "count": {
-              "type": "integer"
-            },
-            "cyclomatic_complexity": {
-              "type": "integer"
-            }
-          },
-          "required": [
-            "count",
-            "cyclomatic_complexity"
-          ],
-          "additionalProperties": false
-        },
-        "error": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "required": [],
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "analyze_component",
-    "description": "Analyze related functions as a group: per-function compact summaries,\n    internal call graph (edges only between supplied functions), shared globals,\n    interface vs internal classification, and strings used by multiple members.",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "addrs": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "description": "Function addresses (comma-separated or list)"
-        }
-      },
-      "required": [
-        "addrs"
-      ]
-    },
-    "outputSchema": {
-      "type": "object",
-      "properties": {
-        "functions": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "addr": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "prototype": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "size": {
-                "type": "integer"
-              },
-              "callees": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "strings": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "basic_blocks": {
-                "type": "integer"
-              },
-              "complexity": {
-                "type": "integer"
-              },
-              "error": {
-                "type": "string"
-              }
-            },
-            "required": [],
-            "additionalProperties": false
-          }
-        },
-        "internal_call_graph": {
-          "type": "object",
-          "properties": {
-            "nodes": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "edges": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "from": {
-                    "type": "string"
-                  },
-                  "to": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "from",
-                  "to",
-                  "name"
-                ],
-                "additionalProperties": false
-              }
-            }
-          },
-          "required": [
-            "nodes",
-            "edges"
-          ],
-          "additionalProperties": false
-        },
-        "shared_globals": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "addr": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "accessed_by": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": [
-              "addr",
-              "name",
-              "accessed_by"
-            ],
-            "additionalProperties": false
-          }
-        },
-        "interface_functions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "internal_only": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "string_usage": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "error": {
-          "type": "string"
-        }
-      },
-      "required": [],
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "diff_before_after",
-    "description": "Apply a rename/type/comment action and return the before/after decompilation\n    side by side. Actions: 'rename_func' ({name}), 'set_type' ({type}),\n    'set_comment' ({comment}). Useful to verify a rename or type change actually\n    improved readability. Returns {before, after, action_applied, changes_detected}.",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "addr": {
-          "type": "string",
-          "description": "Function address"
-        },
-        "action": {
-          "type": "string",
-          "description": "Action: 'rename_func', 'set_type', 'set_comment'"
-        },
-        "action_args": {
-          "type": "object",
-          "description": "Arguments for the action"
-        }
-      },
-      "required": [
-        "addr",
-        "action",
-        "action_args"
-      ]
-    },
-    "outputSchema": {
-      "type": "object",
-      "properties": {
-        "before": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "after": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "action_applied": {
-          "type": "string"
-        },
-        "changes_detected": {
-          "type": "boolean"
-        },
-        "error": {
-          "type": "string"
-        }
-      },
-      "required": [],
-      "additionalProperties": false
-    }
-  },
-  {
     "name": "trace_data_flow",
-    "description": "Follow cross-references from or to an address, automatically traversing\n    multiple hops. 'forward' follows xrefs-from, 'backward' follows xrefs-to.\n    Returns nodes (with function name, instruction, code/data classification) and\n    edges. Do not use for call graph traversal \u2014 use callgraph for that.",
+    "description": "Follow cross-references from or to an address, automatically traversing\n    multiple hops. 'forward' follows xrefs-from, 'backward' follows xrefs-to.\n    Returns nodes (with function name, instruction, code/data classification) and\n    edges. Do not use for call graph traversal — use callgraph for that.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -3000,8 +3357,128 @@
     }
   },
   {
-    "name": "func_features",
-    "description": "Extract name-independent similarity features for functions, page by page. Per function: size, is_named, CFG metrics (bb/edge/complexity/loops/callee/caller counts + out-degree sequence), a 64-perm instruction-shingle MinHash, external API (import) callees, referenced strings, non-trivial immediate constants, and (named functions only) pseudocode identifier tokens. Use '*' for all functions; only the page slice is analyzed so large binaries stay bounded.",
+    "name": "undefine",
+    "description": "Undefine item(s) at each address, converting them back to raw bytes.\n    Size is determined from `end` (exclusive) or `size`; defaults to 1 byte.\n    Uses ida_bytes.DELIT_EXPAND so adjacent items spanning into the range are\n    fully removed. Returns {addr, start, size} on success.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "addr": {
+                    "type": "string",
+                    "description": "Address to undefine (hex or decimal)"
+                  },
+                  "end": {
+                    "type": "string",
+                    "description": "Optional end address"
+                  },
+                  "size": {
+                    "type": "integer",
+                    "description": "Optional size in bytes"
+                  }
+                },
+                "required": [],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "addr": {
+                  "type": "string",
+                  "description": "Address to undefine (hex or decimal)"
+                },
+                "end": {
+                  "type": "string",
+                  "description": "Optional end address"
+                },
+                "size": {
+                  "type": "integer",
+                  "description": "Optional size in bytes"
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": [
+        "items"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "addr": {
+            "type": "string"
+          },
+          "ea": {
+            "type": "string"
+          },
+          "start": {
+            "type": "string"
+          },
+          "end": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "length": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [],
+        "additionalProperties": false
+      }
+    }
+  },
+  {
+    "name": "xref_query",
+    "description": "Query cross-references with direction and type filters.\n    direction='to' finds refs TO addr, 'from' finds refs FROM addr, 'both' finds all.\n    type_filter='code' shows only code xrefs, 'data' only data, 'all' shows both.\n    Supports dedup and pagination.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "queries": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "description": "Xref query: addr, direction (to/from/both), type_filter (code/data/all), offset, count"
+        }
+      },
+      "required": [
+        "queries"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "xrefs_from",
+    "description": "Get cross-references from specified addresses (symmetric with xrefs_to).\n    Returns outgoing code and data references for each address.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -3017,38 +3494,27 @@
               "type": "string"
             }
           ],
-          "description": "Function addresses (comma-separated or list), or '*' for all"
+          "description": "Addresses to find cross-references from"
         },
-        "offset": {
+        "limit": {
           "type": "integer",
-          "description": "Skip first N functions (default: 0)"
-        },
-        "count": {
-          "type": "integer",
-          "description": "Max functions per page (default: 500, max: 2000)"
+          "description": "Max xrefs per address (default: 100, max: 1000)"
         }
       },
-      "required": []
+      "required": [
+        "addrs"
+      ]
     },
     "outputSchema": {
-      "type": "object"
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
     }
   },
   {
-    "name": "binary_fingerprint",
-    "description": "Content fingerprint of the loaded binary for similarity index keying: input file sha256 and md5 (hex, or null if unavailable), total function count, and an arch label (e.g. 'x86_64').",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    },
-    "outputSchema": {
-      "type": "object"
-    }
-  },
-  {
-    "name": "func_tokens",
-    "description": "Emit jTrans-style normalized instruction token streams per function (for a neural BCSD embedding backend), page by page. Uses IDA's operand normalization: registers kept, immediates/displacements -> CONST, stack vars -> var_xxx/arg_xxx, intra-function jumps -> JUMP_ADDR_<idx>. Use '*' for all functions; only the page slice is analyzed. Returns {addr: [token, ...]}.",
+    "name": "xrefs_to",
+    "description": "Get cross-references to specified addresses",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -3064,21 +3530,87 @@
               "type": "string"
             }
           ],
-          "description": "Function addresses (comma-separated or list), or '*' for all"
+          "description": "Addresses to find cross-references to"
         },
-        "offset": {
+        "limit": {
           "type": "integer",
-          "description": "Skip first N functions (default: 0)"
-        },
-        "count": {
-          "type": "integer",
-          "description": "Max functions per page (default: 500, max: 2000)"
+          "description": "Max xrefs per address (default: 100, max: 1000)"
         }
       },
-      "required": []
+      "required": [
+        "addrs"
+      ]
     },
     "outputSchema": {
-      "type": "object"
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  {
+    "name": "xrefs_to_field",
+    "description": "Get cross-references to structure fields",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "queries": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "struct": {
+                    "type": "string",
+                    "description": "Structure name"
+                  },
+                  "field": {
+                    "type": "string",
+                    "description": "Field name"
+                  }
+                },
+                "required": [
+                  "struct",
+                  "field"
+                ],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "struct": {
+                  "type": "string",
+                  "description": "Structure name"
+                },
+                "field": {
+                  "type": "string",
+                  "description": "Field name"
+                }
+              },
+              "required": [
+                "struct",
+                "field"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Max xrefs per field (default: 100, max: 1000)"
+        }
+      },
+      "required": [
+        "queries"
+      ]
+    },
+    "outputSchema": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
     }
   }
 ]

--- a/src/ida_multi_mcp/idalib_manager.py
+++ b/src/ida_multi_mcp/idalib_manager.py
@@ -58,7 +58,7 @@ def _resolve_ida_dir() -> str | None:
         cfg_path = os.path.join(os.path.expanduser("~"), ".idapro", "ida-config.json")
     try:
         import json
-        with open(cfg_path, "r") as f:
+        with open(cfg_path, "r", encoding="utf-8") as f:
             cfg = json.load(f)
         d = cfg.get("Paths", {}).get("ida-install-dir", "").strip()
         if d and os.path.isdir(d):

--- a/src/ida_multi_mcp/plugin/ida_multi_mcp.py
+++ b/src/ida_multi_mcp/plugin/ida_multi_mcp.py
@@ -85,6 +85,22 @@ class IdaMultiMcpPlugin(idaapi.plugin_t):
         else:
             print("[ida-multi-mcp] Plugin loaded (headless mode, server managed externally)")
 
+        # IDA 9.0 SP0 (build 240925) dropped Python API methods that 8.5 added
+        # and 9.0 SP1 restored. Say so here rather than letting individual tools
+        # fail with an opaque AttributeError halfway through a call.
+        try:
+            from ida_multi_mcp.ida_mcp import compat
+
+            missing = compat.missing_required_apis()
+            if missing:
+                print(
+                    f"[ida-multi-mcp] WARNING: IDA {idaapi.get_kernel_version()} is missing "
+                    f"{', '.join(missing)}. Some tools will fail. "
+                    f"If this is IDA 9.0, upgrade to 9.0 SP1 (build 241217) or later."
+                )
+        except Exception:
+            pass  # never block plugin load on the version probe itself
+
         # Install hooks for database lifecycle events
         self.idb_hooks = IdbHooks(self)
         self.ui_hooks = UiHooks(self)

--- a/src/ida_multi_mcp/registry.py
+++ b/src/ida_multi_mcp/registry.py
@@ -196,7 +196,7 @@ class InstanceRegistry:
         if cached is not None:
             return cached
         try:
-            with open(self.registry_path, "r") as f:
+            with open(self.registry_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
             if not isinstance(data, dict):
                 raise ValueError("Registry root must be an object")
@@ -240,7 +240,7 @@ class InstanceRegistry:
                 suffix=".tmp",
                 dir=os.path.dirname(self.registry_path),
             )
-            with os.fdopen(temp_fd, 'w') as f:
+            with os.fdopen(temp_fd, 'w', encoding='utf-8') as f:
                 temp_fd = None  # fdopen takes ownership of fd
                 json.dump(data, f, indent=2)
 

--- a/src/ida_multi_mcp/server.py
+++ b/src/ida_multi_mcp/server.py
@@ -46,11 +46,13 @@ WORKFLOW — follow this order when you start on a binary:
 
 1. `list_instances()` to see what is loaded and get each `instance_id`.
 2. `analysis_wait(instance_id=...)` BEFORE any analysis work on a newly opened
-   binary. IDA analyses in the background, and until it finishes the function
-   list, xrefs, strings and decompiler output are all INCOMPLETE. On a mid-sized
-   DLL this is routinely thousands of missing functions, not a rounding error.
-   Use `analysis_status()` for a non-blocking check. If `analysis_wait` returns
-   `finished: false` it timed out rather than failed — call it again.
+   binary. IDA analyses in the background, and until it settles the function
+   list, xrefs, strings and decompiler output are all INCOMPLETE — on a 23MB DLL
+   that was 12,885 missing functions, not a rounding error. If it returns
+   `finished: false` it timed out rather than failed, so call it again. Treat
+   `finished` as a snapshot rather than a latch: IDA re-queues work, so the flag
+   can flip back. `functions_added` reaching 0 across successive calls is the
+   durable signal. `analysis_status()` is the non-blocking check.
 3. `survey_binary(instance_id=...)` for a one-call overview before drilling in.
 
 ROUTING — pass `instance_id` on every tool call. It is required whenever two or
@@ -707,12 +709,15 @@ class IdaMultiMcpServer:
         cache["analysis_wait"] = {
             "name": "analysis_wait",
             "description": (
-                "Block until IDA's auto-analysis finishes on an instance, then return. "
-                "CALL THIS ONCE AFTER OPENING A BINARY, BEFORE ANY ANALYSIS WORK: until it "
-                "reports finished, the function list, xrefs, strings and decompiler output "
-                "are all incomplete. If it returns finished=false the wait timed out rather "
-                "than failed - call it again to keep waiting. Returns the elapsed wait and "
-                "how many functions appeared meanwhile, so you can see analysis progressing. "
+                "Drive IDA's auto-analysis to completion on an instance, then return. "
+                "CALL THIS ONCE AFTER OPENING A BINARY, BEFORE ANY ANALYSIS WORK: until "
+                "analysis settles, the function list, xrefs, strings and decompiler output "
+                "are all incomplete - on a 23MB DLL that was 12,885 functions missing. "
+                "If it returns finished=false the wait timed out rather than failed - call "
+                "it again to keep waiting. NOTE finished reflects IDA's instantaneous "
+                "'queues empty' flag, not a permanent latch, so it can read true and then "
+                "false again; functions_added reaching 0 across successive calls is the "
+                "more durable signal that analysis has settled. "
                 "Use analysis_status() for a non-blocking check."
             ),
             "inputSchema": {

--- a/src/ida_multi_mcp/server.py
+++ b/src/ida_multi_mcp/server.py
@@ -263,6 +263,14 @@ class IdaMultiMcpServer:
                         "isError": True
                     }
 
+            elif name == "analysis_wait":
+                result = management.analysis_wait(arguments)
+                return {
+                    "content": [{"type": "text", "text": _json_text(result)}],
+                    "structuredContent": result,
+                    "isError": "error" in result,
+                }
+
             elif name == "compare_binaries":
                 result = management.compare_binaries(arguments)
                 return {
@@ -694,6 +702,30 @@ class IdaMultiMcpServer:
                 "properties": {},
                 "required": []
             }
+        }
+
+        cache["analysis_wait"] = {
+            "name": "analysis_wait",
+            "description": (
+                "Block until IDA's auto-analysis finishes on an instance, then return. "
+                "CALL THIS ONCE AFTER OPENING A BINARY, BEFORE ANY ANALYSIS WORK: until it "
+                "reports finished, the function list, xrefs, strings and decompiler output "
+                "are all incomplete. If it returns finished=false the wait timed out rather "
+                "than failed - call it again to keep waiting. Returns the elapsed wait and "
+                "how many functions appeared meanwhile, so you can see analysis progressing. "
+                "Use analysis_status() for a non-blocking check."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "instance_id": {"type": "string", "description": "Target IDA instance ID (required)"},
+                    "timeout_sec": {
+                        "type": "number",
+                        "description": "Seconds to wait before returning (default 120, max 600)",
+                    },
+                },
+                "required": ["instance_id"],
+            },
         }
 
         cache["compare_binaries"] = {

--- a/src/ida_multi_mcp/server.py
+++ b/src/ida_multi_mcp/server.py
@@ -30,7 +30,7 @@ def _load_static_ida_tools() -> list[dict]:
     global _STATIC_IDA_TOOLS
     if _STATIC_IDA_TOOLS is None:
         try:
-            with open(_STATIC_IDA_TOOLS_PATH, "r") as f:
+            with open(_STATIC_IDA_TOOLS_PATH, "r", encoding="utf-8") as f:
                 _STATIC_IDA_TOOLS = json.load(f)
         except Exception as e:
             print(f"[ida-multi-mcp] Warning: failed to load static tool schemas: {e}",

--- a/src/ida_multi_mcp/server.py
+++ b/src/ida_multi_mcp/server.py
@@ -372,10 +372,15 @@ class IdaMultiMcpServer:
                 # description telling the caller to gate on analysis_wait() only
                 # helps if they read it first, so say it again here, attached to
                 # the incomplete answer itself.
+                #
+                # Appended to every return path below, not once here: the
+                # truncation branch builds a fresh content list, and that branch
+                # is the one a big half-analysed binary always takes.
+                analysis_note: list[dict] = []
                 if name in _ANALYSIS_SENSITIVE_TOOLS and self._analysis_incomplete(
                     arguments.get("instance_id")
                 ):
-                    content = list(content) + [{
+                    analysis_note = [{
                         "type": "text",
                         "text": (
                             "\n[ida-multi-mcp] WARNING: IDA auto-analysis has NOT finished on "
@@ -390,7 +395,7 @@ class IdaMultiMcpServer:
                 # Even on errors, keep the structured payload if present.
                 if is_error:
                     return {
-                        "content": content,
+                        "content": list(content) + analysis_note,
                         **({"structuredContent": structured} if structured is not None else {}),
                         "isError": True,
                     }
@@ -417,13 +422,15 @@ class IdaMultiMcpServer:
                     )
 
                     return {
-                        "content": [{"type": "text", "text": preview_text[:max_output] + truncation_notice}],
+                        "content": [
+                            {"type": "text", "text": preview_text[:max_output] + truncation_notice}
+                        ] + analysis_note,
                         "structuredContent": preview_structured,
                         "isError": False,
                     }
 
                 return {
-                    "content": content,
+                    "content": list(content) + analysis_note,
                     "structuredContent": structured,
                     "isError": False,
                 }

--- a/src/ida_multi_mcp/server.py
+++ b/src/ida_multi_mcp/server.py
@@ -8,6 +8,7 @@ import re
 import sys
 import json
 import threading
+import time
 from pathlib import Path
 from typing import Any
 
@@ -36,6 +37,44 @@ def _load_static_ida_tools() -> list[dict]:
                   file=sys.stderr)
             _STATIC_IDA_TOOLS = []
     return _STATIC_IDA_TOOLS
+
+
+_SERVER_INSTRUCTIONS = """\
+ida-multi-mcp routes tool calls to one or more running IDA Pro instances.
+
+WORKFLOW — follow this order when you start on a binary:
+
+1. `list_instances()` to see what is loaded and get each `instance_id`.
+2. `analysis_wait(instance_id=...)` BEFORE any analysis work on a newly opened
+   binary. IDA analyses in the background, and until it finishes the function
+   list, xrefs, strings and decompiler output are all INCOMPLETE. On a mid-sized
+   DLL this is routinely thousands of missing functions, not a rounding error.
+   Use `analysis_status()` for a non-blocking check. If `analysis_wait` returns
+   `finished: false` it timed out rather than failed — call it again.
+3. `survey_binary(instance_id=...)` for a one-call overview before drilling in.
+
+ROUTING — pass `instance_id` on every tool call. It is required whenever two or
+more instances are registered; with exactly one it may be omitted.
+
+COST — IDA runs each instance on a single main thread. Calls to different
+instances proceed in parallel, but calls to the SAME instance queue behind one
+another, and a long scan makes that instance unresponsive. Prefer the batch and
+`*_query` tools over looping, paginate with count/offset on large binaries, and
+use `decompile_to_file` instead of decompiling functions one at a time.
+
+PERSISTENCE — renames, retypes and comments live in memory until `idb_save()`.
+"""
+
+
+# Tools whose results are silently wrong on a partially analysed IDB.
+# Deliberately not every tool: the warning has to stay rare enough to be read.
+_ANALYSIS_SENSITIVE_TOOLS = frozenset({
+    "list_funcs", "func_query", "func_profile", "classify_functions",
+    "lookup_funcs", "export_funcs", "list_globals", "survey_binary",
+    "callgraph", "callees", "xrefs_to", "xrefs_from", "xrefs_to_field",
+    "analyze_component", "analyze_batch", "index_functions", "similar_functions",
+})
+_ANALYSIS_STATE_TTL_SEC = 10.0
 
 
 def _json_text(value: Any) -> str:
@@ -108,7 +147,9 @@ class IdaMultiMcpServer:
         """
         self.registry = InstanceRegistry(registry_path)
         self.router = InstanceRouter(self.registry)
-        self.server = McpServer("ida-multi-mcp", version="1.0.0")
+        self.server = McpServer(
+            "ida-multi-mcp", version="1.0.0", instructions=_SERVER_INSTRUCTIONS
+        )
 
         # idalib lifecycle manager
         self.idalib_manager = IdalibManager(self.registry, python_executable=idalib_python)
@@ -118,6 +159,9 @@ class IdaMultiMcpServer:
         self._tool_cache: dict[str, dict] = {}
         self._cache_valid = False
         self._refresh_lock = threading.Lock()
+        # instance_id -> (analysis_incomplete, monotonic timestamp)
+        self._analysis_state_cache: dict[str, tuple[bool, float]] = {}
+        self._analysis_state_lock = threading.Lock()
 
         # Set up management tools
         management.set_registry(self.registry)
@@ -324,6 +368,24 @@ class IdaMultiMcpServer:
                 if not content:
                     content = [{"type": "text", "text": _json_text(structured)}]
 
+                # Results from a still-analysing IDB are silently partial. A
+                # description telling the caller to gate on analysis_wait() only
+                # helps if they read it first, so say it again here, attached to
+                # the incomplete answer itself.
+                if name in _ANALYSIS_SENSITIVE_TOOLS and self._analysis_incomplete(
+                    arguments.get("instance_id")
+                ):
+                    content = list(content) + [{
+                        "type": "text",
+                        "text": (
+                            "\n[ida-multi-mcp] WARNING: IDA auto-analysis has NOT finished on "
+                            "this instance. Functions, xrefs, strings and decompiler output are "
+                            "incomplete, and this result is very likely missing data. Call "
+                            "analysis_wait(instance_id=...) and then repeat this call before "
+                            "drawing any conclusions."
+                        ),
+                    }]
+
                 # If the tool has an output schema, Factory requires structuredContent.
                 # Even on errors, keep the structured payload if present.
                 if is_error:
@@ -367,6 +429,38 @@ class IdaMultiMcpServer:
                 }
 
         self.server.registry.methods["tools/call"] = custom_tools_call
+
+    def _analysis_incomplete(self, instance_id: str | None) -> bool:
+        """Whether the instance is still auto-analysing.
+
+        Cached briefly: this runs on every analysis-sensitive call, and the
+        answer only ever flips once per database. Anything unknown (no instance,
+        probe failed) reports False — a spurious warning on every result would
+        train the caller to ignore it.
+        """
+        if not instance_id:
+            return False
+        now = time.monotonic()
+        with self._analysis_state_lock:
+            entry = self._analysis_state_cache.get(instance_id)
+            if entry is not None and now - entry[1] < _ANALYSIS_STATE_TTL_SEC:
+                return entry[0]
+
+        try:
+            resp = self.router.route_request(
+                "tools/call",
+                {"name": "analysis_status", "arguments": {"instance_id": instance_id}},
+            )
+            structured = resp.get("structuredContent") if isinstance(resp, dict) else None
+            if not isinstance(structured, dict) or "finished" not in structured:
+                return False
+            incomplete = not bool(structured["finished"])
+        except Exception:
+            return False
+
+        with self._analysis_state_lock:
+            self._analysis_state_cache[instance_id] = (incomplete, now)
+        return incomplete
 
     def _handle_decompile_to_file(self, arguments: dict) -> dict:
         """Decompile functions and save results to local files.

--- a/src/ida_multi_mcp/tools/management.py
+++ b/src/ida_multi_mcp/tools/management.py
@@ -153,6 +153,8 @@ def compare_binaries(arguments: dict) -> dict:
 # come back to the caller as a transport error instead of finished=false.
 ANALYSIS_WAIT_MAX_SEC = 600.0
 _ANALYSIS_POLL_INTERVAL_SEC = 1.0
+# How long each IDA-side driving slice may hold the main thread.
+_ANALYSIS_STEP_SEC = 5.0
 
 
 def analysis_wait(arguments: dict) -> dict:
@@ -192,17 +194,25 @@ def analysis_wait(arguments: dict) -> dict:
     if router is None:
         return {"error": "Router unavailable"}
 
-    def status() -> dict:
-        resp = router.route_request(
-            "tools/call",
-            {"name": "analysis_status", "arguments": {"instance_id": instance_id}},
-        )
+    def probe(tool: str, extra: dict | None = None) -> dict:
+        args = {"instance_id": instance_id}
+        if extra:
+            args.update(extra)
+        resp = router.route_request("tools/call", {"name": tool, "arguments": args})
         if not isinstance(resp, dict):
             return {}
         if "error" in resp:
             return {"_error": resp["error"]}
         body = resp.get("structuredContent")
         return body if isinstance(body, dict) else {}
+
+    def status() -> dict:
+        return probe("analysis_status")
+
+    def drive(seconds: float) -> dict:
+        # Driving, not just watching: IDA's background analysis plateaus short
+        # of completion and auto_is_ok() never flips on its own.
+        return probe("analysis_step", {"max_sec": seconds})
 
     t0 = time.monotonic()
     first = status()
@@ -215,10 +225,17 @@ def analysis_wait(arguments: dict) -> dict:
     last = first
     deadline = t0 + budget
     while not last.get("finished") and time.monotonic() < deadline:
-        time.sleep(min(_ANALYSIS_POLL_INTERVAL_SEC, max(0.0, deadline - time.monotonic())))
-        polled = status()
-        if polled and "_error" not in polled:
-            last = polled
+        slice_sec = max(0.0, min(_ANALYSIS_STEP_SEC, deadline - time.monotonic()))
+        if slice_sec <= 0:
+            break
+        stepped = drive(slice_sec)
+        if stepped and "_error" not in stepped:
+            last = stepped
+        else:
+            polled = status()
+            if polled and "_error" not in polled:
+                last = polled
+            time.sleep(min(_ANALYSIS_POLL_INTERVAL_SEC, max(0.0, deadline - time.monotonic())))
 
     finished = bool(last.get("finished"))
     after = last.get("function_count", before)
@@ -229,7 +246,14 @@ def analysis_wait(arguments: dict) -> dict:
         "functions_added": after - before,
         "state": last.get("state", "unknown"),
         "note": (
-            "Analysis complete."
+            # Honest about what finished=True means. auto_is_ok() is a snapshot
+            # of "queues empty right now", not a latch: observed live returning
+            # True here and False on the very next analysis_status against the
+            # same idle instance. functions_added is the more durable signal --
+            # once it reaches 0 across successive calls, analysis has settled.
+            "Analysis queues drained. This is a snapshot rather than a "
+            "guarantee; if functions_added is 0 here and on a repeat call, "
+            "the database has settled."
             if finished
             else f"Waited {budget:.0f}s and analysis is still running - "
                  f"call analysis_wait() again to continue."

--- a/src/ida_multi_mcp/tools/management.py
+++ b/src/ida_multi_mcp/tools/management.py
@@ -147,3 +147,91 @@ def compare_binaries(arguments: dict) -> dict:
         "entrypoints": _diff_sets(entries_a, entries_b),
         "segments": _diff_sets(segs_a, segs_b),
     }
+
+
+# Bounded above the router's per-request socket timeout so a wait can never
+# come back to the caller as a transport error instead of finished=false.
+ANALYSIS_WAIT_MAX_SEC = 600.0
+_ANALYSIS_POLL_INTERVAL_SEC = 1.0
+
+
+def analysis_wait(arguments: dict) -> dict:
+    """Poll an instance's analysis_status until analysis finishes or we time out.
+
+    Implemented here rather than inside IDA on purpose. The obvious version --
+    call ida_auto.auto_wait() under @idasync -- does not work:
+
+      * auto_wait() is one blocking call that runs until the queues drain. It
+        ignores any deadline we hand it, so `timeout_sec` was not enforced at
+        all; measured live, a requested 30s wait ran 261s.
+      * set_cancelled() does not reliably break it out (auto_wait's cancel path
+        expects a wait box), so a Timer cannot bound it either.
+      * Worst of all it holds IDA's main thread for the whole analysis, which
+        blocks every other caller of that instance for minutes.
+
+    Polling a cheap analysis_status instead gives a real timeout, and leaves the
+    main thread free between polls -- both for the analyser itself and for other
+    tool calls.
+    """
+    import time
+
+    instance_id = arguments.get("instance_id")
+    if not instance_id:
+        return {
+            "error": "Missing required parameter 'instance_id'.",
+            "hint": "Call list_instances() and pass instance_id explicitly.",
+        }
+
+    try:
+        requested = float(arguments.get("timeout_sec", 120.0))
+    except (TypeError, ValueError):
+        requested = 120.0
+    budget = max(0.0, min(requested, ANALYSIS_WAIT_MAX_SEC))
+
+    router = _router
+    if router is None:
+        return {"error": "Router unavailable"}
+
+    def status() -> dict:
+        resp = router.route_request(
+            "tools/call",
+            {"name": "analysis_status", "arguments": {"instance_id": instance_id}},
+        )
+        if not isinstance(resp, dict):
+            return {}
+        if "error" in resp:
+            return {"_error": resp["error"]}
+        body = resp.get("structuredContent")
+        return body if isinstance(body, dict) else {}
+
+    t0 = time.monotonic()
+    first = status()
+    if "_error" in first:
+        return {"error": f"Could not reach instance '{instance_id}': {first['_error']}"}
+    if not first:
+        return {"error": f"Instance '{instance_id}' did not report analysis status."}
+
+    before = first.get("function_count", 0)
+    last = first
+    deadline = t0 + budget
+    while not last.get("finished") and time.monotonic() < deadline:
+        time.sleep(min(_ANALYSIS_POLL_INTERVAL_SEC, max(0.0, deadline - time.monotonic())))
+        polled = status()
+        if polled and "_error" not in polled:
+            last = polled
+
+    finished = bool(last.get("finished"))
+    after = last.get("function_count", before)
+    return {
+        "finished": finished,
+        "waited_sec": round(time.monotonic() - t0, 2),
+        "function_count": after,
+        "functions_added": after - before,
+        "state": last.get("state", "unknown"),
+        "note": (
+            "Analysis complete."
+            if finished
+            else f"Waited {budget:.0f}s and analysis is still running - "
+                 f"call analysis_wait() again to continue."
+        ),
+    }

--- a/src/ida_multi_mcp/vendor/zeromcp/mcp.py
+++ b/src/ida_multi_mcp/vendor/zeromcp/mcp.py
@@ -310,9 +310,11 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
             send_response(200, json.dumps(response).encode("utf-8"))
 
 class McpServer:
-    def __init__(self, name: str, version = "1.0.0", *, extensions: dict[str, set[str]] | None = None):
+    def __init__(self, name: str, version = "1.0.0", *, extensions: dict[str, set[str]] | None = None,
+                 instructions: str | None = None):
         self.name = name
         self.version = version
+        self.instructions = instructions
         self.cors_allowed_origins: Callable[[str], bool] | list[str] | str | None = self.cors_localhost
         self.post_body_limit = 10 * 1024 * 1024  # 10MB
         self.tools = McpRpcRegistry()
@@ -572,7 +574,7 @@ class McpServer:
 
     def _mcp_initialize(self, protocolVersion: str, capabilities: dict, clientInfo: dict, _meta: dict | None = None) -> dict:
         """MCP initialize method"""
-        return {
+        result = {
             "protocolVersion": getattr(self._protocol_version, "data", protocolVersion),
             "capabilities": {
                 "tools": {"listChanged": False},
@@ -587,6 +589,12 @@ class McpServer:
                 "version": self.version,
             },
         }
+        # Server-level usage guidance. Clients surface this once, up front —
+        # the right place for rules that apply across every tool rather than
+        # repeating them in each description.
+        if self.instructions:
+            result["instructions"] = self.instructions
+        return result
 
     def _mcp_tools_list(self, _meta: dict | None = None) -> dict:
         """MCP tools/list method"""

--- a/tests/test_analysis_gating.py
+++ b/tests/test_analysis_gating.py
@@ -135,6 +135,60 @@ def test_no_warning_for_insensitive_tools(srv):
     assert not _has_warning(out)
 
 
+def test_analysis_wait_polls_until_finished(srv):
+    """Router-side wait: poll a cheap status call, do not hold IDA's main thread.
+
+    The IDA-side version called ida_auto.auto_wait() under @idasync. That is one
+    blocking call that ignores any deadline -- measured live, a requested 30s
+    wait ran 261s -- and it pins the main thread for the whole analysis.
+    """
+    from ida_multi_mcp.tools import management
+    management.set_router(srv.router)
+    seq = [
+        {"structuredContent": {"finished": False, "function_count": 100, "state": "queued"}},
+        {"structuredContent": {"finished": False, "function_count": 400, "state": "queued"}},
+        {"structuredContent": {"finished": True, "function_count": 900, "state": "idle"}},
+    ]
+    srv.router.route_request.side_effect = lambda m, p: seq.pop(0) if seq else seq_last
+    seq_last = {"structuredContent": {"finished": True, "function_count": 900, "state": "idle"}}
+    management._ANALYSIS_POLL_INTERVAL_SEC = 0.01
+    out = management.analysis_wait({"instance_id": "k7m2", "timeout_sec": 5})
+    assert out["finished"] is True
+    assert out["function_count"] == 900
+    assert out["functions_added"] == 800, "should report growth across the wait"
+
+
+def test_analysis_wait_honours_its_timeout(srv):
+    """finished=false on timeout, and it must actually return near the deadline."""
+    import time
+    from ida_multi_mcp.tools import management
+    management.set_router(srv.router)
+    management._ANALYSIS_POLL_INTERVAL_SEC = 0.05
+    srv.router.route_request.return_value = {
+        "structuredContent": {"finished": False, "function_count": 10, "state": "queued"}
+    }
+    t0 = time.monotonic()
+    out = management.analysis_wait({"instance_id": "k7m2", "timeout_sec": 0.3})
+    elapsed = time.monotonic() - t0
+    assert out["finished"] is False
+    assert elapsed < 3.0, f"timeout not honoured (took {elapsed:.1f}s)"
+    assert "call analysis_wait() again" in out["note"]
+
+
+def test_analysis_wait_requires_instance_id(srv):
+    from ida_multi_mcp.tools import management
+    management.set_router(srv.router)
+    assert "error" in management.analysis_wait({})
+
+
+def test_analysis_wait_reports_unreachable_instance(srv):
+    from ida_multi_mcp.tools import management
+    management.set_router(srv.router)
+    srv.router.route_request.return_value = {"error": "Failed to connect to instance"}
+    out = management.analysis_wait({"instance_id": "dead"})
+    assert "error" in out and "dead" in out["error"]
+
+
 def test_sensitive_set_covers_the_discovery_tools():
     """These are what an agent reaches for first on a new binary."""
     for name in ("list_funcs", "survey_binary", "func_query", "xrefs_to",

--- a/tests/test_analysis_gating.py
+++ b/tests/test_analysis_gating.py
@@ -85,6 +85,56 @@ def test_malformed_probe_response_stays_silent(srv):
     assert srv._analysis_incomplete("z9z9") is False
 
 
+def _call_tool(srv, name, ida_response, incomplete, max_output=None):
+    """Drive custom_tools_call with a canned IDA response."""
+    srv.registry.get_active = MagicMock(return_value={"k7m2": {}})
+    srv.router.route_request.return_value = ida_response
+    srv._analysis_state_cache["k7m2"] = (incomplete, float("inf"))
+    args = {"instance_id": "k7m2"}
+    if max_output is not None:
+        args["max_output_chars"] = max_output
+    return srv.server.registry.methods["tools/call"](name=name, arguments=args)
+
+
+def _has_warning(result):
+    return any("auto-analysis has NOT finished" in c.get("text", "")
+               for c in result.get("content", []))
+
+
+def test_warning_is_attached_to_a_normal_result(srv):
+    out = _call_tool(srv, "list_funcs", {"structuredContent": {"fns": [1, 2]}}, incomplete=True)
+    assert _has_warning(out)
+
+
+def test_warning_survives_truncation(srv):
+    """The regression: the truncation branch rebuilt content from scratch.
+
+    A big, still-analysing binary always takes that branch, so the warning was
+    dropped in exactly the case it exists for. Caught live on a 23MB DLL with
+    61k functions, where list_funcs came back with no warning attached.
+    """
+    big = {"structuredContent": {"fns": [{"addr": i, "name": f"sub_{i}"} for i in range(4000)]}}
+    out = _call_tool(srv, "list_funcs", big, incomplete=True, max_output=500)
+    assert "TRUNCATED" in out["content"][0]["text"], "expected the truncation path"
+    assert _has_warning(out), "warning was dropped by the truncation branch"
+
+
+def test_warning_is_attached_to_error_results(srv):
+    out = _call_tool(srv, "list_funcs",
+                     {"structuredContent": {"x": 1}, "isError": True}, incomplete=True)
+    assert _has_warning(out)
+
+
+def test_no_warning_once_analysis_is_finished(srv):
+    out = _call_tool(srv, "list_funcs", {"structuredContent": {"fns": []}}, incomplete=False)
+    assert not _has_warning(out)
+
+
+def test_no_warning_for_insensitive_tools(srv):
+    out = _call_tool(srv, "int_convert", {"structuredContent": {"v": 1}}, incomplete=True)
+    assert not _has_warning(out)
+
+
 def test_sensitive_set_covers_the_discovery_tools():
     """These are what an agent reaches for first on a new binary."""
     for name in ("list_funcs", "survey_binary", "func_query", "xrefs_to",

--- a/tests/test_analysis_gating.py
+++ b/tests/test_analysis_gating.py
@@ -189,6 +189,37 @@ def test_analysis_wait_reports_unreachable_instance(srv):
     assert "error" in out and "dead" in out["error"]
 
 
+def test_wait_result_does_not_oversell_completion(srv):
+    """finished=True must not be presented as a guarantee.
+
+    auto_is_ok() is a snapshot of "queues empty right now", not a latch --
+    observed live returning True from analysis_wait and False on the very next
+    analysis_status against the same idle instance. The note has to say so, or
+    a caller will treat one True as proof and stop checking.
+    """
+    from ida_multi_mcp.tools import management
+    management.set_router(srv.router)
+    srv.router.route_request.return_value = {
+        "structuredContent": {"finished": True, "function_count": 5, "state": "idle"}
+    }
+    out = management.analysis_wait({"instance_id": "k7m2"})
+    assert out["finished"] is True
+    note = out["note"].lower()
+    assert "snapshot" in note and "guarantee" in note
+    assert "functions_added" in out
+
+
+def test_analysis_wait_description_flags_the_snapshot_caveat():
+    from ida_multi_mcp.server import IdaMultiMcpServer  # noqa: F401
+    import inspect
+    from ida_multi_mcp import server as server_mod
+    src = inspect.getsource(server_mod)
+    i = src.index('cache["analysis_wait"]')
+    desc = src[i:i + 1600]
+    assert "snapshot" in desc or "not a permanent latch" in desc
+    assert "functions_added" in desc
+
+
 def test_sensitive_set_covers_the_discovery_tools():
     """These are what an agent reaches for first on a new binary."""
     for name in ("list_funcs", "survey_binary", "func_query", "xrefs_to",

--- a/tests/test_analysis_gating.py
+++ b/tests/test_analysis_gating.py
@@ -1,0 +1,114 @@
+"""Tests for the analysis-incomplete guidance the router attaches to results.
+
+Telling an agent in a tool description to wait for auto-analysis only works if
+it reads the description first. These cover the belt-and-braces path: when an
+instance is still analysing, the router appends the warning to the result of
+tools whose output would be silently partial.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ida_multi_mcp import server as server_mod
+from ida_multi_mcp.server import (
+    _ANALYSIS_SENSITIVE_TOOLS,
+    _SERVER_INSTRUCTIONS,
+    IdaMultiMcpServer,
+)
+
+
+@pytest.fixture
+def srv(tmp_path):
+    s = IdaMultiMcpServer(registry_path=str(tmp_path / "instances.json"))
+    s.router = MagicMock()
+    return s
+
+
+def _status(finished):
+    return {"structuredContent": {"finished": finished}}
+
+
+def test_incomplete_analysis_is_detected(srv):
+    srv.router.route_request.return_value = _status(False)
+    assert srv._analysis_incomplete("k7m2") is True
+
+
+def test_finished_analysis_is_not_flagged(srv):
+    srv.router.route_request.return_value = _status(True)
+    assert srv._analysis_incomplete("k7m2") is False
+
+
+def test_result_is_cached_so_every_call_does_not_probe(srv):
+    srv.router.route_request.return_value = _status(False)
+    for _ in range(5):
+        assert srv._analysis_incomplete("k7m2") is True
+    assert srv.router.route_request.call_count == 1
+
+
+def test_cache_is_per_instance(srv):
+    def route(_method, params):
+        return _status(params["arguments"]["instance_id"] == "busy")
+    srv.router.route_request.side_effect = lambda m, p: _status(
+        p["arguments"]["instance_id"] != "busy"
+    )
+    assert srv._analysis_incomplete("busy") is True
+    assert srv._analysis_incomplete("idle") is False
+
+
+def test_expired_cache_reprobes(srv, monkeypatch):
+    srv.router.route_request.return_value = _status(False)
+    assert srv._analysis_incomplete("k7m2") is True
+    # Age the entry past the TTL rather than sleeping through it.
+    incomplete, ts = srv._analysis_state_cache["k7m2"]
+    srv._analysis_state_cache["k7m2"] = (incomplete, ts - server_mod._ANALYSIS_STATE_TTL_SEC - 1)
+    srv.router.route_request.return_value = _status(True)
+    assert srv._analysis_incomplete("k7m2") is False
+
+
+def test_missing_instance_id_is_not_flagged(srv):
+    assert srv._analysis_incomplete(None) is False
+    assert srv._analysis_incomplete("") is False
+    srv.router.route_request.assert_not_called()
+
+
+def test_probe_failure_stays_silent(srv):
+    """A spurious warning on every result would train the caller to ignore it."""
+    srv.router.route_request.side_effect = RuntimeError("instance down")
+    assert srv._analysis_incomplete("k7m2") is False
+
+
+def test_malformed_probe_response_stays_silent(srv):
+    srv.router.route_request.return_value = {"error": "nope"}
+    assert srv._analysis_incomplete("k7m2") is False
+    srv.router.route_request.return_value = {"structuredContent": "not a dict"}
+    assert srv._analysis_incomplete("z9z9") is False
+
+
+def test_sensitive_set_covers_the_discovery_tools():
+    """These are what an agent reaches for first on a new binary."""
+    for name in ("list_funcs", "survey_binary", "func_query", "xrefs_to",
+                 "similar_functions", "callgraph"):
+        assert name in _ANALYSIS_SENSITIVE_TOOLS
+
+
+def test_sensitive_set_excludes_tools_that_do_not_depend_on_analysis():
+    """Warning on everything would make it noise."""
+    for name in ("int_convert", "analysis_status", "analysis_wait",
+                 "list_instances", "idb_save", "get_cached_output"):
+        assert name not in _ANALYSIS_SENSITIVE_TOOLS
+
+
+def test_server_instructions_lead_with_the_analysis_gate():
+    assert "analysis_wait" in _SERVER_INSTRUCTIONS
+    assert "INCOMPLETE" in _SERVER_INSTRUCTIONS
+    # and the other rules an agent needs up front
+    assert "instance_id" in _SERVER_INSTRUCTIONS
+    assert "idb_save" in _SERVER_INSTRUCTIONS
+
+
+def test_instructions_are_advertised_on_initialize(srv):
+    result = srv.server.registry.methods["initialize"](
+        protocolVersion="2025-06-18", capabilities={}, clientInfo={"name": "t", "version": "0"}
+    )
+    assert result["instructions"] == _SERVER_INSTRUCTIONS

--- a/tests/test_compat_fallbacks.py
+++ b/tests/test_compat_fallbacks.py
@@ -1,0 +1,195 @@
+"""Tests for ida_mcp/compat.py version fallbacks (IDA modules stubbed).
+
+The fallback branches exist for IDA 8.3/8.4 and for IDA 9.0 SP0, none of which
+can be exercised on a modern IDA install. They are therefore driven here with
+stubs that present or withhold the specific attributes each wrapper probes.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+_PKG = "ida_multi_mcp.ida_mcp"
+_ABSENT = object()
+
+_IDA_MODULES = ["idaapi", "ida_funcs", "ida_nalt", "ida_typeinf",
+                "ida_ida", "ida_hexrays", "ida_entry", "idc", "idautils"]
+
+
+def _load_compat(saved, *, kernel_version="9.3", present=(), absent=()):
+    """Import a fresh compat with a synthetic IDA surface.
+
+    present/absent name attributes to force onto or off the stub modules,
+    as "module.attr".
+    """
+    def _stub(name, value):
+        if name not in saved:
+            saved[name] = sys.modules.get(name, _ABSENT)
+        sys.modules[name] = value
+
+    for name in _IDA_MODULES:
+        _stub(name, MagicMock(name=name))
+
+    sys.modules["idaapi"].get_kernel_version.return_value = kernel_version
+
+    for spec in absent:
+        mod, _, attr = spec.partition(".")
+        # `del` on a MagicMock marks the attribute as absent, so hasattr() is
+        # False, while leaving every other auto-created attribute intact.
+        delattr(sys.modules[mod], attr)
+
+    for spec in present:
+        mod, _, attr = spec.partition(".")
+        setattr(sys.modules[mod], attr, MagicMock(name=spec))
+
+    saved.setdefault(f"{_PKG}.compat", sys.modules.get(f"{_PKG}.compat", _ABSENT))
+    sys.modules.pop(f"{_PKG}.compat", None)
+    # compat imports only IDA modules, so it can be loaded straight from file
+    # without dragging in the package __init__.
+    import importlib.util
+    import pathlib
+
+    path = pathlib.Path(__file__).resolve().parents[1] / "src" / "ida_multi_mcp" / "ida_mcp" / "compat.py"
+    spec = importlib.util.spec_from_file_location(f"{_PKG}.compat", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def load():
+    saved = {}
+    made = []
+
+    def _factory(**kw):
+        mod = _load_compat(saved, **kw)
+        made.append(mod)
+        return mod
+
+    try:
+        yield _factory
+    finally:
+        for name, previous in saved.items():
+            if previous is _ABSENT:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+
+def test_version_parsing_handles_service_packs(load):
+    compat = load(kernel_version="9.0sp1")
+    assert compat.IDA_VERSION[:2] == (9, 0)
+    assert compat.IDA_GE_90 and compat.IDA_GE_85 and compat.IDA_GE_84
+
+
+def test_unparseable_version_does_not_crash_import(load):
+    """get_kernel_version() is an SDK call; a surprising value must not brick us."""
+    compat = load(kernel_version="not-a-version")
+    assert compat.IDA_VERSION == (0, 0, 0)
+    # Dispatch is by hasattr, so a modern API is still selected.
+    compat.inf_get_min_ea()
+    sys.modules["ida_ida"].inf_get_min_ea.assert_called_once()
+
+
+def test_inf_accessors_prefer_ida_ida(load):
+    compat = load()
+    compat.inf_get_min_ea()
+    compat.inf_get_max_ea()
+    compat.inf_get_omin_ea()
+    compat.inf_get_omax_ea()
+    for name in ("inf_get_min_ea", "inf_get_max_ea", "inf_get_omin_ea", "inf_get_omax_ea"):
+        getattr(sys.modules["ida_ida"], name).assert_called_once()
+
+
+def test_inf_accessors_fall_back_to_inf_structure_on_pre_85(load):
+    """IDA < 8.5 has no ida_ida.inf_get_*; the legacy struct carries the fields."""
+    compat = load(kernel_version="8.3", absent=("ida_ida.inf_get_min_ea",))
+    idaapi = sys.modules["idaapi"]
+    idaapi.get_inf_structure.return_value.min_ea = 0x400000
+    assert compat.inf_get_min_ea() == 0x400000
+
+
+def test_get_ordinal_limit_falls_back_to_ordinal_qty(load):
+    """get_ordinal_limit arrived in 8.4; before that it was get_ordinal_qty."""
+    compat = load(kernel_version="8.3", absent=("ida_typeinf.get_ordinal_limit",))
+    sys.modules["ida_typeinf"].get_ordinal_qty.return_value = 42
+    assert compat.get_ordinal_limit() == 42
+
+
+def test_get_func_name_falls_back_when_method_missing(load):
+    """func_t.get_name arrived in 8.5 and is absent in IDA 9.0 SP0."""
+    compat = load()
+    func = MagicMock(spec=["start_ea"])
+    func.start_ea = 0x1000
+    sys.modules["ida_funcs"].get_func_name.return_value = "sub_1000"
+    assert compat.get_func_name(func) == "sub_1000"
+    sys.modules["ida_funcs"].get_func_name.assert_called_once_with(0x1000)
+
+
+def test_tinfo_get_udm_uses_modern_api_when_present(load):
+    compat = load()
+    tif = MagicMock()
+    tif.get_udm.return_value = (3, "udm")
+    assert compat.tinfo_get_udm(tif, "field") == (3, "udm")
+
+
+def test_tinfo_get_udm_falls_back_to_find_udm(load):
+    """IDA 9.0 SP0 dropped tinfo_t.get_udm; find_udm + get_udm_by_tid stands in."""
+    compat = load()
+    tif = MagicMock(spec=["find_udm", "get_udm_tid", "get_udm_by_tid"])
+    tif.find_udm.return_value = 2
+    tif.get_udm_tid.return_value = 0xAB
+
+    udm = sys.modules["ida_typeinf"].udm_t.return_value
+    udm.name = "field"
+
+    idx, got = compat.tinfo_get_udm(tif, "field")
+    assert idx == 2 and got is udm
+    tif.get_udm_by_tid.assert_called_once_with(udm, 0xAB)
+
+
+def test_tinfo_get_udm_reports_missing_member(load):
+    compat = load()
+    tif = MagicMock(spec=["find_udm"])
+    tif.find_udm.return_value = -1
+    assert compat.tinfo_get_udm(tif, "nope") == (-1, None)
+
+
+def test_tinfo_get_udm_treats_unpopulated_udm_as_missing(load):
+    """get_udm_by_tid returns 0 on success, so trust udm.name, not the rc."""
+    compat = load()
+    tif = MagicMock(spec=["find_udm", "get_udm_tid", "get_udm_by_tid"])
+    tif.find_udm.return_value = 1
+    sys.modules["ida_typeinf"].udm_t.return_value.name = ""
+    assert compat.tinfo_get_udm(tif, "field") == (-1, None)
+
+
+def test_missing_required_apis_flags_ida_90_sp0(load):
+    """9.0 SP0 shipped without methods 8.5 added and 9.0 SP1 restored."""
+    compat = load(
+        kernel_version="9.0",
+        absent=("ida_typeinf.tinfo_t",),
+    )
+    sys.modules["ida_typeinf"].tinfo_t = lambda: MagicMock(spec=[])
+    sys.modules["ida_funcs"].func_t = lambda: MagicMock(spec=[])
+    missing = compat.missing_required_apis()
+    assert set(missing) == {"func_t.get_name", "func_t.get_prototype", "tinfo_t.get_udm"}
+    with pytest.raises(RuntimeError, match="9.0 SP1"):
+        compat.assert_supported_ida()
+
+
+def test_missing_required_apis_silent_on_old_ida(load):
+    """Pre-9.0 legitimately lacks these; the fallbacks cover it, so stay quiet."""
+    compat = load(kernel_version="8.3")
+    sys.modules["ida_funcs"].func_t = lambda: MagicMock(spec=[])
+    sys.modules["ida_typeinf"].tinfo_t = lambda: MagicMock(spec=[])
+    assert compat.missing_required_apis() == []
+    compat.assert_supported_ida()
+
+
+def test_missing_required_apis_silent_on_healthy_ida(load):
+    compat = load(kernel_version="9.3")
+    assert compat.missing_required_apis() == []
+    compat.assert_supported_ida()

--- a/tests/test_static_tool_schemas.py
+++ b/tests/test_static_tool_schemas.py
@@ -1,0 +1,67 @@
+"""Tests for the static tools/list fallback.
+
+ida_tool_schemas.json is what a client sees when no IDA instance is connected --
+exactly when an agent is deciding what to do. It is loaded with a bare open(),
+which on a non-UTF-8 default locale (cp949 on Korean Windows, cp1252, ...) fails
+on the first non-ASCII byte. _load_static_ida_tools swallows that and returns [],
+so the entire IDA tool catalogue silently disappears offline: 76 advertised
+tools drop to 15, and nothing says why.
+
+That is not hypothetical -- it fired the moment a tool docstring gained an
+em dash.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ida_multi_mcp import server as server_mod
+
+SCHEMA_PATH = Path(server_mod.__file__).parent / "ida_tool_schemas.json"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    server_mod._STATIC_IDA_TOOLS = None
+    yield
+    server_mod._STATIC_IDA_TOOLS = None
+
+
+def test_static_schemas_load():
+    tools = server_mod._load_static_ida_tools()
+    assert tools, "static tool catalogue failed to load"
+    assert len(tools) > 40
+
+
+def test_static_schemas_survive_a_non_utf8_default_locale(monkeypatch):
+    """The real failure mode: locale-dependent decoding of a UTF-8 file."""
+    real_open = open
+
+    def cp949_open(file, mode="r", *args, **kwargs):
+        # Simulate a machine whose preferred encoding is cp949 by forcing it
+        # whenever the caller did not pin one explicitly.
+        if "b" not in mode and "encoding" not in kwargs:
+            kwargs["encoding"] = "cp949"
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", cp949_open)
+    tools = server_mod._load_static_ida_tools()
+    assert tools, "static catalogue lost under a cp949 default locale"
+
+
+def test_static_schema_file_is_valid_and_non_ascii_safe():
+    raw = SCHEMA_PATH.read_bytes()
+    tools = json.loads(raw.decode("utf-8"))
+    assert isinstance(tools, list) and tools
+    for t in tools:
+        assert {"name", "description", "inputSchema"} <= set(t)
+        # instance_id is injected by the router; baking it in would double up
+        assert "instance_id" not in t["inputSchema"].get("properties", {})
+
+
+def test_static_catalogue_advertises_the_analysis_gate():
+    """An agent choosing what to do offline still has to learn about these."""
+    names = {t["name"] for t in server_mod._load_static_ida_tools()}
+    assert "analysis_status" in names
+    assert "list_funcs" in names


### PR DESCRIPTION
Three things, all found by running against live IDA 9.3 instances.

## 1. `auto_analysis_ready` was inverted — analysis completion was undetectable

```python
"auto_analysis_ready": not ida_auto.auto_is_ok()
```

IDA documents `auto_is_ok()` as *"Are all queues empty? (i.e. has autoanalysis finished?)"* — **True once analysis is done**. The negation made the field report the opposite of the truth in both directions: "not ready" on a fully analysed IDB, and "ready" while analysis was still running.

Proven live — on an idle IDB the SDK returned `auto_is_ok()=True`, `get_auto_state()=AU_NONE`, while `server_health` said `auto_analysis_ready=False`.

**Two new tools** make the state addressable, with descriptions written so an agent knows when to use them:

- **`analysis_status()`** — non-blocking. `finished`, current phase, function count so far, plus a hint on whether results can be trusted yet.
- **`analysis_wait(timeout_sec=120)`** — blocks until analysis completes. `finished: false` means the wait timed out, not that it failed, so the caller just loops. Internally it loops `auto_wait()` as well, since the tool deadline's `set_cancelled()` (from #28) makes `auto_wait` return early — resuming beats aborting the whole wait.

### Why it matters, measured

On an 8.5 MB DLL that was still analysing:

```
analysis_status()  -> finished=false  function_count=9,580
analysis_wait(120) -> finished=true   waited_sec=37.25  functions_added=3,672
analysis_status()  -> finished=true   function_count=13,252
```

**3,672 functions — 28% of the binary — did not exist yet** at the point an unwaiting agent would have started drawing conclusions.

One nuance: `get_auto_state()` reads `AU_NONE` whenever IDA has borrowed the main thread back to service our request, which is *always* the case inside a tool call. That was being reported as "idle" and contradicted `finished: false`, so `AU_NONE` with work outstanding is now labelled "queued" instead.

## 2. `infer_types` was broken on IDA 9.x

`api_types.infer_types` called `ida_hexrays.guess_tinfo` directly, but `guess_tinfo` moved to `ida_typeinf`. Every call on IDA 9.3 returned:

```
error: module 'ida_hexrays' has no attribute 'guess_tinfo'
```

Now routed through `compat.guess_tinfo`, which prefers the modern location. Verified live: all four probed addresses went from that error to `__int64 __fastcall()` with `method=hexrays`.

## 3. compat.py actually covers the moved APIs now

It shimmed two API groups while call sites reached past it for the rest, pinning us to IDA 8.5+ despite the README having claimed 8.3. Routed through compat:

| API | Since | Call sites |
|---|---|---|
| `ida_ida.inf_get_{min,max,omin,omax}_ea` | 8.5 | `api_analysis`, `utils` |
| `ida_typeinf.get_ordinal_limit` | 8.4 | `api_resources`, `api_types` |
| `tinfo_t.get_udm` | 8.5 | `api_modify`, `api_stack`, `api_types` |

Wrappers dispatch on `hasattr`, not on the parsed version, so a surprising `get_kernel_version()` string cannot route a modern IDA down the legacy path (where `get_inf_structure` no longer exists at all).

`missing_required_apis()` reports what IDA 9.0 SP0 (build 240925) dropped and 9.0 SP1 restored; the plugin warns at load rather than letting a tool fail with an opaque `AttributeError` mid-call.

The version-gating approach is **ported from upstream ida-pro-mcp's `compat.py`** by Duncan Ogilvie (MIT).

> **The README still says 8.5+.** The hard blockers are gone, but nothing here has run on a real 8.3/8.4 — I only have 9.3. Claiming 8.3 support untested is the exact mistake this PR series started by fixing. The fallback branches are covered by `tests/test_compat_fallbacks.py`, which withholds the specific attribute each wrapper probes.

## 4. `idb_save` no longer takes the save-as path in the GUI

It always passed an explicit path, which is a save-as. Now: `None` for IDA's own in-place save (Ctrl+W) in the GUI, a compressed copy only when given a *different* destination, and `DBFL_KILL|DBFL_COMP` packing only when headless, where there are no live working files to clobber. Reports which mode it used. GUI branch follows upstream `6673de9`.

## Live verification

- Full harness against two instances: **15/15**
- `find`/`find_bytes` (`inf_get_*`), `search_structs` (`get_ordinal_limit`) unchanged
- `declare_stack`/`delete_stack` round trip resolving and removing a real frame member (`tinfo_get_udm`)
- Tool catalog: 73 → **75**, both new tools present with full descriptions

```
python -m pytest -q                                   # 389 passed, 4 skipped
python -m ruff check src/ tests/ --select F821,F811    # All checks passed
```

Also documents `ida -A` for skipping IDA's load dialog, which blocks before the plugin exists and so cannot be dismissed from the MCP side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)