### PR TITLE
fix: stabilize managed idalib IDB lifecycle on Windows

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,9 @@ Location:
 Each registered instance includes:
 - **id** — 4-char instance identifier (k7m2, px3a, etc.)
 - **pid** — Process ID of the IDA Pro instance
-- **host** — Always 127.0.0.1 (localhost)
+- **host** — Loopback only: Windows managed workers prefer `::1` after a
+  successful bind probe and otherwise use `127.0.0.1`; all other platforms use
+  `127.0.0.1`
 - **port** — Dynamically assigned HTTP port
 - **binary_name** — Filename (malware.exe, driver.dll, etc.)
 - **binary_path** — Full path to binary
@@ -76,6 +78,7 @@ When you open a different binary in an IDA instance:
 
 | Decision | Rationale |
 |----------|-----------|
+| Loopback-only transport | Keeps workers local; Windows prefers IPv6 loopback when available to avoid IPv4 filter-stack resets, with IPv4 fallback |
 | Port 0 (auto-assigned) | Eliminates port conflicts, scales to unlimited instances |
 | 4-char base36 IDs | Short, readable, 1.68M combinations, easy to remember |
 | File-based registry | Simple, cross-process, debuggable, no database dependency |

--- a/src/ida_multi_mcp/ida_mcp/http.py
+++ b/src/ida_multi_mcp/ida_mcp/http.py
@@ -173,7 +173,11 @@ class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
         """
         origin = self.headers.get("Origin")
         port = self.server_port
-        if origin not in (f"http://127.0.0.1:{port}", f"http://localhost:{port}"):
+        if origin not in (
+            f"http://127.0.0.1:{port}",
+            f"http://localhost:{port}",
+            f"http://[::1]:{port}",
+        ):
             self.send_error(403, "Invalid Origin")
             return False
         return True
@@ -185,7 +189,11 @@ class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
         """
         host = self.headers.get("Host")
         port = self.server_port
-        if host not in (f"127.0.0.1:{port}", f"localhost:{port}"):
+        if host not in (
+            f"127.0.0.1:{port}",
+            f"localhost:{port}",
+            f"[::1]:{port}",
+        ):
             self.send_error(403, "Invalid Host")
             return False
         return True

--- a/src/ida_multi_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_multi_mcp/ida_mcp/zeromcp/mcp.py
@@ -12,6 +12,7 @@ import time
 import uuid
 import json
 import inspect
+import socket
 import threading
 import traceback
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer, HTTPServer
@@ -21,6 +22,29 @@ from urllib.parse import urlparse, parse_qs
 from io import BufferedIOBase
 
 from .jsonrpc import JsonRpcRegistry, JsonRpcError, JsonRpcException, get_current_request_id, register_pending_request, unregister_pending_request, cancel_request
+
+
+class _IPv6HTTPServer(HTTPServer):
+    address_family = socket.AF_INET6
+
+
+class _IPv6ThreadingHTTPServer(ThreadingHTTPServer):
+    address_family = socket.AF_INET6
+
+
+def _http_server_class(host: str, background: bool):
+    if host == "::1":
+        return _IPv6ThreadingHTTPServer if background else _IPv6HTTPServer
+    return ThreadingHTTPServer if background else HTTPServer
+
+
+def _host_header_hostname(host_header: str) -> str | None:
+    if not host_header:
+        return ""
+    try:
+        return urlparse(f"//{host_header}").hostname
+    except ValueError:
+        return None
 
 class McpToolError(Exception):
     def __init__(self, message: str):
@@ -147,8 +171,7 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
     def _check_host_header(self) -> bool:
         """Validate Host header to prevent DNS rebinding attacks on all endpoints."""
         host_header = self.headers.get("Host", "")
-        # Strip port to get hostname
-        hostname = host_header.split(":")[0] if host_header else ""
+        hostname = _host_header_hostname(host_header)
         if hostname not in ("127.0.0.1", "localhost", "::1", ""):
             self.send_error(403, "Forbidden: invalid Host header")
             return False
@@ -361,7 +384,7 @@ class McpServer:
 
         # Create server with deferred binding
         assert issubclass(request_handler, McpHttpRequestHandler)
-        self._http_server = (ThreadingHTTPServer if background else HTTPServer)(
+        self._http_server = _http_server_class(host, background)(
             (host, port),
             request_handler,
             bind_and_activate=False

--- a/src/ida_multi_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_multi_mcp/ida_mcp/zeromcp/mcp.py
@@ -409,9 +409,10 @@ class McpServer:
         # Only start thread after successful bind
         self._running = True
 
+        url_host = f"[{host}]" if ":" in host else host
         print("[MCP] Server started:")
-        print(f"  Streamable HTTP: http://{host}:{port}/mcp")
-        print(f"  SSE: http://{host}:{port}/sse")
+        print(f"  Streamable HTTP: http://{url_host}:{port}/mcp")
+        print(f"  SSE: http://{url_host}:{port}/sse")
 
         def serve_forever():
             try:

--- a/src/ida_multi_mcp/idalib_manager.py
+++ b/src/ida_multi_mcp/idalib_manager.py
@@ -8,7 +8,10 @@ Does NOT depend on ``idapro`` — purely manages subprocesses.
 from __future__ import annotations
 
 import atexit
+import http.client
+import json
 import os
+import secrets
 import socket
 import subprocess
 import sys
@@ -26,6 +29,16 @@ if TYPE_CHECKING:
 _READY_TIMEOUT = 120
 # Poll interval while waiting for worker readiness.
 _READY_POLL_INTERVAL = 0.5
+# A worker can answer the readiness ping a fraction of a second before its
+# resource endpoint is ready.  That matters for IDB inputs: their file name is
+# not necessarily the original module name, so registering the lexical `.i64`
+# or `.idb` name makes every later router identity check fail.
+_IDB_METADATA_QUERY_ATTEMPTS = 4
+_IDB_METADATA_QUERY_INTERVAL = 0.25
+_IDB_SUFFIXES = frozenset({".i64", ".idb"})
+_WORKER_SHUTDOWN_METHOD = "ida-multi-mcp/shutdown"
+_WORKER_SHUTDOWN_TOKEN_ENV = "IDA_MULTI_MCP_WORKER_SHUTDOWN_TOKEN"
+_WORKER_SHUTDOWN_TIMEOUT = 60
 
 # idalib library file name per platform.
 _IDALIB_NAMES = {
@@ -75,9 +88,60 @@ def _find_free_port(host: str = "127.0.0.1") -> int:
 
     There is a small TOCTOU race, but acceptable for localhost-only use.
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    family = socket.AF_INET6 if host == "::1" else socket.AF_INET
+    with socket.socket(family, socket.SOCK_STREAM) as s:
         s.bind((host, 0))
         return s.getsockname()[1]
+
+
+def _preferred_loopback_host() -> str:
+    """Return the most reliable local transport for a managed worker.
+
+    Some Windows network-filter stacks intermittently reset IPv4 loopback
+    connections even though the server successfully handled the request.
+    Prefer the independent IPv6 loopback path when it can actually bind; keep
+    the historical IPv4 endpoint everywhere else and when IPv6 is disabled.
+    """
+    if sys.platform != "win32":
+        return "127.0.0.1"
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as probe:
+            probe.bind(("::1", 0))
+    except OSError:
+        return "127.0.0.1"
+    return "::1"
+
+
+def _request_worker_shutdown(
+    host: str,
+    port: int,
+    token: str,
+    timeout: float = 10.0,
+) -> bool:
+    """Request one authenticated, graceful worker shutdown over loopback."""
+    connection = http.client.HTTPConnection(host, port, timeout=timeout)
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "method": _WORKER_SHUTDOWN_METHOD,
+            "params": {"token": token},
+            "id": 1,
+        }
+    )
+    try:
+        connection.request(
+            "POST",
+            "/mcp",
+            body,
+            {"Content-Type": "application/json"},
+        )
+        response = connection.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+        return response.status == 200 and payload.get("result", {}).get("accepted") is True
+    except Exception:
+        return False
+    finally:
+        connection.close()
 
 
 class IdalibManager:
@@ -98,6 +162,7 @@ class IdalibManager:
         self.python_executable = python_executable or sys.executable
         # instance_id -> subprocess.Popen
         self._processes: dict[str, subprocess.Popen] = {}
+        self._shutdown_tokens: dict[str, str] = {}
         # Register cleanup on interpreter shutdown
         atexit.register(self.close_all_sessions)
 
@@ -109,7 +174,7 @@ class IdalibManager:
         self,
         input_path: str,
         *,
-        host: str = "127.0.0.1",
+        host: str | None = None,
         timeout: int = _READY_TIMEOUT,
         unsafe: bool = False,
     ) -> dict:
@@ -131,12 +196,14 @@ class IdalibManager:
         if not os.path.isfile(resolved_path):
             return {"error": f"File not found: {input_path}"}
 
-        port = _find_free_port(host)
+        selected_host = host or _preferred_loopback_host()
+        port = _find_free_port(selected_host)
 
+        shutdown_token = secrets.token_urlsafe(32)
         cmd = [
             self.python_executable,
             "-m", "ida_multi_mcp.idalib_worker",
-            "--host", host,
+            "--host", selected_host,
             "--port", str(port),
         ]
         if unsafe:
@@ -159,12 +226,15 @@ class IdalibManager:
             # stdout=DEVNULL discards IDA's analysis output.
             # stderr=PIPE is drained by a background thread (see below) to
             # prevent pipe buffer deadlock.
+            worker_env = os.environ.copy()
+            worker_env[_WORKER_SHUTDOWN_TOKEN_ENV] = shutdown_token
             proc = subprocess.Popen(
                 cmd,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 creationflags=creation_flags,
+                env=worker_env,
             )
         except FileNotFoundError:
             return {
@@ -193,14 +263,15 @@ class IdalibManager:
         stderr_thread.start()
 
         # Wait for the worker to become ready.
-        if not self._wait_for_ready(host, port, proc, timeout):
+        if not self._wait_for_ready(selected_host, port, proc, timeout):
             # Worker didn't come up — terminate first so its dying stderr is
             # captured by the drain thread, then collect it for diagnostics.
-            try:
-                proc.terminate()
-                proc.wait(timeout=5)
-            except Exception:
-                proc.kill()
+            self._terminate_gracefully(
+                proc,
+                host=selected_host,
+                port=port,
+                shutdown_token=shutdown_token,
+            )
             stderr_thread.join(timeout=1)
             stderr_text = b"".join(stderr_chunks).decode(errors="replace")[-500:]
             return {
@@ -211,25 +282,57 @@ class IdalibManager:
             }
 
         # Ask the worker for its canonical module name so the registry matches
-        # what the metadata resource reports. Falls back to basename when the
-        # input was an IDB (e.g. foo.exe.i64 → module is "foo.exe") or query fails.
-        metadata = query_binary_metadata(host, port, timeout=5.0)
-        module_name = (metadata or {}).get("module") if metadata else None
+        # what the metadata resource reports. A newly listening worker can
+        # transiently reset this first resource request. Retry only for IDB
+        # inputs, where falling back to the lexical database name would create
+        # a permanently unroutable instance (foo.exe.i64 != foo.exe).
+        is_idb_input = os.path.splitext(resolved_path)[1].casefold() in _IDB_SUFFIXES
+        metadata = None
+        module_name = None
+        attempts = _IDB_METADATA_QUERY_ATTEMPTS if is_idb_input else 1
+        for attempt in range(attempts):
+            metadata = query_binary_metadata(selected_host, port, timeout=5.0)
+            candidate = (metadata or {}).get("module") if metadata else None
+            if isinstance(candidate, str) and candidate.strip():
+                module_name = candidate.strip()
+                break
+            if proc.poll() is not None:
+                break
+            if attempt + 1 < attempts:
+                time.sleep(_IDB_METADATA_QUERY_INTERVAL)
+
+        if is_idb_input and module_name is None:
+            self._terminate_gracefully(
+                proc,
+                host=selected_host,
+                port=port,
+                shutdown_token=shutdown_token,
+            )
+            stderr_thread.join(timeout=1)
+            return {
+                "error": (
+                    "idalib worker became ready, but canonical IDB module metadata "
+                    f"was unavailable after {attempts} attempts; worker stopped "
+                    "without registering an ambiguous instance"
+                )
+            }
+
         binary_name = module_name or os.path.basename(resolved_path)
         instance_id = self.registry.register(
             pid=proc.pid,
             port=port,
             idb_path=resolved_path,
-            host=host,
+            host=selected_host,
             binary_name=binary_name,
             binary_path=resolved_path,
             type="idalib",
         )
 
         self._processes[instance_id] = proc
+        self._shutdown_tokens[instance_id] = shutdown_token
         return {
             "instance_id": instance_id,
-            "host": host,
+            "host": selected_host,
             "port": port,
             "pid": proc.pid,
             "binary": binary_name,
@@ -252,14 +355,28 @@ class IdalibManager:
 
         # Terminate the subprocess, preferring a graceful shutdown so the
         # worker can close its IDB cleanly.
-        self._terminate_gracefully(proc)
+        info = self.registry.get_instance(instance_id)
+        token = self._shutdown_tokens.get(instance_id)
+        self._terminate_gracefully(
+            proc,
+            host=info.get("host") if info else None,
+            port=info.get("port") if info else None,
+            shutdown_token=token,
+        )
 
         del self._processes[instance_id]
+        self._shutdown_tokens.pop(instance_id, None)
         self.registry.unregister(instance_id)
         return {"ok": True}
 
     @staticmethod
-    def _terminate_gracefully(proc: subprocess.Popen) -> None:
+    def _terminate_gracefully(
+        proc: subprocess.Popen,
+        *,
+        host: str | None = None,
+        port: int | None = None,
+        shutdown_token: str | None = None,
+    ) -> None:
         """Ask the worker to shut down cleanly, then force-kill if it lingers.
 
         On Windows, ``proc.terminate()`` maps to TerminateProcess, which the
@@ -269,6 +386,19 @@ class IdalibManager:
         """
         if proc.poll() is not None:
             return
+
+        # Preferred path: an authenticated loopback request makes the HTTP
+        # server return normally, so the worker can pack and close its IDB.
+        # Windows CREATE_NO_WINDOW workers cannot reliably receive CTRL_BREAK.
+        if host and port and shutdown_token:
+            requested = _request_worker_shutdown(host, port, shutdown_token)
+            try:
+                proc.wait(timeout=_WORKER_SHUTDOWN_TIMEOUT if requested else 5)
+                return
+            except subprocess.TimeoutExpired:
+                pass
+            except Exception:
+                pass
 
         # Step 1: graceful request (CTRL_BREAK on Windows, SIGTERM on POSIX).
         try:
@@ -319,6 +449,7 @@ class IdalibManager:
             if not alive:
                 # Clean up dead workers.
                 del self._processes[iid]
+                self._shutdown_tokens.pop(iid, None)
                 self.registry.unregister(iid)
                 continue
             result.append({

--- a/src/ida_multi_mcp/idalib_manager.py
+++ b/src/ida_multi_mcp/idalib_manager.py
@@ -290,13 +290,17 @@ class IdalibManager:
         metadata = None
         module_name = None
         attempts = _IDB_METADATA_QUERY_ATTEMPTS if is_idb_input else 1
+        attempts_made = 0
+        worker_returncode = None
         for attempt in range(attempts):
+            attempts_made = attempt + 1
             metadata = query_binary_metadata(selected_host, port, timeout=5.0)
             candidate = (metadata or {}).get("module") if metadata else None
             if isinstance(candidate, str) and candidate.strip():
                 module_name = candidate.strip()
                 break
-            if proc.poll() is not None:
+            worker_returncode = proc.poll()
+            if worker_returncode is not None:
                 break
             if attempt + 1 < attempts:
                 time.sleep(_IDB_METADATA_QUERY_INTERVAL)
@@ -309,10 +313,20 @@ class IdalibManager:
                 shutdown_token=shutdown_token,
             )
             stderr_thread.join(timeout=1)
+            stderr_text = b"".join(stderr_chunks).decode(errors="replace")[-500:]
+            if worker_returncode is not None:
+                failure_detail = (
+                    f" after {attempts_made} attempt(s); worker exited with code "
+                    f"{worker_returncode}"
+                )
+                if stderr_text:
+                    failure_detail += f". Last stderr: {stderr_text}"
+            else:
+                failure_detail = f" after {attempts_made} attempt(s)"
             return {
                 "error": (
                     "idalib worker became ready, but canonical IDB module metadata "
-                    f"was unavailable after {attempts} attempts; worker stopped "
+                    f"was unavailable{failure_detail}; worker stopped "
                     "without registering an ambiguous instance"
                 )
             }

--- a/src/ida_multi_mcp/idalib_worker.py
+++ b/src/ida_multi_mcp/idalib_worker.py
@@ -17,11 +17,55 @@ from __future__ import annotations
 import argparse
 import atexit
 import logging
+import os
+import secrets
 import signal
 import sys
+import threading
 from pathlib import Path
 
+
+def _http_origin(host: str, port: int) -> str:
+    display_host = f"[{host}]" if ":" in host else host
+    return f"http://{display_host}:{port}"
+
+
 logger = logging.getLogger("idalib-worker")
+_WORKER_SHUTDOWN_METHOD = "ida-multi-mcp/shutdown"
+_WORKER_SHUTDOWN_TOKEN_ENV = "IDA_MULTI_MCP_WORKER_SHUTDOWN_TOKEN"
+
+
+def _close_database_packed(idapro_module) -> bool:
+    """Persist one packed IDB and close without recreating loose work files.
+
+    Returns ``True`` when the explicit packed save succeeded. If it cannot be
+    completed, fall back to idapro's normal save-on-close behavior so edits are
+    not discarded merely to keep the directory tidy.
+    """
+    try:
+        import ida_loader
+
+        current_path = ida_loader.get_path(ida_loader.PATH_TYPE_IDB)
+        flags = ida_loader.DBFL_KILL | ida_loader.DBFL_COMP
+        if current_path and ida_loader.save_database(current_path, flags):
+            idapro_module.close_database(save=False)
+            return True
+    except Exception as exc:
+        logger.warning("Packed IDB save failed; using normal close: %s", exc)
+
+    idapro_module.close_database(save=True)
+    return False
+
+
+def _register_shutdown_rpc(mcp_server, expected_token: str) -> None:
+    """Register a manager-only RPC that lets the server exit cleanly."""
+    def _shutdown(token: str) -> dict:
+        if not secrets.compare_digest(token, expected_token):
+            raise PermissionError("invalid worker shutdown token")
+        threading.Thread(target=mcp_server.stop, daemon=True).start()
+        return {"accepted": True}
+
+    mcp_server.registry.method(_shutdown, name=_WORKER_SHUTDOWN_METHOD)
 
 
 def main() -> None:
@@ -81,7 +125,18 @@ def main() -> None:
     logger.info("Auto-analysis done.")
 
     # --- Import tool package (triggers @tool registration) -------------------
+    skipped_methods = {
+        value.strip()
+        for value in os.environ.get("IDA_MCP_LOG_SKIP_METHODS", "tools/call").split(",")
+        if value.strip()
+    }
+    skipped_methods.add(_WORKER_SHUTDOWN_METHOD)
+    os.environ["IDA_MCP_LOG_SKIP_METHODS"] = ",".join(sorted(skipped_methods))
     from ida_multi_mcp.ida_mcp import MCP_SERVER, MCP_UNSAFE  # noqa: E402
+
+    shutdown_token = os.environ.pop(_WORKER_SHUTDOWN_TOKEN_ENV, "")
+    if shutdown_token:
+        _register_shutdown_rpc(MCP_SERVER, shutdown_token)
 
     # Gate unsafe tools unless --unsafe.
     if not args.unsafe:
@@ -103,7 +158,7 @@ def main() -> None:
             return
         _closed = True
         try:
-            idapro.close_database()
+            _close_database_packed(idapro)
         except Exception:
             pass
 
@@ -127,10 +182,11 @@ def main() -> None:
     # serve it — the cache lives here, in rpc's module state. Without this the URL
     # keeps rpc's default (port 13337), which nothing listens on.
     from ida_multi_mcp.ida_mcp.rpc import set_download_base_url
-    set_download_base_url(f"http://{args.host}:{args.port}")
+    set_download_base_url(_http_origin(args.host, args.port))
 
     logger.info("Serving on %s:%d", args.host, args.port)
     MCP_SERVER.serve(host=args.host, port=args.port, background=False)
+    _close_db_once()
 
 
 if __name__ == "__main__":

--- a/src/ida_multi_mcp/idalib_worker.py
+++ b/src/ida_multi_mcp/idalib_worker.py
@@ -35,6 +35,29 @@ _WORKER_SHUTDOWN_METHOD = "ida-multi-mcp/shutdown"
 _WORKER_SHUTDOWN_TOKEN_ENV = "IDA_MULTI_MCP_WORKER_SHUTDOWN_TOKEN"
 
 
+def _idapro_import_failure_message(exc: ImportError) -> str:
+    """Classify an idapro import failure without hiding its real cause."""
+    current: BaseException | None = exc
+    while current is not None:
+        if getattr(current, "winerror", None) == 4551:
+            return (
+                "Windows Application Control blocked IDA's idalib.dll "
+                "(WinError 4551). The idapro package is installed but cannot "
+                "initialize under the active code-integrity policy. Use an "
+                "allowed/signed IDA build or connect a permitted GUI IDA "
+                "instance; reinstalling the Python package will not fix this."
+            )
+        current = current.__cause__ or current.__context__
+
+    detail = str(exc).strip()
+    suffix = f" Import error: {detail}" if detail else ""
+    return (
+        f"Failed to import the 'idapro' package in {sys.executable}. Install it "
+        "or point --idalib-python at the correct interpreter."
+        f"{suffix}"
+    )
+
+
 def _close_database_packed(idapro_module) -> bool:
     """Persist one packed IDB and close without recreating loose work files.
 
@@ -96,12 +119,8 @@ def main() -> None:
     # --- Initialize idalib (must happen before any ida_* import) -------------
     try:
         import idapro  # noqa: F401 — side-effect: initialises headless IDA
-    except ImportError:
-        logger.error(
-            "The 'idapro' package is not installed in this Python (%s). "
-            "Install it or point --idalib-python at the correct interpreter.",
-            sys.executable,
-        )
+    except ImportError as exc:
+        logger.error("%s", _idapro_import_failure_message(exc))
         sys.exit(1)
 
     # Suppress console noise unless verbose

--- a/src/ida_multi_mcp/vendor/zeromcp/mcp.py
+++ b/src/ida_multi_mcp/vendor/zeromcp/mcp.py
@@ -412,9 +412,10 @@ class McpServer:
         # Only start thread after successful bind
         self._running = True
 
+        url_host = f"[{host}]" if ":" in host else host
         print("[MCP] Server started:", file=sys.stderr)
-        print(f"  Streamable HTTP: http://{host}:{port}/mcp", file=sys.stderr)
-        print(f"  SSE: http://{host}:{port}/sse", file=sys.stderr)
+        print(f"  Streamable HTTP: http://{url_host}:{port}/mcp", file=sys.stderr)
+        print(f"  SSE: http://{url_host}:{port}/sse", file=sys.stderr)
 
         def serve_forever():
             try:

--- a/src/ida_multi_mcp/vendor/zeromcp/mcp.py
+++ b/src/ida_multi_mcp/vendor/zeromcp/mcp.py
@@ -13,6 +13,7 @@ import time
 import uuid
 import json
 import inspect
+import socket
 import threading
 import traceback
 from concurrent.futures import ThreadPoolExecutor, wait as futures_wait
@@ -23,6 +24,29 @@ from urllib.parse import urlparse, parse_qs
 from io import BufferedIOBase
 
 from .jsonrpc import JsonRpcRegistry, JsonRpcError, JsonRpcException, get_current_request_id, register_pending_request, unregister_pending_request, cancel_request
+
+
+class _IPv6HTTPServer(HTTPServer):
+    address_family = socket.AF_INET6
+
+
+class _IPv6ThreadingHTTPServer(ThreadingHTTPServer):
+    address_family = socket.AF_INET6
+
+
+def _http_server_class(host: str, background: bool):
+    if host == "::1":
+        return _IPv6ThreadingHTTPServer if background else _IPv6HTTPServer
+    return ThreadingHTTPServer if background else HTTPServer
+
+
+def _host_header_hostname(host_header: str) -> str | None:
+    if not host_header:
+        return ""
+    try:
+        return urlparse(f"//{host_header}").hostname
+    except ValueError:
+        return None
 
 class McpToolError(Exception):
     def __init__(self, message: str):
@@ -135,7 +159,7 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
         """Validate Host header to prevent DNS rebinding attacks on all endpoints."""
         host_header = self.headers.get("Host", "")
         # Strip port to get hostname
-        hostname = host_header.split(":")[0] if host_header else ""
+        hostname = _host_header_hostname(host_header)
         if hostname not in ("127.0.0.1", "localhost", "::1", ""):
             self.send_error(403, "Forbidden: invalid Host header")
             return False
@@ -363,7 +387,7 @@ class McpServer:
 
         # Create server with deferred binding
         assert issubclass(request_handler, McpHttpRequestHandler)
-        self._http_server = (ThreadingHTTPServer if background else HTTPServer)(
+        self._http_server = _http_server_class(host, background)(
             (host, port),
             request_handler,
             bind_and_activate=False

--- a/tests/test_http_ipv6.py
+++ b/tests/test_http_ipv6.py
@@ -1,0 +1,23 @@
+import socket
+
+from ida_multi_mcp.vendor.zeromcp.mcp import (
+    _IPv6HTTPServer,
+    _IPv6ThreadingHTTPServer,
+    _host_header_hostname,
+    _http_server_class,
+)
+
+
+def test_ipv6_host_header_is_parsed_without_losing_identity():
+    assert _host_header_hostname("[::1]:54321") == "::1"
+
+
+def test_malformed_host_header_fails_closed():
+    assert _host_header_hostname("[::1") is None
+
+
+def test_ipv6_server_classes_use_ipv6_sockets():
+    assert _http_server_class("::1", False) is _IPv6HTTPServer
+    assert _http_server_class("::1", True) is _IPv6ThreadingHTTPServer
+    assert _IPv6HTTPServer.address_family == socket.AF_INET6
+    assert _IPv6ThreadingHTTPServer.address_family == socket.AF_INET6

--- a/tests/test_idalib_manager.py
+++ b/tests/test_idalib_manager.py
@@ -243,6 +243,36 @@ class TestIdalibManagerSpawn:
         assert mock_terminate.call_args.kwargs["shutdown_token"]
         assert tmp_registry.list_instances() == {}
 
+    @patch("ida_multi_mcp.idalib_manager.IdalibManager._wait_for_ready", return_value=True)
+    @patch("ida_multi_mcp.idalib_manager.query_binary_metadata", return_value=None)
+    @patch("ida_multi_mcp.idalib_manager.subprocess.Popen")
+    def test_spawn_on_idb_reports_early_metadata_worker_exit(
+        self,
+        mock_popen,
+        mock_meta,
+        mock_ready,
+        tmp_path,
+        tmp_registry,
+    ):
+        idb = tmp_path / "test.exe.i64"
+        idb.write_bytes(b"\x00" * 16)
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 77780
+        mock_proc.poll.return_value = 23
+        mock_proc.stderr.read.side_effect = [b"metadata worker failed", b""]
+        mock_popen.return_value = mock_proc
+
+        mgr = IdalibManager(tmp_registry)
+        result = mgr.spawn_session(str(idb))
+
+        assert mock_ready.call_count == 1
+        assert mock_meta.call_count == 1
+        assert "after 1 attempt(s)" in result["error"]
+        assert "worker exited with code 23" in result["error"]
+        assert "metadata worker failed" in result["error"]
+        assert tmp_registry.list_instances() == {}
+
     @patch("ida_multi_mcp.idalib_manager.subprocess.Popen")
     @patch("ida_multi_mcp.idalib_manager.ping_instance", return_value=False)
     def test_spawn_timeout(self, mock_ping, mock_popen, tmp_path, tmp_registry):

--- a/tests/test_idalib_manager.py
+++ b/tests/test_idalib_manager.py
@@ -4,12 +4,16 @@ All tests mock subprocesses; no idapro required.
 """
 
 import subprocess
-import time
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ida_multi_mcp.idalib_manager import IdalibManager, _find_free_port
+from ida_multi_mcp.idalib_manager import (
+    IdalibManager,
+    _find_free_port,
+    _preferred_loopback_host,
+    _request_worker_shutdown,
+)
 
 
 class TestFindFreePort:
@@ -23,11 +27,59 @@ class TestFindFreePort:
         # At least 2 unique ports (unlikely all 5 collide)
         assert len(ports) >= 2
 
+    def test_supports_ipv6_loopback_when_available(self):
+        try:
+            port = _find_free_port("::1")
+        except OSError:
+            pytest.skip("IPv6 loopback is disabled")
+        assert isinstance(port, int)
+        assert port > 0
+
+
+class TestPreferredLoopbackHost:
+    @patch("ida_multi_mcp.idalib_manager.sys.platform", "win32")
+    def test_windows_prefers_ipv6_when_bind_succeeds(self):
+        fake_socket = MagicMock()
+        fake_socket.__enter__.return_value = fake_socket
+        with patch("ida_multi_mcp.idalib_manager.socket.socket", return_value=fake_socket):
+            assert _preferred_loopback_host() == "::1"
+        fake_socket.bind.assert_called_once_with(("::1", 0))
+
+    @patch("ida_multi_mcp.idalib_manager.sys.platform", "win32")
+    def test_windows_falls_back_when_ipv6_is_unavailable(self):
+        fake_socket = MagicMock()
+        fake_socket.__enter__.return_value = fake_socket
+        fake_socket.bind.side_effect = OSError("IPv6 disabled")
+        with patch("ida_multi_mcp.idalib_manager.socket.socket", return_value=fake_socket):
+            assert _preferred_loopback_host() == "127.0.0.1"
+
+    @patch("ida_multi_mcp.idalib_manager.sys.platform", "linux")
+    def test_non_windows_preserves_ipv4_default(self):
+        assert _preferred_loopback_host() == "127.0.0.1"
+
+
+class TestWorkerShutdownRequest:
+    @patch("ida_multi_mcp.idalib_manager.http.client.HTTPConnection")
+    def test_accepts_only_explicit_success_response(self, mock_connection):
+        response = MagicMock()
+        response.status = 200
+        response.read.return_value = b'{"jsonrpc":"2.0","result":{"accepted":true},"id":1}'
+        mock_connection.return_value.getresponse.return_value = response
+
+        assert _request_worker_shutdown("::1", 54321, "secret") is True
+        request_body = mock_connection.return_value.request.call_args.args[2]
+        assert '"ida-multi-mcp/shutdown"' in request_body
+        assert '"secret"' in request_body
+        mock_connection.return_value.close.assert_called_once()
+
 
 @pytest.fixture(autouse=True)
 def _mock_idalib_available():
     """Assume IDA Pro (idalib) is available in all manager tests."""
-    with patch("ida_multi_mcp.idalib_manager.is_idalib_available", return_value=True):
+    with (
+        patch("ida_multi_mcp.idalib_manager.is_idalib_available", return_value=True),
+        patch("ida_multi_mcp.idalib_manager.atexit.register"),
+    ):
         yield
 
 
@@ -100,6 +152,7 @@ class TestIdalibManagerSpawn:
         mgr.spawn_session(str(binary))
 
         assert mock_popen.call_args.kwargs["stdin"] == subprocess.DEVNULL
+        assert "IDA_MULTI_MCP_WORKER_SHUTDOWN_TOKEN" in mock_popen.call_args.kwargs["env"]
 
     @patch("ida_multi_mcp.idalib_manager.query_binary_metadata",
            return_value={"module": "test.exe", "path": "/tmp/test.exe.i64"})
@@ -125,6 +178,70 @@ class TestIdalibManagerSpawn:
         assert "error" not in result
         info = tmp_registry.get_instance(result["instance_id"])
         assert info["binary_name"] == "test.exe"
+
+    @patch("ida_multi_mcp.idalib_manager.time.sleep")
+    @patch(
+        "ida_multi_mcp.idalib_manager.query_binary_metadata",
+        side_effect=[None, {"module": "test.exe", "path": "/tmp/test.exe.i64"}],
+    )
+    @patch("ida_multi_mcp.idalib_manager.subprocess.Popen")
+    @patch("ida_multi_mcp.idalib_manager.ping_instance", return_value=True)
+    def test_spawn_on_idb_retries_transient_metadata_reset(
+        self, mock_ping, mock_popen, mock_meta, mock_sleep, tmp_path, tmp_registry,
+    ):
+        idb = tmp_path / "test.exe.i64"
+        idb.write_bytes(b"\x00" * 16)
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 77778
+        mock_proc.poll.return_value = None
+        mock_proc.stderr.read.return_value = b""
+        mock_popen.return_value = mock_proc
+
+        mgr = IdalibManager(tmp_registry)
+        result = mgr.spawn_session(str(idb))
+
+        assert "error" not in result
+        assert mock_meta.call_count == 2
+        mock_sleep.assert_called_once()
+        info = tmp_registry.get_instance(result["instance_id"])
+        assert info["binary_name"] == "test.exe"
+
+    @patch("ida_multi_mcp.idalib_manager.IdalibManager._terminate_gracefully")
+    @patch("ida_multi_mcp.idalib_manager.time.sleep")
+    @patch("ida_multi_mcp.idalib_manager.query_binary_metadata", return_value=None)
+    @patch("ida_multi_mcp.idalib_manager.subprocess.Popen")
+    @patch("ida_multi_mcp.idalib_manager.ping_instance", return_value=True)
+    def test_spawn_on_idb_fails_closed_without_canonical_metadata(
+        self,
+        mock_ping,
+        mock_popen,
+        mock_meta,
+        mock_sleep,
+        mock_terminate,
+        tmp_path,
+        tmp_registry,
+    ):
+        idb = tmp_path / "renamed.i64"
+        idb.write_bytes(b"\x00" * 16)
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 77779
+        mock_proc.poll.return_value = None
+        mock_proc.stderr.read.return_value = b""
+        mock_popen.return_value = mock_proc
+
+        mgr = IdalibManager(tmp_registry)
+        result = mgr.spawn_session(str(idb), host="127.0.0.1")
+
+        assert "canonical IDB module metadata was unavailable" in result["error"]
+        assert mock_meta.call_count == 4
+        assert mock_sleep.call_count == 3
+        assert mock_terminate.call_args.args == (mock_proc,)
+        assert mock_terminate.call_args.kwargs["host"] == "127.0.0.1"
+        assert mock_terminate.call_args.kwargs["port"] > 0
+        assert mock_terminate.call_args.kwargs["shutdown_token"]
+        assert tmp_registry.list_instances() == {}
 
     @patch("ida_multi_mcp.idalib_manager.subprocess.Popen")
     @patch("ida_multi_mcp.idalib_manager.ping_instance", return_value=False)
@@ -182,6 +299,24 @@ class TestIdalibManagerClose:
 
 
 class TestGracefulTermination:
+    @patch("ida_multi_mcp.idalib_manager._request_worker_shutdown", return_value=True)
+    def test_authenticated_rpc_allows_clean_exit(self, mock_shutdown):
+        proc = MagicMock()
+        proc.poll.return_value = None
+
+        IdalibManager._terminate_gracefully(
+            proc,
+            host="::1",
+            port=54321,
+            shutdown_token="secret",
+        )
+
+        mock_shutdown.assert_called_once_with("::1", 54321, "secret")
+        proc.wait.assert_called_once_with(timeout=60)
+        proc.send_signal.assert_not_called()
+        proc.terminate.assert_not_called()
+        proc.kill.assert_not_called()
+
     def test_skips_already_exited(self):
         proc = MagicMock()
         proc.poll.return_value = 0  # already exited

--- a/tests/test_idalib_worker_download_url.py
+++ b/tests/test_idalib_worker_download_url.py
@@ -39,6 +39,18 @@ def _run_worker(monkeypatch, tmp_path, port):
         "idalib_worker", "--host", "127.0.0.1", "--port", str(port), str(binary),
     ])
     from ida_multi_mcp import idalib_worker
+    monkeypatch.setattr(idalib_worker.atexit, "register", MagicMock())
+    idalib_worker.main()
+
+
+def _run_ipv6_worker(monkeypatch, tmp_path, port):
+    binary = tmp_path / "sample.bin"
+    binary.write_bytes(b"\x00" * 16)
+    monkeypatch.setattr(sys, "argv", [
+        "idalib_worker", "--host", "::1", "--port", str(port), str(binary),
+    ])
+    from ida_multi_mcp import idalib_worker
+    monkeypatch.setattr(idalib_worker.atexit, "register", MagicMock())
     idalib_worker.main()
 
 
@@ -63,3 +75,67 @@ def test_download_base_url_is_set_before_serving(
     _run_worker(monkeypatch, tmp_path, 54321)
 
     assert call_order == ["set_url", "serve"]
+
+
+def test_ipv6_download_base_url_is_bracketed(
+    stubbed_worker_env, monkeypatch, tmp_path,
+):
+    _, rpc = stubbed_worker_env
+    _run_ipv6_worker(monkeypatch, tmp_path, 54321)
+
+    rpc.set_download_base_url.assert_called_once_with("http://[::1]:54321")
+
+
+def test_close_database_packs_then_closes_without_resaving(monkeypatch):
+    from ida_multi_mcp.idalib_worker import _close_database_packed
+
+    idapro = MagicMock()
+    ida_loader = MagicMock()
+    ida_loader.PATH_TYPE_IDB = 1
+    ida_loader.DBFL_KILL = 2
+    ida_loader.DBFL_COMP = 4
+    ida_loader.get_path.return_value = "/tmp/sample.i64"
+    ida_loader.save_database.return_value = True
+    monkeypatch.setitem(sys.modules, "ida_loader", ida_loader)
+
+    assert _close_database_packed(idapro) is True
+    ida_loader.save_database.assert_called_once_with("/tmp/sample.i64", 6)
+    idapro.close_database.assert_called_once_with(save=False)
+
+
+def test_close_database_preserves_edits_when_packed_save_fails(monkeypatch):
+    from ida_multi_mcp.idalib_worker import _close_database_packed
+
+    idapro = MagicMock()
+    ida_loader = MagicMock()
+    ida_loader.PATH_TYPE_IDB = 1
+    ida_loader.DBFL_KILL = 2
+    ida_loader.DBFL_COMP = 4
+    ida_loader.get_path.return_value = "/tmp/sample.i64"
+    ida_loader.save_database.return_value = False
+    monkeypatch.setitem(sys.modules, "ida_loader", ida_loader)
+
+    assert _close_database_packed(idapro) is False
+    idapro.close_database.assert_called_once_with(save=True)
+
+
+def test_shutdown_rpc_requires_token_and_stops_server(monkeypatch):
+    from ida_multi_mcp.idalib_worker import _register_shutdown_rpc
+
+    server = MagicMock()
+    callbacks = {}
+    server.registry.method.side_effect = (
+        lambda callback, name: callbacks.__setitem__(name, callback)
+    )
+    thread = MagicMock()
+    monkeypatch.setattr("ida_multi_mcp.idalib_worker.threading.Thread", lambda **kwargs: thread)
+
+    _register_shutdown_rpc(server, "expected")
+    shutdown = callbacks["ida-multi-mcp/shutdown"]
+
+    with pytest.raises(PermissionError):
+        shutdown("wrong")
+    thread.start.assert_not_called()
+
+    assert shutdown("expected") == {"accepted": True}
+    thread.start.assert_called_once()

--- a/tests/test_idalib_worker_download_url.py
+++ b/tests/test_idalib_worker_download_url.py
@@ -139,3 +139,31 @@ def test_shutdown_rpc_requires_token_and_stops_server(monkeypatch):
 
     assert shutdown("expected") == {"accepted": True}
     thread.start.assert_called_once()
+
+
+def test_idapro_import_failure_reports_windows_application_control_block():
+    from ida_multi_mcp.idalib_worker import _idapro_import_failure_message
+
+    policy_error = OSError(4551, "An Application Control policy has blocked this file")
+    policy_error.winerror = 4551
+    failure = ImportError("Failed loading IDA library file")
+    failure.__cause__ = policy_error
+
+    message = _idapro_import_failure_message(failure)
+
+    assert "Windows Application Control" in message
+    assert "WinError 4551" in message
+    assert "idapro package is installed" in message
+    assert "reinstalling the Python package will not fix this" in message
+
+
+def test_idapro_import_failure_preserves_generic_import_detail(monkeypatch):
+    from ida_multi_mcp.idalib_worker import _idapro_import_failure_message
+
+    monkeypatch.setattr(sys, "executable", r"C:\Python\python.exe")
+
+    message = _idapro_import_failure_message(ImportError("No module named idapro"))
+
+    assert r"C:\Python\python.exe" in message
+    assert "point --idalib-python" in message
+    assert "No module named idapro" in message

--- a/tests/test_zeromcp_parity.py
+++ b/tests/test_zeromcp_parity.py
@@ -65,6 +65,41 @@ def _import_ida_mcp_zeromcp():
     return McpServer
 
 
+class _NoopHttpServer:
+    def __init__(self, *_args, **_kwargs):
+        self.allow_reuse_address = False
+        self.allow_reuse_port = False
+
+    def server_bind(self):
+        pass
+
+    def server_activate(self):
+        pass
+
+    def server_close(self):
+        pass
+
+    def serve_forever(self):
+        pass
+
+
+@pytest.mark.parametrize("implementation", ["vendor", "ida_mcp"])
+def test_ipv6_advertised_urls_are_bracketed(implementation, monkeypatch, capsys):
+    if implementation == "vendor":
+        McpServer = VendorMcpServer
+    else:
+        McpServer = _import_ida_mcp_zeromcp()
+    module = sys.modules[McpServer.__module__]
+    monkeypatch.setattr(module, "_http_server_class", lambda *_args: _NoopHttpServer)
+
+    McpServer("test").serve("::1", 43210, background=False)
+
+    captured = capsys.readouterr()
+    advertised = captured.out + captured.err
+    assert "http://[::1]:43210/mcp" in advertised
+    assert "http://[::1]:43210/sse" in advertised
+
+
 class TestNotificationsInitializedParity:
     def test_vendor_registers_handler(self):
         srv = VendorMcpServer("test")


### PR DESCRIPTION
## Summary

- prefer bind-tested IPv6 loopback for managed idalib workers on Windows, with an explicit IPv4 fallback when IPv6 is unavailable
- preserve canonical module identity when reopening packed `.i64`/`.idb` files and fail closed if metadata cannot be established
- add a per-process authenticated shutdown RPC so hidden Windows workers can pack and close databases instead of being force-killed
- emit valid bracketed IPv6 URLs and validate IPv6 Host/Origin headers
- pack headless databases with `DBFL_KILL | DBFL_COMP`, while retaining save-on-close as the data-preserving fallback
- distinguish Windows Application Control WinError 4551 from a missing `idapro` package and retain the underlying detail for other import failures

## Why

On the affected Windows host, fresh IPv4 loopback connections were intermittently reset even for a minimal standard-library HTTP server, while the IPv6 loopback control completed 100/100 requests. Separately, `CREATE_NO_WINDOW` workers could not reliably receive `CTRL_BREAK_EVENT`, leaving loose `.id0/.id1/.id2/.nam/.til` files and a stale packed IDB.

The shutdown token is generated per worker, passed only through the child environment, removed before serving, and excluded from request logs.

The same host also exposed a misleading diagnostic: Windows Application Control can block an unsigned `idalib.dll` with WinError 4551 while `idapro` is installed correctly. The worker now reports that policy failure instead of advising a pointless package reinstall.

## Verification

- `python -m pytest -q`: 446 passed, 9 skipped
- scoped Ruff: passed
- `py_compile`: passed
- `git diff --check`: passed
- real packed-IDB reopen: 100/100 pings and 20/20 metadata reads
- real IDB identity: 131,197 functions, queue empty, original binary SHA-256 preserved
- post-fix real protocol audit: packed IDB opened on `::1`, analysis settled twice, searches/xrefs completed, and authenticated shutdown exited cleanly
- clean shutdown leaves only the source binary and one packed `.i64`; no worker remains

---
@codex Please review this PR for correctness, Windows process lifecycle safety, transport compatibility, diagnostic accuracy, and test coverage.