### PR TITLE
Fix Windows MCP handshake crash under PYTHONUTF8

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -64,6 +64,25 @@ This usually means IDA's Python cannot find the package due to a **Python versio
 </details>
 
 <details>
+<summary>MCP handshake fails on Windows: "connection closed: initialize response"</summary>
+
+This happens when the MCP client starts Python in UTF-8 mode (`PYTHONUTF8=1`, Grok and some Codex/Claude setups) on a non-English Windows console.
+
+`ida-multi-mcp` scans for live IDA GUI processes with `tasklist` / `netstat` **before** answering MCP `initialize`. Those utilities emit OEM/GBK. With `text=True` and UTF-8 decoding, CPython's stdout reader raises `UnicodeDecodeError`, `check_output` returns `None`, and `out.strip()` crashes the process.
+
+Current `ida-multi-mcp` decodes those commands as OEM with replacement and treats discovery failures as "no GUI instances" so headless `idalib_*` tools still start.
+
+If you are on an older install:
+
+```bash
+pip install -U git+https://github.com/MeroZemory/ida-multi-mcp.git
+```
+
+Then restart the MCP client. You do **not** need IDA GUI running for the stdio server to handshake.
+
+</details>
+
+<details>
 <summary>MCP server fails to connect (macOS)</summary>
 
 If your MCP client shows `Status: failed` for ida-multi-mcp, the registered command may point to the wrong Python version.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,7 @@
 # Troubleshooting
 
+Last updated: 2026-09-09
+
 [← back to README](../README.md)
 
 ## Troubleshooting
@@ -71,6 +73,8 @@ This happens when the MCP client starts Python in UTF-8 mode (`PYTHONUTF8=1`, Gr
 `ida-multi-mcp` scans for live IDA GUI processes with `tasklist` / `netstat` **before** answering MCP `initialize`. Those utilities emit OEM/GBK. With `text=True` and UTF-8 decoding, CPython's stdout reader raises `UnicodeDecodeError`, `check_output` returns `None`, and `out.strip()` crashes the process.
 
 Current `ida-multi-mcp` decodes those commands as OEM with replacement and treats discovery failures as "no GUI instances" so headless `idalib_*` tools still start.
+
+The Windows discovery implementation is in [`src/ida_multi_mcp/health.py`](../src/ida_multi_mcp/health.py).
 
 If you are on an older install:
 

--- a/src/ida_multi_mcp/health.py
+++ b/src/ida_multi_mcp/health.py
@@ -192,106 +192,117 @@ def query_binary_metadata(host: str, port: int, timeout: float = 5.0) -> dict | 
     return None
 
 
+_IDA_PROCESS_NAMES = {
+    "ida.exe", "ida64.exe", "idat.exe", "idat64.exe",
+    "ida", "ida64", "idat", "idat64",
+}
+_LISTEN_STATES = {"LISTENING", "侦听"}
+
+
+def _console_output(cmd: list[str], timeout: int = 10) -> str:
+    """Run a console utility and return decoded stdout.
+
+    Windows ``tasklist`` / ``netstat`` emit OEM/GBK. Python UTF-8 mode
+    (``PYTHONUTF8=1``, common in MCP clients) makes ``text=True`` decode
+    as UTF-8. The reader thread then raises ``UnicodeDecodeError``,
+    ``check_output`` returns ``None``, and callers crash on ``.strip()``
+    before MCP ``initialize`` — the client sees
+    ``handshake failed: connection closed: initialize response``.
+    """
+    kwargs: dict = {
+        "timeout": timeout,
+        "stderr": subprocess.DEVNULL,
+        "errors": "replace",
+    }
+    if sys.platform == "win32":
+        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+        kwargs["encoding"] = "oem"
+    else:
+        kwargs["encoding"] = "utf-8"
+    try:
+        out = subprocess.check_output(cmd, **kwargs)
+    except (subprocess.SubprocessError, OSError, UnicodeError):
+        return ""
+    return out or ""
+
+
 def _find_ida_listening_ports() -> list[tuple[int, int]]:
     """Find TCP ports owned by IDA processes (Windows and Unix).
 
     Returns:
         List of (pid, port) tuples for IDA processes with listening TCP ports
     """
-    ida_names = {"ida.exe", "ida64.exe", "idat.exe", "idat64.exe",
-                 "ida", "ida64", "idat", "idat64"}
-    results = []
+    results: list[tuple[int, int]] = []
 
     if sys.platform == "win32":
-        try:
-            # Get IDA PIDs
-            out = subprocess.check_output(
-                ["tasklist", "/FO", "CSV", "/NH"],
-                text=True, timeout=10, creationflags=subprocess.CREATE_NO_WINDOW,
-            )
-            ida_pids = set()
-            for line in out.strip().splitlines():
-                parts = line.strip('"').split('","')
-                if len(parts) >= 2 and parts[0].lower() in ida_names:
-                    try:
-                        ida_pids.add(int(parts[1]))
-                    except ValueError:
-                        pass
+        out = _console_output(["tasklist", "/FO", "CSV", "/NH"])
+        ida_pids: set[int] = set()
+        for line in out.strip().splitlines():
+            parts = line.strip('"').split('","')
+            if len(parts) >= 2 and parts[0].lower() in _IDA_PROCESS_NAMES:
+                try:
+                    ida_pids.add(int(parts[1]))
+                except ValueError:
+                    continue
+        if not ida_pids:
+            return []
 
-            if not ida_pids:
-                return []
+        netstat = _console_output(["netstat", "-ano", "-p", "TCP"])
+        for line in netstat.splitlines():
+            parts = line.split()
+            if len(parts) < 5:
+                continue
+            if parts[3].upper() not in _LISTEN_STATES:
+                continue
+            try:
+                pid = int(parts[4])
+            except ValueError:
+                continue
+            if pid not in ida_pids:
+                continue
+            # Local address, e.g. 127.0.0.1:57079 or [::1]:57079
+            port_str = parts[1].rsplit(":", 1)[-1]
+            try:
+                results.append((pid, int(port_str)))
+            except ValueError:
+                continue
+        return results
 
-            # Get listening ports for those PIDs
-            out = subprocess.check_output(
-                ["netstat", "-ano", "-p", "TCP"],
-                text=True, timeout=10, creationflags=subprocess.CREATE_NO_WINDOW,
-            )
-            for line in out.splitlines():
-                parts = line.split()
-                if len(parts) >= 5 and parts[3] == "LISTENING":
+    out = _console_output(["lsof", "-iTCP", "-sTCP:LISTEN", "-nP", "-F", "pcn"])
+    if out:
+        current_pid = None
+        current_name = None
+        for line in out.splitlines():
+            if line.startswith("p"):
+                current_pid = int(line[1:])
+            elif line.startswith("c"):
+                current_name = line[1:]
+            elif line.startswith("n") and current_pid and current_name:
+                if current_name.lower() in _IDA_PROCESS_NAMES:
+                    port_str = line.rsplit(":", 1)[-1]
                     try:
-                        pid = int(parts[4])
+                        results.append((current_pid, int(port_str)))
                     except ValueError:
                         continue
-                    if pid in ida_pids:
-                        # Parse local address (e.g. 127.0.0.1:57079)
-                        addr = parts[1]
-                        port_str = addr.rsplit(":", 1)[-1]
-                        try:
-                            results.append((pid, int(port_str)))
-                        except ValueError:
-                            pass
-        except (subprocess.SubprocessError, OSError):
-            pass
-    else:
-        # Unix: use lsof
-        try:
-            out = subprocess.check_output(
-                ["lsof", "-iTCP", "-sTCP:LISTEN", "-nP", "-F", "pcn"],
-                text=True, timeout=10,
-            )
-            current_pid = None
-            current_name = None
-            for line in out.splitlines():
-                if line.startswith("p"):
-                    current_pid = int(line[1:])
-                elif line.startswith("c"):
-                    current_name = line[1:]
-                elif line.startswith("n") and current_pid and current_name:
-                    if current_name.lower() in ida_names:
-                        port_str = line.rsplit(":", 1)[-1]
-                        try:
-                            results.append((current_pid, int(port_str)))
-                        except ValueError:
-                            pass
-        except (subprocess.SubprocessError, OSError, FileNotFoundError):
-            # lsof not available, try ss
-            try:
-                out = subprocess.check_output(
-                    ["ss", "-tlnp"],
-                    text=True, timeout=10,
-                )
-                for line in out.splitlines():
-                    for name in ida_names:
-                        if name in line:
-                            # Extract port and pid
-                            parts = line.split()
-                            for part in parts:
-                                if ":" in part:
-                                    port_str = part.rsplit(":", 1)[-1]
-                                    try:
-                                        port = int(port_str)
-                                        # Extract pid from pid=NNNN
-                                        import re
-                                        m = re.search(r"pid=(\d+)", line)
-                                        if m:
-                                            results.append((int(m.group(1)), port))
-                                        break
-                                    except ValueError:
-                                        continue
-            except (subprocess.SubprocessError, OSError, FileNotFoundError):
-                pass
+        return results
 
+    out = _console_output(["ss", "-tlnp"])
+    import re
+    for line in out.splitlines():
+        if not any(name in line for name in _IDA_PROCESS_NAMES):
+            continue
+        match = re.search(r"pid=(\d+)", line)
+        if not match:
+            continue
+        for part in line.split():
+            if ":" not in part:
+                continue
+            port_str = part.rsplit(":", 1)[-1]
+            try:
+                results.append((int(match.group(1)), int(port_str)))
+            except ValueError:
+                continue
+            break
     return results
 
 
@@ -303,6 +314,7 @@ def rediscover_instances(registry: "InstanceRegistry") -> list[str]:
     registers any that aren't already in the registry.
 
     Called on proxy startup when the registry has no registered instances.
+    Discovery failures must not prevent MCP initialize / stdio serve.
 
     Args:
         registry: The instance registry
@@ -310,6 +322,14 @@ def rediscover_instances(registry: "InstanceRegistry") -> list[str]:
     Returns:
         List of newly registered instance IDs
     """
+    try:
+        return _rediscover_instances(registry)
+    except Exception as exc:
+        print(f"[ida-multi-mcp] instance rediscovery skipped: {exc}", file=sys.stderr)
+        return []
+
+
+def _rediscover_instances(registry: "InstanceRegistry") -> list[str]:
     registered = []
     existing = registry.list_instances()
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -12,6 +12,9 @@ from ida_multi_mcp.health import (
     check_instance_health,
     cleanup_stale_instances,
     query_binary_metadata,
+    rediscover_instances,
+    _console_output,
+    _find_ida_listening_ports,
 )
 
 
@@ -158,3 +161,70 @@ class TestQueryBinaryMetadata:
 
     def test_rejects_non_localhost(self):
         assert query_binary_metadata("10.0.0.1", 5000) is None
+
+
+# ---------------------------------------------------------------------------
+# Windows console discovery (PYTHONUTF8 / OEM)
+# ---------------------------------------------------------------------------
+
+class TestConsoleOutput:
+    def test_windows_uses_oem_and_replace(self):
+        with patch("ida_multi_mcp.health.sys.platform", "win32"):
+            with patch("subprocess.check_output", return_value=None) as mock_output:
+                assert _console_output(["tasklist", "/FO", "CSV", "/NH"]) == ""
+        kwargs = mock_output.call_args.kwargs
+        assert kwargs["encoding"] == "oem"
+        assert kwargs["errors"] == "replace"
+
+    def test_none_stdout_becomes_empty_string(self):
+        with patch("subprocess.check_output", return_value=None):
+            assert _console_output(["tasklist"]) == ""
+
+    def test_unicode_decode_error_becomes_empty_string(self):
+        err = UnicodeDecodeError("utf-8", b"\xb1", 0, 1, "invalid start byte")
+        with patch("subprocess.check_output", side_effect=err):
+            assert _console_output(["tasklist"]) == ""
+
+
+class TestFindIdaListeningPorts:
+    def test_empty_console_output_does_not_crash(self):
+        with patch("ida_multi_mcp.health.sys.platform", "win32"):
+            with patch("ida_multi_mcp.health._console_output", return_value=""):
+                assert _find_ida_listening_ports() == []
+
+    def test_parses_english_listen_state(self):
+        def fake_output(cmd, timeout=10):
+            if cmd[0] == "tasklist":
+                return '"ida.exe","4242","Console","1","100,000 K"\n'
+            return "  TCP    127.0.0.1:57079         0.0.0.0:0              LISTENING       4242\n"
+
+        with patch("ida_multi_mcp.health.sys.platform", "win32"):
+            with patch("ida_multi_mcp.health._console_output", side_effect=fake_output):
+                assert _find_ida_listening_ports() == [(4242, 57079)]
+
+    def test_parses_localized_listen_state_and_session_name(self):
+        def fake_output(cmd, timeout=10):
+            if cmd[0] == "tasklist":
+                return '"ida64.exe","4242","控制台","1","100,000 K"\n'
+            return "  TCP    127.0.0.1:57079         0.0.0.0:0              侦听            4242\n"
+
+        with patch("ida_multi_mcp.health.sys.platform", "win32"):
+            with patch("ida_multi_mcp.health._console_output", side_effect=fake_output):
+                assert _find_ida_listening_ports() == [(4242, 57079)]
+
+    def test_parses_ipv6_local_address(self):
+        def fake_output(cmd, timeout=10):
+            if cmd[0] == "tasklist":
+                return '"ida.exe","99","Console","1","8 K"\n'
+            return "  TCP    [::1]:12345            [::]:0                 LISTENING       99\n"
+
+        with patch("ida_multi_mcp.health.sys.platform", "win32"):
+            with patch("ida_multi_mcp.health._console_output", side_effect=fake_output):
+                assert _find_ida_listening_ports() == [(99, 12345)]
+
+
+class TestRediscoverInstances:
+    def test_swallows_unexpected_errors(self):
+        registry = MagicMock()
+        registry.list_instances.side_effect = RuntimeError("boom")
+        assert rediscover_instances(registry) == []

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -170,8 +170,9 @@ class TestQueryBinaryMetadata:
 class TestConsoleOutput:
     def test_windows_uses_oem_and_replace(self):
         with patch("ida_multi_mcp.health.sys.platform", "win32"):
-            with patch("subprocess.check_output", return_value=None) as mock_output:
-                assert _console_output(["tasklist", "/FO", "CSV", "/NH"]) == ""
+            with patch("subprocess.CREATE_NO_WINDOW", 0, create=True):
+                with patch("subprocess.check_output", return_value=None) as mock_output:
+                    assert _console_output(["tasklist", "/FO", "CSV", "/NH"]) == ""
         kwargs = mock_output.call_args.kwargs
         assert kwargs["encoding"] == "oem"
         assert kwargs["errors"] == "replace"


### PR DESCRIPTION
## Problem

On Chinese (and other non-English) Windows, MCP clients such as Grok start Python in UTF-8 mode (`PYTHONUTF8=1`). `ida-multi-mcp` scans for live IDA GUI processes with `tasklist /FO CSV` and `netstat` **before** answering MCP `initialize`.

Those utilities emit OEM/GBK. With `subprocess.check_output(..., text=True)` and no `encoding=`, CPython decodes as UTF-8. The stdout reader thread raises `UnicodeDecodeError` (often `byte 0xb1`), `check_output` returns `None`, and `out.strip()` crashes the process. The client reports:

`
handshake failed: connection closed: initialize response
`

This happens even when no IDA GUI is running. Headless `idalib_*` tools never get a chance to start.

Reproduced with Python 3.13 UTF-8 mode: `text=True` on `tasklist` returns `None`; the raw bytes decode with GBK/OEM.

## Fix

- Decode console utilities with `encoding="oem"` on Windows and UTF-8 elsewhere, always `errors="replace"`.
- Treat empty/`None` stdout as "no GUI instances" instead of crashing.
- Accept localized listen states (`LISTENING` / `侦听`) and IPv6 local addresses.
- Catch unexpected rediscovery errors so they cannot prevent MCP `initialize`.

## Tests

`pytest tests/test_health.py`: 18 passed, 3 skipped (Unix-only cases on Windows).

Live stdio `initialize` under `PYTHONUTF8=1` now returns `serverInfo.name=ida-multi-mcp` with no `UnicodeDecodeError`.