### PR TITLE
feat(cli): add --verify to check the installed plugin loader

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 This guide is for AI agents. Follow each step exactly.
 
-Last updated: 2026-02-17
+Last updated: 2026-07-30
 Governance reference: `docs/README.md`
 Authority note: this document is operational guidance and must not redefine contracts.
 
@@ -206,18 +206,25 @@ Pass criteria:
 
 ### 2) Plugin deployment health
 
-macOS/Linux:
 ```bash
-ls -l ~/.idapro/plugins/ida_multi_mcp.py
-```
-
-Windows (PowerShell):
-```powershell
-Get-Item "$env:APPDATA\\Hex-Rays\\IDA Pro\\plugins\\ida_multi_mcp.py"
+ida-multi-mcp --verify
 ```
 
 Pass criteria:
-- loader file exists in IDA plugins directory
+- exit code is 0 and the JSON reports `"match": true`
+
+`--verify` compares the sha256 of the installed loader against the packaged one,
+reading through a symlink when the install is symlinked. Do not judge this by file
+size: `--install` prefers a symlink, and Windows reports a symlink's own length as
+0 bytes, so a correct install looks empty to `Get-Item` and to anything else that
+inspects the link rather than its target.
+
+Reported `mode` values:
+- `symlink` — linked to the packaged loader; picks up package updates directly
+- `copy` — a copy was made because symlinks were unavailable (on Windows this
+  needs Administrator or Developer Mode). Re-run `--install` after upgrading the
+  package, since a copy does not track it
+- `missing` — nothing installed at that path
 
 ### 3) Runtime registration health (requires IDA open with a binary)
 
@@ -244,8 +251,9 @@ If post-flight checks fail, apply fixes in order.
 1. Python mismatch suspected:
    - Re-check IDA console Python version (`import sys; print(sys.version)`).
    - Reinstall with that exact version (`python3.11 -m pip install ...` or `py -3.12 -m pip install ...`).
-2. Plugin loader missing:
+2. Plugin loader missing or stale (`--verify` reports `"match": false`):
    - Re-run `ida-multi-mcp --install` (or `--install --ida-dir <IDA_DIR>` for custom installs).
+   - Re-run `ida-multi-mcp --verify` to confirm `"match": true`.
 3. No instances registered:
    - Restart IDA.
    - Open any binary.

--- a/src/ida_multi_mcp/__main__.py
+++ b/src/ida_multi_mcp/__main__.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 import argparse
+import hashlib
 import json
 import tempfile
 import time
@@ -1162,6 +1163,76 @@ def cmd_config(args):
     return 0
 
 
+def _sha256_file(path: Path) -> str | None:
+    """Content hash, reading through a symlink. None when unreadable."""
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _loader_install_state(custom_dir=None) -> dict:
+    """Describe the installed loader: where, how, and whether it matches ours.
+
+    File size is not a usable check here: Windows reports a symlink's own length
+    as 0 bytes, so a correctly symlinked loader looks empty to `Get-Item` and to
+    anything else reading the link rather than its target. Compare content hashes
+    through the link instead, which is mode-agnostic.
+    """
+    packaged = Path(__file__).parent / "plugin" / "ida_multi_mcp_loader.py"
+    installed = _get_ida_plugins_dir(custom_dir) / "ida_multi_mcp.py"
+
+    is_symlink = installed.is_symlink()
+    exists = installed.exists()  # follows the link, so a dangling one is False
+
+    if is_symlink:
+        mode = "symlink"
+    elif exists:
+        mode = "copy"
+    else:
+        mode = "missing"
+
+    link_target = None
+    if is_symlink:
+        try:
+            link_target = str(installed.resolve())
+        except OSError:
+            pass
+
+    packaged_sha = _sha256_file(packaged)
+    installed_sha = _sha256_file(installed) if exists else None
+
+    return {
+        "packaged_loader": str(packaged),
+        "installed_loader": str(installed),
+        "mode": mode,
+        "exists": exists,
+        "link_target": link_target,
+        "packaged_sha256": packaged_sha,
+        "installed_sha256": installed_sha,
+        "match": bool(installed_sha and installed_sha == packaged_sha),
+    }
+
+
+def cmd_verify(args):
+    """Report installed-loader state as JSON. Exit 0 only when it matches."""
+    state = _loader_install_state(args.ida_dir)
+    print(json.dumps(state, indent=2))
+
+    if state["match"]:
+        return 0
+    if state["mode"] == "missing":
+        print("\n  Loader is not installed. Run: ida-multi-mcp --install",
+              file=sys.stderr)
+    elif state["installed_sha256"] is None:
+        print("\n  Loader path exists but could not be read (dangling symlink?). "
+              "Run: ida-multi-mcp --install", file=sys.stderr)
+    else:
+        print("\n  Installed loader differs from the packaged one, so it is stale. "
+              "Run: ida-multi-mcp --install", file=sys.stderr)
+    return 1
+
+
 def main():
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -1184,8 +1255,12 @@ def main():
         help="Print MCP client configuration JSON"
     )
     parser.add_argument(
+        "--verify", action="store_true",
+        help="Verify the installed IDA plugin loader (JSON; exit 1 if stale or missing)"
+    )
+    parser.add_argument(
         "--ida-dir", type=str, default=None,
-        help="Custom IDA Pro directory (for --install/--uninstall)"
+        help="Custom IDA Pro directory (for --install/--uninstall/--verify)"
     )
     parser.add_argument(
         "--registry", type=str, default=None,
@@ -1203,6 +1278,8 @@ def main():
         sys.exit(cmd_install(args))
     elif args.uninstall:
         sys.exit(cmd_uninstall(args))
+    elif args.verify:
+        sys.exit(cmd_verify(args))
     elif args.list:
         cmd_list(args)
         return

--- a/tests/test_verify_loader.py
+++ b/tests/test_verify_loader.py
@@ -1,0 +1,91 @@
+"""`--verify` must judge the installed loader by content, not by file size.
+
+Windows reports a symlink's own length as 0 bytes, so a correctly symlinked
+loader looks empty to anything inspecting the link instead of its target. These
+tests pin that both install modes verify identically, and that a stale or
+dangling loader is reported as such rather than as "present".
+"""
+
+from pathlib import Path
+
+import pytest
+
+import ida_multi_mcp
+from ida_multi_mcp.__main__ import _loader_install_state
+
+
+@pytest.fixture
+def ida_dir(tmp_path):
+    """A fake IDA directory; _loader_install_state appends `plugins/` itself."""
+    (tmp_path / "plugins").mkdir()
+    return tmp_path
+
+
+def _packaged_bytes() -> bytes:
+    src = Path(ida_multi_mcp.__file__).parent / "plugin" / "ida_multi_mcp_loader.py"
+    return src.read_bytes()
+
+
+def _try_symlink(link, target):
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlinks unavailable here: {exc}")
+
+
+class TestNotInstalled:
+    def test_missing_loader_is_reported_as_missing(self, ida_dir):
+        state = _loader_install_state(str(ida_dir))
+
+        assert state["mode"] == "missing"
+        assert state["exists"] is False
+        assert state["installed_sha256"] is None
+        assert state["match"] is False
+
+
+class TestCopyInstall:
+    def test_matching_copy_verifies(self, ida_dir):
+        (ida_dir / "plugins" / "ida_multi_mcp.py").write_bytes(_packaged_bytes())
+
+        state = _loader_install_state(str(ida_dir))
+
+        assert state["mode"] == "copy"
+        assert state["match"] is True
+        assert state["installed_sha256"] == state["packaged_sha256"]
+
+    def test_stale_copy_does_not_verify(self, ida_dir):
+        (ida_dir / "plugins" / "ida_multi_mcp.py").write_bytes(
+            _packaged_bytes() + b"\n# left over from an older version\n"
+        )
+
+        state = _loader_install_state(str(ida_dir))
+
+        assert state["mode"] == "copy"
+        assert state["exists"] is True
+        assert state["match"] is False
+
+
+class TestSymlinkInstall:
+    def test_symlink_verifies_by_content_not_size(self, ida_dir, tmp_path):
+        target = tmp_path / "loader_source.py"
+        target.write_bytes(_packaged_bytes())
+        link = ida_dir / "plugins" / "ida_multi_mcp.py"
+        _try_symlink(link, target)
+
+        state = _loader_install_state(str(ida_dir))
+
+        assert state["mode"] == "symlink"
+        assert state["link_target"] is not None
+        # The check that a size-based test would get wrong.
+        assert state["match"] is True
+
+    def test_dangling_symlink_is_not_reported_as_present(self, ida_dir, tmp_path):
+        link = ida_dir / "plugins" / "ida_multi_mcp.py"
+        _try_symlink(link, tmp_path / "gone.py")
+
+        state = _loader_install_state(str(ida_dir))
+
+        assert state["mode"] == "symlink"
+        assert state["exists"] is False
+        assert state["installed_sha256"] is None
+        assert state["match"] is False


### PR DESCRIPTION
This is the "keep symlink, fix verification instead" half of the installer
discussion in #32.

## Why

Post-flight step 2 in `docs/installation.md` told the reader to run `Get-Item` on
the loader path and judge by "loader file exists". That output table includes
`Length`, which Windows reports as **0** for a symlink -- and `--install` prefers a
symlink -- so a correct install reads as an empty file to anyone inspecting the
link rather than its target. The ambiguity belongs to the check, not to the
install mode, so this fixes the check.

## What

`ida-multi-mcp --verify` prints the loader's install state as JSON and exits
non-zero when it is missing, stale or dangling:

```json
{
  "packaged_loader": "...",
  "installed_loader": "...",
  "mode": "symlink",
  "exists": true,
  "link_target": "...",
  "packaged_sha256": "98de30fc...",
  "installed_sha256": "98de30fc...",
  "match": true
}
```

Content hashes are read through the link, so both install modes verify
identically. Agents and scripts get an unambiguous signal instead of an
eyeballed file listing.

Docs changes:

- post-flight step 2 now runs `--verify`, pass criterion is `"match": true`
- each `mode` is explained, including that a `copy` does not track package
  upgrades and needs a re-install (the cost of switching away from symlinks)
- the remediation playbook closes the loop with a re-verify

## Tests

Five tests: missing, matching copy, stale copy, symlinked, dangling symlink. The
two symlink cases skip where symlink creation is unprivileged (Windows without
Administrator or Developer Mode) and run on the ubuntu and macos matrix legs.

Local: 419 passed, 6 skipped. `ruff check --select F821,F811` clean.

Verified by hand in both directions against a fake IDA dir -- `mode: missing` with
exit 1, and `mode: copy` / `match: true` with exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
