### PR TITLE
fix(idalib): point headless download URLs at the worker's own port

### DIFF
--- a/src/ida_multi_mcp/idalib_worker.py
+++ b/src/ida_multi_mcp/idalib_worker.py
@@ -123,6 +123,12 @@ def main() -> None:
         signal.signal(signal.SIGBREAK, _shutdown)
 
     # --- Serve ---------------------------------------------------------------
+    # Truncated tool output hands back a download URL, and only this process can
+    # serve it — the cache lives here, in rpc's module state. Without this the URL
+    # keeps rpc's default (port 13337), which nothing listens on.
+    from ida_multi_mcp.ida_mcp.rpc import set_download_base_url
+    set_download_base_url(f"http://{args.host}:{args.port}")
+
     logger.info("Serving on %s:%d", args.host, args.port)
     MCP_SERVER.serve(host=args.host, port=args.port, background=False)
 

--- a/tests/test_idalib_worker_download_url.py
+++ b/tests/test_idalib_worker_download_url.py
@@ -1,0 +1,65 @@
+"""The idalib worker must point download URLs at its own port.
+
+Truncated tool output returns a `/output/<id>.json` URL, and only the process
+holding the output cache can serve it. The GUI plugin already sets its own port;
+the worker used to leave rpc's default in place, so URLs from headless sessions
+pointed at port 13337 with nothing listening.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def stubbed_worker_env(monkeypatch):
+    """Stub idalib/IDA imports so worker.main() runs without IDA."""
+    idapro = MagicMock()
+    monkeypatch.setitem(sys.modules, "idapro", idapro)
+    monkeypatch.setitem(sys.modules, "ida_auto", MagicMock())
+
+    ida_mcp = types.ModuleType("ida_multi_mcp.ida_mcp")
+    ida_mcp.MCP_SERVER = MagicMock()
+    ida_mcp.MCP_UNSAFE = set()
+    monkeypatch.setitem(sys.modules, "ida_multi_mcp.ida_mcp", ida_mcp)
+
+    rpc = types.ModuleType("ida_multi_mcp.ida_mcp.rpc")
+    rpc.set_download_base_url = MagicMock()
+    monkeypatch.setitem(sys.modules, "ida_multi_mcp.ida_mcp.rpc", rpc)
+
+    return ida_mcp, rpc
+
+
+def _run_worker(monkeypatch, tmp_path, port):
+    binary = tmp_path / "sample.bin"
+    binary.write_bytes(b"\x00" * 16)
+    monkeypatch.setattr(sys, "argv", [
+        "idalib_worker", "--host", "127.0.0.1", "--port", str(port), str(binary),
+    ])
+    from ida_multi_mcp import idalib_worker
+    idalib_worker.main()
+
+
+def test_download_base_url_uses_the_workers_own_port(
+    stubbed_worker_env, monkeypatch, tmp_path,
+):
+    _, rpc = stubbed_worker_env
+    _run_worker(monkeypatch, tmp_path, 54321)
+
+    rpc.set_download_base_url.assert_called_once_with("http://127.0.0.1:54321")
+
+
+def test_download_base_url_is_set_before_serving(
+    stubbed_worker_env, monkeypatch, tmp_path,
+):
+    """A URL set after serve() would never apply — serve blocks until shutdown."""
+    ida_mcp, rpc = stubbed_worker_env
+    call_order = []
+    rpc.set_download_base_url.side_effect = lambda url: call_order.append("set_url")
+    ida_mcp.MCP_SERVER.serve.side_effect = lambda **kw: call_order.append("serve")
+
+    _run_worker(monkeypatch, tmp_path, 54321)
+
+    assert call_order == ["set_url", "serve"]


### PR DESCRIPTION
Fixes #33.

`idalib_worker.py` now calls `set_download_base_url()` with its own `--host`/`--port`
before `MCP_SERVER.serve()`, matching what the GUI plugin already does. `--port` is
`required=True` and the manager always passes a concrete free port, so the value is
known up front; it has to be set before `serve(background=False)`, which blocks.

Severity note: I initially wrote this off as a broken convenience, which was wrong.
`rpc`'s `_output_cache` has no readers outside `rpc.py` and no tool exposes it, so
`/output/<id>.json` is the only way to reach it. `get_cached_output` is not a
fallback -- it reads the router's `ResponseCache`, which holds the already-truncated
preview. With a dead base URL the remainder of the output was unrecoverable.

Two tests, both verified to fail without the one-line change:

- the URL names the worker's own port
- it is set *before* `serve()` (a URL set afterwards would never apply)

They stub `idapro` / `ida_auto` / `ida_multi_mcp.ida_mcp` via `monkeypatch.setitem`
on `sys.modules`, following the pattern in `test_utils_pure.py`, so no IDA is
needed.

Full suite: 418 passed, 4 skipped.

The dead 13337 default in `rpc.py:20` is left alone here and noted in #33 as a
separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
