### PR TITLE
fix(rpc): stop advertising a download URL nobody answers

### DIFF
--- a/src/ida_multi_mcp/ida_mcp/rpc.py
+++ b/src/ida_multi_mcp/ida_mcp/rpc.py
@@ -17,7 +17,11 @@ OUTPUT_CACHE_MAX_SIZE = 100
 OUTPUT_CACHE_TTL_SECONDS = 600  # 10 minutes
 _output_cache: dict[str, tuple[Any, float]] = {}  # id -> (data, timestamp)
 _output_cache_lock = threading.Lock()  # Thread safety for concurrent HTTP requests
-_download_base_url: str = os.environ.get("IDA_MCP_URL", "http://127.0.0.1:13337")
+# Unset until whoever serves the /output/ route names their own port. There is no
+# sensible default: the cache below is this process's module state, so only this
+# process can answer, and guessing a port would advertise a dead address. Callers
+# that serve the route must call set_download_base_url().
+_download_base_url: str | None = os.environ.get("IDA_MCP_URL")
 
 
 def set_download_base_url(url: str) -> None:
@@ -25,7 +29,7 @@ def set_download_base_url(url: str) -> None:
     _download_base_url = url.rstrip("/")
 
 
-def get_download_base_url() -> str:
+def get_download_base_url() -> str | None:
     return _download_base_url
 
 
@@ -63,14 +67,25 @@ def _truncate_value(value: Any, depth: int = 0) -> Any:
 
 
 def _add_download_info(result: Any, output_id: str, total_chars: int) -> Any:
-    download_url = f"{_download_base_url}/output/{output_id}.json"
     info = {
         "_output_truncated": True,
         "_total_chars": total_chars,
         "_output_id": output_id,
-        "_download_url": download_url,
-        "_download_hint": f"Output truncated. Run: curl -o .ida-mcp/{output_id}.json {download_url}",
     }
+    if _download_base_url:
+        download_url = f"{_download_base_url}/output/{output_id}.json"
+        info["_download_url"] = download_url
+        info["_download_hint"] = (
+            f"Output truncated. Run: curl -o .ida-mcp/{output_id}.json {download_url}"
+        )
+    else:
+        # Say so rather than hand out a URL nobody answers. The remainder of the
+        # output is only reachable over /output/, so a wrong address loses it.
+        info["_download_error"] = (
+            "Output truncated, but no download URL is configured for this instance "
+            "(set_download_base_url was never called). The remaining "
+            f"{total_chars:,} chars cannot be retrieved."
+        )
 
     if isinstance(result, dict):
         return {**result, **info}

--- a/tests/test_rpc_download_info.py
+++ b/tests/test_rpc_download_info.py
@@ -1,0 +1,97 @@
+"""Truncated-output metadata must never advertise a URL nobody answers.
+
+The remainder of a truncated result lives in rpc's `_output_cache`, reachable
+only over the `/output/<id>.json` route on the process that holds it. A wrong
+base URL therefore loses the data rather than merely misaddressing it, so an
+unset base URL has to say so instead of guessing a port.
+"""
+
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stubs so `ida_multi_mcp.ida_mcp.__init__` can run without IDA. rpc itself is
+# left real -- it only depends on the bundled zeromcp copy. setdefault keeps
+# this idempotent when another test module has already installed stubs.
+# ---------------------------------------------------------------------------
+
+for _name in ("ida_bytes", "ida_funcs", "ida_hexrays", "ida_kernwin", "ida_nalt",
+              "ida_typeinf", "ida_ida", "ida_lines", "idaapi", "idautils", "idc"):
+    sys.modules.setdefault(_name, MagicMock())
+
+_PKG = "ida_multi_mcp.ida_mcp"
+
+if f"{_PKG}.sync" not in sys.modules:
+    _sync = types.ModuleType(f"{_PKG}.sync")
+    _sync.IDAError = type("IDAError", (Exception,), {})
+    _sync.IDASyncError = type("IDASyncError", (Exception,), {})
+    _sync.CancelledError = type("CancelledError", (Exception,), {})
+    _sync.idasync = lambda f: f
+    _sync.ida_major = 9
+    sys.modules[f"{_PKG}.sync"] = _sync
+
+# Only the api_* modules and http need faking: utils and compat load fine once the
+# ida_* stubs above are in place, and other test modules import the real ones.
+for _sub in ("http", "framework",
+             "api_core", "api_analysis", "api_memory", "api_types", "api_modify",
+             "api_stack", "api_debug", "api_python", "api_resources", "api_survey",
+             "api_composite", "api_similarity"):
+    sys.modules.setdefault(f"{_PKG}.{_sub}", MagicMock())
+
+
+@pytest.fixture
+def rpc():
+    mod = importlib.import_module(f"{_PKG}.rpc")
+    # A MagicMock would satisfy every assertion below by accident.
+    assert isinstance(mod, types.ModuleType), "expected the real rpc module, got a stub"
+    return mod
+
+
+class TestDownloadInfoWithBaseUrl:
+    def test_url_and_hint_use_the_configured_base(self, rpc, monkeypatch):
+        monkeypatch.setattr(rpc, "_download_base_url", "http://127.0.0.1:54321")
+
+        info = rpc._add_download_info({"data": "x"}, "abc123", 90_000)
+
+        assert info["_download_url"] == "http://127.0.0.1:54321/output/abc123.json"
+        assert "curl" in info["_download_hint"]
+        assert "_download_error" not in info
+
+    def test_set_download_base_url_strips_trailing_slash(self, rpc, monkeypatch):
+        monkeypatch.setattr(rpc, "_download_base_url", None)
+        rpc.set_download_base_url("http://127.0.0.1:54321/")
+
+        assert rpc.get_download_base_url() == "http://127.0.0.1:54321"
+
+
+class TestDownloadInfoWithoutBaseUrl:
+    def test_no_url_is_advertised(self, rpc, monkeypatch):
+        monkeypatch.setattr(rpc, "_download_base_url", None)
+
+        info = rpc._add_download_info({"data": "x"}, "abc123", 90_000)
+
+        assert "_download_url" not in info
+        assert "_download_hint" not in info
+
+    def test_it_says_the_output_is_unreachable(self, rpc, monkeypatch):
+        monkeypatch.setattr(rpc, "_download_base_url", None)
+
+        info = rpc._add_download_info({"data": "x"}, "abc123", 90_000)
+
+        assert "_download_error" in info
+        assert "90,000" in info["_download_error"]
+
+    def test_output_id_survives_so_the_truncation_is_still_traceable(
+        self, rpc, monkeypatch,
+    ):
+        monkeypatch.setattr(rpc, "_download_base_url", None)
+
+        info = rpc._add_download_info({"data": "x"}, "abc123", 90_000)
+
+        assert info["_output_id"] == "abc123"
+        assert info["_output_truncated"] is True
+        assert info["_total_chars"] == 90_000


### PR DESCRIPTION
Follow-up cleanup noted at the end of #33.

`_download_base_url` defaulted to `http://127.0.0.1:13337`, a constant inherited
from the ida-pro-mcp lineage where a broker listened on that port. This project
binds no fixed port, so the default was never correct -- and because rpc's
`_output_cache` is reachable only over `/output/<id>.json`, handing out a dead
address silently lost the remainder of a truncated result.

Changes:

- default to unset (`IDA_MCP_URL` still overrides)
- when unset, emit `_download_error` saying the remaining chars cannot be
  retrieved, instead of `_download_url`/`_download_hint` pointing at a guess
- `_output_id`, `_output_truncated` and `_total_chars` are unchanged, so the
  truncation stays traceable either way

Both processes that serve the route set the base URL: the GUI plugin already did,
and the idalib worker does as of #34. The unset branch is therefore a loud
failure rather than a routine path.

Five tests; the two behavioural ones (`test_no_url_is_advertised`,
`test_it_says_the_output_is_unreachable`) were verified to fail on `main`. The
test module stubs the IDA C modules and the `api_*` submodules so the real `rpc`
can be imported without IDA, following `test_utils_pure.py`.

Full suite: 421 passed, 4 skipped. `ruff check --select F821,F811` clean.

Best reviewed after #34, though the two are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
